### PR TITLE
Add REST API for the simulator component

### DIFF
--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/BridgeInterface.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/BridgeInterface.java
@@ -19,6 +19,8 @@
  */
 package eu.learnpad.sim;
 
+import javax.ws.rs.Path;
+
 import eu.learnpad.sim.rest.IProcessHandlingAPI;
 import eu.learnpad.sim.rest.ISimulationMonitoringAPI;
 
@@ -26,6 +28,7 @@ import eu.learnpad.sim.rest.ISimulationMonitoringAPI;
  * @author Tom Jorquera - Linagora
  *
  */
+@Path("/learnpad/sim/")
 public interface BridgeInterface extends IProcessHandlingAPI,
 		ISimulationMonitoringAPI {
 

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/BridgeInterface.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/BridgeInterface.java
@@ -19,7 +19,10 @@
  */
 package eu.learnpad.sim;
 
+import javax.ws.rs.Consumes;
 import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
 
 import eu.learnpad.sim.rest.IProcessHandlingAPI;
 import eu.learnpad.sim.rest.ISimulationMonitoringAPI;
@@ -29,6 +32,8 @@ import eu.learnpad.sim.rest.ISimulationMonitoringAPI;
  *
  */
 @Path("/learnpad/sim/")
+@Consumes(MediaType.APPLICATION_JSON)
+@Produces(MediaType.APPLICATION_JSON)
 public interface BridgeInterface extends IProcessHandlingAPI,
 		ISimulationMonitoringAPI {
 

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/BridgeInterface.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/BridgeInterface.java
@@ -1,0 +1,32 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package eu.learnpad.sim;
+
+import eu.learnpad.sim.rest.IProcessHandlingAPI;
+import eu.learnpad.sim.rest.ISimulationMonitoringAPI;
+
+/**
+ * @author Tom Jorquera - Linagora
+ *
+ */
+public interface BridgeInterface extends IProcessHandlingAPI,
+		ISimulationMonitoringAPI {
+
+}

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/CoreFacade.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/CoreFacade.java
@@ -1,0 +1,30 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package eu.learnpad.sim;
+
+import eu.learnpad.sim.rest.IUserInfosAPI;
+
+/**
+ * @author Tom Jorquera - Linagora
+ *
+ */
+public interface CoreFacade extends IUserInfosAPI {
+
+}

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/IProcessHandlingAPI.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/IProcessHandlingAPI.java
@@ -49,7 +49,7 @@ public interface IProcessHandlingAPI {
 	 * @return current process definitions IDs
 	 */
 	@GET
-	@Path("/learnpad/sim/processes")
+	@Path("/processes")
 	public Collection<String> getProcessDefinitions();
 
 	/**
@@ -59,7 +59,7 @@ public interface IProcessHandlingAPI {
 	 * @return the IDs of all the added process definitions
 	 */
 	@POST
-	@Path("/learnpad/sim/processes")
+	@Path("/processes")
 	public Collection<String> addProcessDefinition(
 			String processDefinitionFilePath);
 
@@ -70,7 +70,7 @@ public interface IProcessHandlingAPI {
 	 * @return the info associated with this process definition
 	 */
 	@GET
-	@Path("/learnpad/sim/processes/{id:.*}")
+	@Path("/processes/{id:.*}")
 	public ProcessData getProcessInfos(@PathParam("id") String processId);
 
 	/**
@@ -78,7 +78,7 @@ public interface IProcessHandlingAPI {
 	 * @return a collection of the current process instances IDs
 	 */
 	@GET
-	@Path("/learnpad/sim/instances")
+	@Path("/instances")
 	public Collection<String> getProcessInstances();
 
 	/**
@@ -88,7 +88,7 @@ public interface IProcessHandlingAPI {
 	 * @return the created process instance data
 	 */
 	@POST
-	@Path("/learnpad/sim/instances")
+	@Path("/instances")
 	public ProcessInstanceData addProcessInstance(ProcessInstanceData data);
 
 	/**
@@ -98,7 +98,7 @@ public interface IProcessHandlingAPI {
 	 * @return the info associated with this process instance
 	 */
 	@GET
-	@Path("/learnpad/sim/instances/{id:.*}")
+	@Path("/instances/{id:.*}")
 	public ProcessInstanceData getProcessInstanceInfos(
 			@PathParam("id") String processInstanceId);
 }

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/IProcessHandlingAPI.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/IProcessHandlingAPI.java
@@ -21,10 +21,13 @@ package eu.learnpad.sim.rest;
 
 import java.util.Collection;
 
+import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
 
 import eu.learnpad.sim.rest.data.ProcessData;
 import eu.learnpad.sim.rest.data.ProcessInstanceData;
@@ -37,6 +40,8 @@ import eu.learnpad.sim.rest.data.ProcessInstanceData;
  * @author Tom Jorquera - Linagora
  *
  */
+@Consumes(MediaType.APPLICATION_JSON)
+@Produces(MediaType.APPLICATION_JSON)
 public interface IProcessHandlingAPI {
 
 	/**

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/IProcessHandlingAPI.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/IProcessHandlingAPI.java
@@ -1,0 +1,107 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package eu.learnpad.sim.rest;
+
+import java.util.Collection;
+
+import javassist.NotFoundException;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import eu.learnpad.sim.rest.data.ProcessData;
+import eu.learnpad.sim.rest.data.ProcessInstanceData;
+
+/**
+ *
+ * This interface describes the REST API functionalities related to processes
+ * and process instances handling
+ *
+ * @author Tom Jorquera - Linagora
+ *
+ */
+@Consumes(MediaType.APPLICATION_JSON)
+@Produces(MediaType.APPLICATION_JSON)
+public interface IProcessHandlingAPI {
+
+	/**
+	 *
+	 * @return current process definitions IDs
+	 */
+	@GET
+	@Path("/learnpad/sim/processes")
+	public Collection<String> getProcessDefinitions();
+
+	/**
+	 *
+	 * @param processDefinitionFilePath
+	 *            the processes definition file
+	 * @return the IDs of all the added process definitions
+	 */
+	@POST
+	@Path("/learnpad/sim/processes")
+	public Collection<String> addProcessDefinition(
+			String processDefinitionFilePath);
+
+	/**
+	 *
+	 * @param processId
+	 *            the id of a process definition
+	 * @return the info associated with this process definition
+	 */
+	@GET
+	@Path("/learnpad/sim/processes/{id:.*}")
+	public ProcessData getProcessInfos(@PathParam("id") String processId)
+			throws NotFoundException;
+
+	/**
+	 *
+	 * @return a collection of the current process instances IDs
+	 */
+	@GET
+	@Path("/learnpad/sim/instances")
+	public Collection<String> getProcessInstances();
+
+	/**
+	 *
+	 * @param data
+	 *            the process instance data
+	 * @return the created process instance data
+	 */
+	@POST
+	@Path("/learnpad/sim/instances")
+	public ProcessInstanceData addProcessInstance(ProcessInstanceData data);
+
+	/**
+	 *
+	 * @param processInstanceId
+	 *            the id of a process instance
+	 * @return the info associated with this process instance
+	 */
+	@GET
+	@Path("/learnpad/sim/instances/{id:.*}")
+	public ProcessInstanceData getProcessInstanceInfos(
+			@PathParam("id") String processInstanceId) throws NotFoundException;
+}

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/IProcessHandlingAPI.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/IProcessHandlingAPI.java
@@ -41,7 +41,7 @@ public interface IProcessHandlingAPI {
 
 	/**
 	 *
-	 * @return current process definitions IDs
+	 * @return current process definitions artifact IDs
 	 */
 	@GET
 	@Path("/processes")
@@ -49,28 +49,29 @@ public interface IProcessHandlingAPI {
 
 	/**
 	 *
-	 * @param processDefinitionFilePath
-	 *            the processes definition file
-	 * @return the IDs of all the added process definitions
+	 * @param processDefinitionFileURL
+	 *            an exact URL to get the processes definition file
+	 * @return the artifact IDs of all the added process definitions
 	 */
 	@POST
 	@Path("/processes")
 	public Collection<String> addProcessDefinition(
-			String processDefinitionFilePath);
+			String processDefinitionFileURL);
 
 	/**
 	 *
-	 * @param processId
-	 *            the id of a process definition
+	 * @param processArtifactId
+	 *            the artifact id of a process definition
 	 * @return the info associated with this process definition
 	 */
 	@GET
-	@Path("/processes/{id:.*}")
-	public ProcessData getProcessInfos(@PathParam("id") String processId);
+	@Path("/processes/{artifactid:.*}")
+	public ProcessData getProcessInfos(
+			@PathParam("artifactid") String processArtifactId);
 
 	/**
 	 *
-	 * @return a collection of the current process instances IDs
+	 * @return a collection of the current process instances artifact IDs
 	 */
 	@GET
 	@Path("/instances")
@@ -80,7 +81,7 @@ public interface IProcessHandlingAPI {
 	 *
 	 * @param data
 	 *            the process instance data
-	 * @return the created process instance data
+	 * @return the created process instance artifact id
 	 */
 	@POST
 	@Path("/instances")
@@ -88,12 +89,12 @@ public interface IProcessHandlingAPI {
 
 	/**
 	 *
-	 * @param processInstanceId
+	 * @param processInstanceArtifactId
 	 *            the id of a process instance
 	 * @return the info associated with this process instance
 	 */
 	@GET
-	@Path("/instances/{id:.*}")
+	@Path("/instances/{artifactid:.*}")
 	public ProcessInstanceData getProcessInstanceInfos(
-			@PathParam("id") String processInstanceId);
+			@PathParam("artifactid") String processInstanceArtifactId);
 }

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/IProcessHandlingAPI.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/IProcessHandlingAPI.java
@@ -85,7 +85,7 @@ public interface IProcessHandlingAPI {
 	 */
 	@POST
 	@Path("/instances")
-	public ProcessInstanceData addProcessInstance(ProcessInstanceData data);
+	public String addProcessInstance(ProcessInstanceData data);
 
 	/**
 	 *

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/IProcessHandlingAPI.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/IProcessHandlingAPI.java
@@ -21,8 +21,6 @@ package eu.learnpad.sim.rest;
 
 import java.util.Collection;
 
-import javassist.NotFoundException;
-
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
@@ -73,8 +71,7 @@ public interface IProcessHandlingAPI {
 	 */
 	@GET
 	@Path("/learnpad/sim/processes/{id:.*}")
-	public ProcessData getProcessInfos(@PathParam("id") String processId)
-			throws NotFoundException;
+	public ProcessData getProcessInfos(@PathParam("id") String processId);
 
 	/**
 	 *
@@ -103,5 +100,5 @@ public interface IProcessHandlingAPI {
 	@GET
 	@Path("/learnpad/sim/instances/{id:.*}")
 	public ProcessInstanceData getProcessInstanceInfos(
-			@PathParam("id") String processInstanceId) throws NotFoundException;
+			@PathParam("id") String processInstanceId);
 }

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/IProcessHandlingAPI.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/IProcessHandlingAPI.java
@@ -21,13 +21,10 @@ package eu.learnpad.sim.rest;
 
 import java.util.Collection;
 
-import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
 
 import eu.learnpad.sim.rest.data.ProcessData;
 import eu.learnpad.sim.rest.data.ProcessInstanceData;
@@ -40,8 +37,6 @@ import eu.learnpad.sim.rest.data.ProcessInstanceData;
  * @author Tom Jorquera - Linagora
  *
  */
-@Consumes(MediaType.APPLICATION_JSON)
-@Produces(MediaType.APPLICATION_JSON)
 public interface IProcessHandlingAPI {
 
 	/**

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/ISimulationMonitoringAPI.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/ISimulationMonitoringAPI.java
@@ -19,9 +19,13 @@
  */
 package eu.learnpad.sim.rest;
 
+import java.io.InputStream;
+
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
 
 /**
  *
@@ -41,7 +45,8 @@ public interface ISimulationMonitoringAPI {
 	 */
 	@GET
 	@Path("/results/simulations/{processinstanceartifactid:.*}")
-	public String getSimulationResults(
+	@Produces(MediaType.APPLICATION_OCTET_STREAM)
+	public InputStream getSimulationResults(
 			@PathParam("processinstanceartifactid") String processinstanceartifactid);
 
 	/**
@@ -52,7 +57,8 @@ public interface ISimulationMonitoringAPI {
 	 */
 	@GET
 	@Path("/results/users/{userartifactid:.*}")
-	public String getSimulationTraceForLearner(
+	@Produces(MediaType.APPLICATION_OCTET_STREAM)
+	public InputStream getSimulationTraceForLearner(
 			@PathParam("userartifactid") String userartifactid);
 
 	/**
@@ -63,7 +69,8 @@ public interface ISimulationMonitoringAPI {
 	 */
 	@GET
 	@Path("/results/models/{modelartifactid:.*}")
-	public String getSimulationTraceForBP(
+	@Produces(MediaType.APPLICATION_OCTET_STREAM)
+	public InputStream getSimulationTraceForBP(
 			@PathParam("modelartifactid") String processartifactid);
 
 }

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/ISimulationMonitoringAPI.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/ISimulationMonitoringAPI.java
@@ -1,0 +1,72 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package eu.learnpad.sim.rest;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+/**
+ *
+ * This interface describes the REST API functionalities related to simulation
+ * monitoring
+ *
+ * @author Tom Jorquera - Linagora
+ *
+ */
+@Consumes(MediaType.APPLICATION_JSON)
+@Produces(MediaType.APPLICATION_JSON)
+public interface ISimulationMonitoringAPI {
+
+	/**
+	 * Get the result file associated with a specific simulation
+	 *
+	 * @param simulation
+	 * @return the String to the result file
+	 */
+	@GET
+	@Path("/learnpad/sim/results/simulations/{simulation:.*}")
+	public String getSimulationResults(
+			@PathParam("simulation") String simulation);
+
+	/**
+	 * Get the trace file associated with a learner
+	 *
+	 * @param user
+	 * @return the String to the trace file
+	 */
+	@GET
+	@Path("/learnpad/sim/traces/users/{user:.*}")
+	public String getSimulationTraceForLearner(@PathParam("user") String user);
+
+	/**
+	 * Get the trace file associated with a model
+	 *
+	 * @param model
+	 * @return the String to the trace file
+	 */
+	@GET
+	@Path("/learnpad/sim/traces/models/{model:.*}")
+	public String getSimulationTraceForBP(@PathParam("model") String model);
+
+}

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/ISimulationMonitoringAPI.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/ISimulationMonitoringAPI.java
@@ -41,32 +41,33 @@ public interface ISimulationMonitoringAPI {
 	/**
 	 * Get the result file associated with a specific simulation
 	 *
-	 * @param simulation
+	 * @param simulationid
 	 * @return the String to the result file
 	 */
 	@GET
-	@Path("/learnpad/sim/results/simulations/{simulation:.*}")
+	@Path("/learnpad/sim/results/simulations/{simulationid:.*}")
 	public String getSimulationResults(
-			@PathParam("simulation") String simulation);
+			@PathParam("simulationid") String simulationid);
 
 	/**
 	 * Get the trace file associated with a learner
 	 *
-	 * @param user
+	 * @param userid
 	 * @return the String to the trace file
 	 */
 	@GET
-	@Path("/learnpad/sim/traces/users/{user:.*}")
-	public String getSimulationTraceForLearner(@PathParam("user") String user);
+	@Path("/learnpad/sim/traces/users/{userid:.*}")
+	public String getSimulationTraceForLearner(
+			@PathParam("userid") String userid);
 
 	/**
 	 * Get the trace file associated with a model
 	 *
-	 * @param model
+	 * @param modelid
 	 * @return the String to the trace file
 	 */
 	@GET
-	@Path("/learnpad/sim/traces/models/{model:.*}")
-	public String getSimulationTraceForBP(@PathParam("model") String model);
+	@Path("/learnpad/sim/traces/models/{modelid:.*}")
+	public String getSimulationTraceForBP(@PathParam("modelid") String modelid);
 
 }

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/ISimulationMonitoringAPI.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/ISimulationMonitoringAPI.java
@@ -34,35 +34,36 @@ import javax.ws.rs.PathParam;
 public interface ISimulationMonitoringAPI {
 
 	/**
-	 * Get the result file associated with a specific simulation
+	 * Get the result file associated with a specific process instance
 	 *
-	 * @param simulationid
-	 * @return the String to the result file
+	 * @param processinstanceartifactid
+	 * @return the result file
 	 */
 	@GET
-	@Path("/results/simulations/{simulationid:.*}")
+	@Path("/results/simulations/{processinstanceartifactid:.*}")
 	public String getSimulationResults(
-			@PathParam("simulationid") String simulationid);
+			@PathParam("processinstanceartifactid") String processinstanceartifactid);
 
 	/**
-	 * Get the trace file associated with a learner
+	 * Get the results file associated with a learner
 	 *
-	 * @param userid
-	 * @return the String to the trace file
+	 * @param userartifactid
+	 * @return the result file
 	 */
 	@GET
-	@Path("/results/users/{userid:.*}")
+	@Path("/results/users/{userartifactid:.*}")
 	public String getSimulationTraceForLearner(
-			@PathParam("userid") String userid);
+			@PathParam("userartifactid") String userartifactid);
 
 	/**
-	 * Get the trace file associated with a model
+	 * Get the logs file associated with a process
 	 *
-	 * @param modelid
-	 * @return the String to the trace file
+	 * @param processartifactid
+	 * @return the result file
 	 */
 	@GET
-	@Path("/results/models/{modelid:.*}")
-	public String getSimulationTraceForBP(@PathParam("modelid") String modelid);
+	@Path("/results/models/{modelartifactid:.*}")
+	public String getSimulationTraceForBP(
+			@PathParam("modelartifactid") String processartifactid);
 
 }

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/ISimulationMonitoringAPI.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/ISimulationMonitoringAPI.java
@@ -44,9 +44,9 @@ public interface ISimulationMonitoringAPI {
 	 * @return the result file
 	 */
 	@GET
-	@Path("/results/simulations/{processinstanceartifactid:.*}")
+	@Path("/results/instances/{processinstanceartifactid:.*}")
 	@Produces(MediaType.APPLICATION_OCTET_STREAM)
-	public InputStream getSimulationResults(
+	public InputStream getProcessInstanceResults(
 			@PathParam("processinstanceartifactid") String processinstanceartifactid);
 
 	/**
@@ -58,19 +58,19 @@ public interface ISimulationMonitoringAPI {
 	@GET
 	@Path("/results/users/{userartifactid:.*}")
 	@Produces(MediaType.APPLICATION_OCTET_STREAM)
-	public InputStream getSimulationTraceForLearner(
+	public InputStream getUserResults(
 			@PathParam("userartifactid") String userartifactid);
 
 	/**
-	 * Get the logs file associated with a process
+	 * Get the results file associated with a process
 	 *
 	 * @param processartifactid
 	 * @return the result file
 	 */
 	@GET
-	@Path("/results/models/{modelartifactid:.*}")
+	@Path("/results/processes/{processartifactid:.*}")
 	@Produces(MediaType.APPLICATION_OCTET_STREAM)
-	public InputStream getSimulationTraceForBP(
-			@PathParam("modelartifactid") String processartifactid);
+	public InputStream getProcessResults(
+			@PathParam("processartifactid") String processartifactid);
 
 }

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/ISimulationMonitoringAPI.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/ISimulationMonitoringAPI.java
@@ -19,12 +19,9 @@
  */
 package eu.learnpad.sim.rest;
 
-import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
 
 /**
  *
@@ -34,9 +31,6 @@ import javax.ws.rs.core.MediaType;
  * @author Tom Jorquera - Linagora
  *
  */
-@Path("/results")
-@Consumes(MediaType.APPLICATION_JSON)
-@Produces(MediaType.APPLICATION_JSON)
 public interface ISimulationMonitoringAPI {
 
 	/**
@@ -46,7 +40,7 @@ public interface ISimulationMonitoringAPI {
 	 * @return the String to the result file
 	 */
 	@GET
-	@Path("/simulations/{simulationid:.*}")
+	@Path("/results/simulations/{simulationid:.*}")
 	public String getSimulationResults(
 			@PathParam("simulationid") String simulationid);
 
@@ -57,7 +51,7 @@ public interface ISimulationMonitoringAPI {
 	 * @return the String to the trace file
 	 */
 	@GET
-	@Path("/traces/users/{userid:.*}")
+	@Path("/results/users/{userid:.*}")
 	public String getSimulationTraceForLearner(
 			@PathParam("userid") String userid);
 
@@ -68,7 +62,7 @@ public interface ISimulationMonitoringAPI {
 	 * @return the String to the trace file
 	 */
 	@GET
-	@Path("/traces/models/{modelid:.*}")
+	@Path("/results/models/{modelid:.*}")
 	public String getSimulationTraceForBP(@PathParam("modelid") String modelid);
 
 }

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/ISimulationMonitoringAPI.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/ISimulationMonitoringAPI.java
@@ -34,6 +34,7 @@ import javax.ws.rs.core.MediaType;
  * @author Tom Jorquera - Linagora
  *
  */
+@Path("/results")
 @Consumes(MediaType.APPLICATION_JSON)
 @Produces(MediaType.APPLICATION_JSON)
 public interface ISimulationMonitoringAPI {
@@ -45,7 +46,7 @@ public interface ISimulationMonitoringAPI {
 	 * @return the String to the result file
 	 */
 	@GET
-	@Path("/learnpad/sim/results/simulations/{simulationid:.*}")
+	@Path("/simulations/{simulationid:.*}")
 	public String getSimulationResults(
 			@PathParam("simulationid") String simulationid);
 
@@ -56,7 +57,7 @@ public interface ISimulationMonitoringAPI {
 	 * @return the String to the trace file
 	 */
 	@GET
-	@Path("/learnpad/sim/traces/users/{userid:.*}")
+	@Path("/traces/users/{userid:.*}")
 	public String getSimulationTraceForLearner(
 			@PathParam("userid") String userid);
 
@@ -67,7 +68,7 @@ public interface ISimulationMonitoringAPI {
 	 * @return the String to the trace file
 	 */
 	@GET
-	@Path("/learnpad/sim/traces/models/{modelid:.*}")
+	@Path("/traces/models/{modelid:.*}")
 	public String getSimulationTraceForBP(@PathParam("modelid") String modelid);
 
 }

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/IUserInfosAPI.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/IUserInfosAPI.java
@@ -44,6 +44,7 @@ public interface IUserInfosAPI {
 	public List<String> getUsers();
 
 	@GET
-	@Path("/{userid:.*}")
-	public UserData getUserData(@PathParam("userid") String userId);
+	@Path("/{userartifactid:.*}")
+	public UserData getUserData(
+			@PathParam("userartifactid") String userartifactid);
 }

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/IUserInfosAPI.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/IUserInfosAPI.java
@@ -1,0 +1,32 @@
+/**
+ *
+ */
+package eu.learnpad.sim.rest;
+
+import java.util.List;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import eu.learnpad.sim.rest.data.UserData;
+
+/**
+ * @author Tom Jorquera - Linagora
+ *
+ */
+@Consumes(MediaType.APPLICATION_JSON)
+@Produces(MediaType.APPLICATION_JSON)
+public interface IUserInfosAPI {
+
+	@GET
+	@Path("/learnpad/sim/users")
+	public List<String> getUsers();
+
+	@GET
+	@Path("/learnpad/sim/users/{userid:.*}")
+	public UserData getUserData(@PathParam("userid") String userId);
+}

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/IUserInfosAPI.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/IUserInfosAPI.java
@@ -18,15 +18,16 @@ import eu.learnpad.sim.rest.data.UserData;
  * @author Tom Jorquera - Linagora
  *
  */
+@Path("/users")
 @Consumes(MediaType.APPLICATION_JSON)
 @Produces(MediaType.APPLICATION_JSON)
 public interface IUserInfosAPI {
 
 	@GET
-	@Path("/learnpad/sim/users")
+	@Path("/")
 	public List<String> getUsers();
 
 	@GET
-	@Path("/learnpad/sim/users/{userid:.*}")
+	@Path("/{userid:.*}")
 	public UserData getUserData(@PathParam("userid") String userId);
 }

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/IUserInfosAPI.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/IUserInfosAPI.java
@@ -34,7 +34,7 @@ import eu.learnpad.sim.rest.data.UserData;
  * @author Tom Jorquera - Linagora
  *
  */
-@Path("/users")
+@Path("/learnpad/sim/users")
 @Consumes(MediaType.APPLICATION_JSON)
 @Produces(MediaType.APPLICATION_JSON)
 public interface IUserInfosAPI {

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/IUserInfosAPI.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/IUserInfosAPI.java
@@ -1,5 +1,21 @@
-/**
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
  *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 package eu.learnpad.sim.rest;
 

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/data/ProcessData.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/data/ProcessData.java
@@ -33,7 +33,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  */
 public class ProcessData {
 
-	public String artifactid;
 	public String name;
 	public String description;
 	public Collection<String> singleRoles;
@@ -43,12 +42,10 @@ public class ProcessData {
 	};
 
 	@JsonCreator
-	public ProcessData(@JsonProperty("artifactid") String artifactid,
-			@JsonProperty("name") String name,
+	public ProcessData(@JsonProperty("name") String name,
 			@JsonProperty("description") String description,
 			@JsonProperty("singleRoles") Collection<String> singleRoles,
 			@JsonProperty("groupRoles") Collection<String> groupRoles) {
-		this.artifactid = artifactid;
 		this.name = name;
 		this.description = description;
 		this.singleRoles = singleRoles;

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/data/ProcessData.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/data/ProcessData.java
@@ -33,7 +33,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  */
 public class ProcessData {
 
-	public String id;
+	public String artifactid;
 	public String name;
 	public String description;
 	public Collection<String> singleRoles;
@@ -43,12 +43,12 @@ public class ProcessData {
 	};
 
 	@JsonCreator
-	public ProcessData(@JsonProperty("id") String id,
+	public ProcessData(@JsonProperty("artifactid") String artifactid,
 			@JsonProperty("name") String name,
 			@JsonProperty("description") String description,
 			@JsonProperty("singleRoles") Collection<String> singleRoles,
 			@JsonProperty("groupRoles") Collection<String> groupRoles) {
-		this.id = id;
+		this.artifactid = artifactid;
 		this.name = name;
 		this.description = description;
 		this.singleRoles = singleRoles;

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/data/ProcessData.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/data/ProcessData.java
@@ -1,0 +1,59 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package eu.learnpad.sim.rest.data;
+
+import java.util.Collection;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * This class contains the data structure with all the informations returned by
+ * the API about a given process definition.
+ *
+ * @author Tom Jorquera - Linagora
+ *
+ */
+public class ProcessData {
+
+	public String id;
+	public String name;
+	public String description;
+	public Collection<String> singleRoles;
+	public Collection<String> groupRoles;
+
+	public ProcessData() {
+	};
+
+	@JsonCreator
+	public ProcessData(@JsonProperty("id") String id,
+			@JsonProperty("name") String name,
+			@JsonProperty("description") String description,
+			@JsonProperty("singleRoles") Collection<String> singleRoles,
+			@JsonProperty("groupRoles") Collection<String> groupRoles) {
+		super();
+		this.id = id;
+		this.name = name;
+		this.description = description;
+		this.singleRoles = singleRoles;
+		this.groupRoles = groupRoles;
+	}
+
+}

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/data/ProcessData.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/data/ProcessData.java
@@ -48,7 +48,6 @@ public class ProcessData {
 			@JsonProperty("description") String description,
 			@JsonProperty("singleRoles") Collection<String> singleRoles,
 			@JsonProperty("groupRoles") Collection<String> groupRoles) {
-		super();
 		this.id = id;
 		this.name = name;
 		this.description = description;

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/data/ProcessInstanceData.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/data/ProcessInstanceData.java
@@ -1,0 +1,56 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package eu.learnpad.sim.rest.data;
+
+import java.util.Collection;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * This class contains the data structure with all the informations returned by
+ * the API about a given process instance.
+ *
+ * @author Tom Jorquera - Linagora
+ *
+ */
+public class ProcessInstanceData {
+
+	public String process;
+	public Map<String, Object> parameters;
+	public Collection<String> users;
+	public Map<String, Collection<String>> routes;
+
+	public ProcessInstanceData() {
+	};
+
+	@JsonCreator
+	public ProcessInstanceData(@JsonProperty("process") String process,
+			@JsonProperty("parameters") Map<String, Object> parameters,
+			@JsonProperty("users") Collection<String> users,
+			@JsonProperty("routes") Map<String, Collection<String>> routes) {
+		this.process = process;
+		this.parameters = parameters;
+		this.users = users;
+		this.routes = routes;
+	}
+
+}

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/data/ProcessInstanceData.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/data/ProcessInstanceData.java
@@ -34,7 +34,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  */
 public class ProcessInstanceData {
 
-	public String process;
+	public String processartifactid;
 	public Map<String, Object> parameters;
 	public Collection<String> users;
 	public Map<String, Collection<String>> routes;
@@ -43,11 +43,12 @@ public class ProcessInstanceData {
 	};
 
 	@JsonCreator
-	public ProcessInstanceData(@JsonProperty("process") String process,
+	public ProcessInstanceData(
+			@JsonProperty("processartifactid") String processartifactid,
 			@JsonProperty("parameters") Map<String, Object> parameters,
 			@JsonProperty("users") Collection<String> users,
 			@JsonProperty("routes") Map<String, Collection<String>> routes) {
-		this.process = process;
+		this.processartifactid = processartifactid;
 		this.parameters = parameters;
 		this.users = users;
 		this.routes = routes;

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/data/UserData.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/data/UserData.java
@@ -28,7 +28,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  */
 public class UserData {
 
-	public String id;
+	public String artifactid;
 	public String firstName;
 	public String lastName;
 	public String bio;
@@ -38,13 +38,13 @@ public class UserData {
 	}
 
 	@JsonCreator
-	public UserData(@JsonProperty("id") String id,
+	public UserData(@JsonProperty("artifactid") String artifactid,
 			@JsonProperty("firstName") String firstName,
 			@JsonProperty("lastName") String lastName,
 			@JsonProperty("bio") String bio,
 			@JsonProperty("pictureURL") String pictureURL) {
 		super();
-		this.id = id;
+		this.artifactid = artifactid;
 		this.firstName = firstName;
 		this.lastName = lastName;
 		this.bio = bio;

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/data/UserData.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/data/UserData.java
@@ -1,0 +1,33 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package eu.learnpad.sim.rest.data;
+
+/**
+ * @author Tom Jorquera - Linagora
+ *
+ */
+public class UserData {
+
+	public String firstName;
+	public String lastName;
+	public String bio;
+	public String pictureURL;
+
+}

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/data/UserData.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/data/UserData.java
@@ -28,7 +28,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  */
 public class UserData {
 
-	public String artifactid;
 	public String firstName;
 	public String lastName;
 	public String bio;
@@ -38,13 +37,11 @@ public class UserData {
 	}
 
 	@JsonCreator
-	public UserData(@JsonProperty("artifactid") String artifactid,
-			@JsonProperty("firstName") String firstName,
+	public UserData(@JsonProperty("firstName") String firstName,
 			@JsonProperty("lastName") String lastName,
 			@JsonProperty("bio") String bio,
 			@JsonProperty("pictureURL") String pictureURL) {
 		super();
-		this.artifactid = artifactid;
 		this.firstName = firstName;
 		this.lastName = lastName;
 		this.bio = bio;

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/data/UserData.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/data/UserData.java
@@ -25,6 +25,7 @@ package eu.learnpad.sim.rest.data;
  */
 public class UserData {
 
+	public String id;
 	public String firstName;
 	public String lastName;
 	public String bio;

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/data/UserData.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/data/UserData.java
@@ -19,6 +19,9 @@
  */
 package eu.learnpad.sim.rest.data;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 /**
  * @author Tom Jorquera - Linagora
  *
@@ -30,5 +33,22 @@ public class UserData {
 	public String lastName;
 	public String bio;
 	public String pictureURL;
+
+	public UserData() {
+	}
+
+	@JsonCreator
+	public UserData(@JsonProperty("id") String id,
+			@JsonProperty("firstName") String firstName,
+			@JsonProperty("lastName") String lastName,
+			@JsonProperty("bio") String bio,
+			@JsonProperty("pictureURL") String pictureURL) {
+		super();
+		this.id = id;
+		this.firstName = firstName;
+		this.lastName = lastName;
+		this.bio = bio;
+		this.pictureURL = pictureURL;
+	}
 
 }


### PR DESCRIPTION
NOTE: this PR is the updated version of PR #38

Add Bridge and Core interfaces for the simulator, with REST API
description and associated data format.

The sim.rest.data package contains the description of the different data
structures required for creating and instantiating processes, as well as
for describing users.
The classes contained in this package are meant to be converted in and
from JSON when being passed to or by the REST API.

Notably, the sim.rest.IUserInfosAPI interface and sim.rest.data.UserData
class describe the expected API provided by the core facade. It seems a
little weird to describe them here since several modules may require the
same functionalities, each declaring similar interfaces...
Maybe these parts of the spec could be reified to a common shared
package.