### PR TITLE
REST API for the Content Analysis component Added

### DIFF
--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/ca/Bridge.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/ca/Bridge.java
@@ -1,0 +1,26 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package eu.learnpad.ca;
+
+public abstract class Bridge implements BridgeInterface{
+
+	protected CoreFacade corefacade;
+	
+}

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/ca/BridgeInterface.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/ca/BridgeInterface.java
@@ -1,0 +1,29 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package eu.learnpad.ca;
+
+import eu.learnpad.ca.rest.ColloborativeContentVerifications;
+import eu.learnpad.ca.rest.StaticContentVerifications;
+
+
+
+public interface BridgeInterface extends ColloborativeContentVerifications, StaticContentVerifications {
+
+}

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/ca/Controller.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/ca/Controller.java
@@ -1,0 +1,26 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package eu.learnpad.ca;
+
+public abstract class Controller implements CoreFacade{
+
+	protected BridgeInterface bridge;
+	
+}

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/ca/CoreFacade.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/ca/CoreFacade.java
@@ -1,0 +1,6 @@
+package eu.learnpad.ca;
+
+
+public interface CoreFacade {
+
+}

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/ca/rest/ColloborativeContentVerifications.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/ca/rest/ColloborativeContentVerifications.java
@@ -1,0 +1,95 @@
+
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package eu.learnpad.ca.rest;
+
+
+import java.util.Collection;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+
+import eu.learnpad.ca.rest.data.collaborative.AnnotateCollaborativeContentAnalysis;
+import eu.learnpad.ca.rest.data.collaborative.CollaborativeContentAnalysis;
+import eu.learnpad.exception.LpRestException;
+
+@Consumes(MediaType.APPLICATION_XML)
+@Produces(MediaType.APPLICATION_XML)
+public interface ColloborativeContentVerifications {
+
+	
+	@Path("/learnpad/ca/validatecollaborativecontent")
+	@POST
+	String putValidateCollaborativeContent(@QueryParam("collaborativecontent") CollaborativeContentAnalysis contentFile)
+				throws LpRestException;
+	
+	@Path("/learnpad/ca/validatecollaborativecontent")
+	@PUT
+	String updateValidateCollaborativeContent(@QueryParam("collaborativecontent") CollaborativeContentAnalysis contentFile)
+				throws LpRestException;
+
+	@Path("/learnpad/ca/validatecollaborativecontent/{idAnnotateCollaborativeContentAnalysis:.*}")
+	@GET
+	Collection<AnnotateCollaborativeContentAnalysis> getCollaborativeContentVerifications(@PathParam("idAnnotateCollaborativeContentAnalysis") String contentID)
+			throws LpRestException;
+	
+	@Path("/learnpad/ca/validatecollaborativecontent/{idAnnotateCollaborativeContentAnalysis:.*}/status")
+	@GET
+	String getStatusCollaborativeContentVerifications(@PathParam("idAnnotateCollaborativeContentAnalysis") String contentID)
+			throws LpRestException;
+}
+/**
+*@startuml
+*
+LPCorePlatform -> ContentAnalysis:putValidateCollaborativeContent(contentXML) HTTP Req @POST /learnpad/ca/validatecollaborativecontent 
+activate ContentAnalysis #FFBBBB 
+
+ContentAnalysis-->LPCorePlatform: Http Response OK (idAnnotateCollaborativeContentAnalysis)
+
+ContentAnalysis->ContentAnalysis: Perform verifications
+
+LPCorePlatform -> ContentAnalysis: getStatusCollaborativeContentVerifications(idAnnotateCollaborativeContentAnalysis) @GET /learnpad/ca/collaborativecontentverifications/{idAnnotateCollaborativeContentAnalysis}/status
+
+ContentAnalysis-->LPCorePlatform: Http Response OK (Status:Processing)
+
+
+
+LPCorePlatform -> ContentAnalysis: getStatusCollaborativeContentVerifications(idAnnotateCollaborativeContentAnalysis) @GET /learnpad/ca/collaborativecontentverifications/{idAnnotateCollaborativeContentAnalysis}/status
+
+
+ContentAnalysis-->LPCorePlatform: Http Response OK (Status:OK)
+
+deactivate ContentAnalysis #FFBBBB 
+
+LPCorePlatform -> ContentAnalysis: getCollaborativeContentVerifications(idAnnotateCollaborativeContentAnalysis) @GET  /learnpad/ca/collaborativecontentverifications/{idAnnotateCollaborativeContentAnalysis}
+
+ContentAnalysis-->LPCorePlatform: Http Response OK (Collection<annotateCollaborativeContentAnalysis>)
+
+
+
+*@enduml
+**/

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/ca/rest/StaticContentVerifications.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/ca/rest/StaticContentVerifications.java
@@ -1,0 +1,94 @@
+
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package eu.learnpad.ca.rest;
+
+
+import java.util.Collection;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+
+import eu.learnpad.ca.rest.data.stat.AnnotateStaticContentAnalysis;
+import eu.learnpad.ca.rest.data.stat.StaticContentAnalysis;
+import eu.learnpad.exception.LpRestException;
+
+@Consumes(MediaType.APPLICATION_XML)
+@Produces(MediaType.APPLICATION_XML)
+public interface StaticContentVerifications {
+
+	
+	@Path("/learnpad/ca/validatestaticcontent")
+	@POST
+	String putValidateStaticContent(@QueryParam("staticcontent") StaticContentAnalysis contentFile)
+				throws LpRestException;
+	
+	@Path("/learnpad/ca/validatestaticcontent")
+	@PUT
+	String updateValidateStaticContent(@QueryParam("staticcontent") byte[] contentFile)
+				throws LpRestException;
+
+	@Path("/learnpad/ca/staticcontentverifications/{idAnnotateStaticContentAnalysis:.*}")
+	@GET
+	Collection<AnnotateStaticContentAnalysis> getStaticContentVerifications(@PathParam("idAnnotateStaticContentAnalysis") String contentID)
+			throws LpRestException;
+	
+	@Path("/learnpad/ca/staticcontentverifications/{idAnnotateStaticContentAnalysis:.*}/status")
+	@GET
+	String getStatusStaticContentVerifications(@PathParam("idAnnotateStaticContentAnalysis") String contentID)
+			throws LpRestException;
+}
+/**
+*@startuml
+*
+LPCorePlatform -> ContentAnalysis:putValidateStaticContent(contentXML) HTTP Req @POST /learnpad/ca/validatestaticcontent 
+activate ContentAnalysis #FFBBBB 
+
+ContentAnalysis-->LPCorePlatform: Http Response OK (idAnnotateStaticContentAnalysis)
+
+ContentAnalysis->ContentAnalysis: Perform verifications
+
+LPCorePlatform -> ContentAnalysis: getStatusStaticContentVerifications(idAnnotateStaticContentAnalysis) @GET /learnpad/ca/staticcontentverifications/{idAnnotateStaticContentAnalysis}/status
+
+ContentAnalysis-->LPCorePlatform: Http Response OK (Status:Processing)
+
+
+
+LPCorePlatform -> ContentAnalysis: getStatusStaticContentVerifications(idAnnotateStaticContentAnalysis) @GET /learnpad/ca/staticcontentverifications/{idAnnotateStaticContentAnalysis}/status
+
+ContentAnalysis-->LPCorePlatform: Http Response OK (Status:OK)
+
+deactivate ContentAnalysis #FFBBBB 
+
+LPCorePlatform -> ContentAnalysis: getStaticContentVerifications(idAnnotateStaticContentAnalysis) @GET  /learnpad/ca/staticcontentverifications/{idAnnotateStaticContentAnalysis}
+
+ContentAnalysis-->LPCorePlatform: Http Response OK (Collection<annotateStaticContentAnalysis>)
+
+
+
+*@enduml
+**/

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/ca/rest/data/Annotation.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/ca/rest/data/Annotation.java
@@ -1,0 +1,153 @@
+package eu.learnpad.ca.rest.data;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlType;
+
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "")
+public  class Annotation {
+
+	@XmlAttribute(name = "id", required = true)
+	protected Integer id;
+	@XmlAttribute(name = "type", required = true)
+	protected String type;
+	@XmlAttribute(name = "StartNode", required = true)
+	protected Integer startNode;
+	@XmlAttribute(name = "EndNode", required = true)
+	protected Integer endNode;
+	@XmlAttribute(name = "recommendation", required = true)
+	protected String recommendation;
+
+	/**
+	 * get the value of id.
+	 * 
+	 * @return
+	 *     possible object is
+	 *     {@link Integer }
+	 *     
+	 */
+	public Integer getId() {
+		return id;
+	}
+
+	/**
+	 * set the value of id.
+	 * 
+	 * @param value
+	 *     allowed object is
+	 *     {@link Integer }
+	 *     
+	 */
+	public void setId(Integer value) {
+		this.id = value;
+	}
+
+	/**
+	 * get the value of type.
+	 * 
+	 * @return
+	 *     possible object is
+	 *     {@link String }
+	 *     
+	 */
+	public String getType() {
+		return type;
+	}
+
+	/**
+	 * set the value of type.
+	 * 
+	 * @param value
+	 *     allowed object is
+	 *     {@link String }
+	 *     
+	 */
+	public void setType(String value) {
+		this.type = value;
+	}
+
+	/**
+	 * get the value of startNode.
+	 * 
+	 * @return
+	 *     possible object is
+	 *     {@link Integer }
+	 *     
+	 */
+	public Integer getStartNode() {
+		return startNode;
+	}
+
+	/**
+	 * set the value of startNode.
+	 * 
+	 * @param value
+	 *     allowed object is
+	 *     {@link Integer }
+	 *     
+	 */
+	public void setStartNode(Integer value) {
+		this.startNode = value;
+	}
+
+	/**
+	 * get the value of endNode.
+	 * 
+	 * @return
+	 *     possible object is
+	 *     {@link Integer }
+	 *     
+	 */
+	public Integer getEndNode() {
+		return endNode;
+	}
+
+	/**
+	 * set the value of endNode.
+	 * 
+	 * @param value
+	 *     allowed object is
+	 *     {@link Integer }
+	 *     
+	 */
+	public void setEndNode(Integer value) {
+		this.endNode = value;
+	}
+
+	/**
+	 * get the value of recommendation.
+	 * 
+	 * @return
+	 *     possible object is
+	 *     {@link String }
+	 *     
+	 */
+	public String getRecommendation() {
+		return recommendation;
+	}
+
+	/**
+	 * set the value of recommendation.
+	 * 
+	 * @param value
+	 *     allowed object is
+	 *     {@link String }
+	 *     
+	 */
+	public void setRecommendation(String value) {
+		this.recommendation = value;
+	}
+
+	@Override
+	public String toString() {
+		return "Annotation_id=" + id + "[type=" + type + ", startNode="
+				+ startNode + ", endNode=" + endNode + ", recommendation="
+				+ recommendation + "]\n";
+	}
+	
+	
+
+}
+

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/ca/rest/data/Content.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/ca/rest/data/Content.java
@@ -1,0 +1,55 @@
+package eu.learnpad.ca.rest.data;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElementRef;
+import javax.xml.bind.annotation.XmlMixed;
+import javax.xml.bind.annotation.XmlRootElement;
+
+
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlRootElement
+public  class Content {
+
+	@XmlMixed
+	@XmlElementRef(type=Node.class, name="Node")
+	protected List<Object> Content;
+
+	/**
+	 * get the value of Content
+	 * @return List of Object
+	 */
+	public List<Object> getContent() {
+		if (Content == null) {
+			Content = new ArrayList<Object>();
+		}
+		return this.Content;
+	}
+
+	/***
+	 * Set get the value of Content
+	 * @param obj
+	 */
+	public void setContent(Object obj){
+		if (Content == null) {
+			Content = new ArrayList<Object>();
+		}
+		if(obj instanceof String | obj instanceof Node){
+			this.setContent(obj);
+		}
+
+	}
+
+	@Override
+	public String toString() {
+		return   Content.toString();
+	}
+
+
+
+
+
+}

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/ca/rest/data/Node.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/ca/rest/data/Node.java
@@ -1,0 +1,62 @@
+package eu.learnpad.ca.rest.data;
+
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlRootElement;
+
+
+@XmlRootElement(name = "Node")
+public class Node {
+
+
+	protected Integer id=-1;
+	
+	/**
+	 * Get the value of id.
+	 * 
+	 * @return
+	 *     possible object is
+	 *     {@link Integer }
+	 *     
+	 */
+	@XmlAttribute(name = "id")
+	public Integer getId() {
+		return id;
+	}
+
+	/**
+	 * Set the value of id.
+	 * 
+	 * @param value
+	 *     allowed object is
+	 *     {@link Integer }
+	 *     
+	 */
+	public void setId(Integer value) {
+		this.id = value;
+	}
+
+	@Override
+	public String toString() {
+		return "Node id=" + id + " ";
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (!(obj instanceof Node))
+			return false;
+		Node other = (Node) obj;
+		if (id == null) {
+			if (other.id != null)
+				return false;
+		} else if (!id.equals(other.id))
+			return false;
+		return true;
+	}
+
+
+
+}

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/ca/rest/data/QualityCriteria.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/ca/rest/data/QualityCriteria.java
@@ -1,0 +1,180 @@
+package eu.learnpad.ca.rest.data;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "")
+public class QualityCriteria {
+
+    @XmlAttribute(name = "simplicity")
+    protected Boolean simplicity;
+    @XmlAttribute(name = "non_ambiguity")
+    protected Boolean nonAmbiguity;
+    @XmlAttribute(name = "content_clarity")
+    protected Boolean contentClarity;
+    @XmlAttribute(name = "presentation_clarity")
+    protected Boolean presentationClarity;
+    @XmlAttribute(name = "completeness")
+    protected Boolean completeness;
+    @XmlAttribute(name = "correctness")
+    protected Boolean correctness;
+
+    /**
+     * Get the value of simplicity.
+     * 
+     * @return
+     *     possible object is
+     *     {@link Boolean }
+     *     
+     */
+    public Boolean isSimplicity() {
+        return simplicity;
+    }
+
+    /**
+     * Set the value of simplicity.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link Boolean }
+     *     
+     */
+    public void setSimplicity(Boolean value) {
+        this.simplicity = value;
+    }
+
+    /**
+     * Get the value of nonAmbiguity.
+     * 
+     * @return
+     *     possible object is
+     *     {@link Boolean }
+     *     
+     */
+    public Boolean isNonAmbiguity() {
+        return nonAmbiguity;
+    }
+
+    /**
+     * Set the value of nonAmbiguity.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link Boolean }
+     *     
+     */
+    public void setNonAmbiguity(Boolean value) {
+        this.nonAmbiguity = value;
+    }
+
+    /**
+     * Get the value of contentClarity.
+     * 
+     * @return
+     *     possible object is
+     *     {@link Boolean }
+     *     
+     */
+    public Boolean isContentClarity() {
+        return contentClarity;
+    }
+
+    /**
+     * Set the value of contentClarity.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link Boolean }
+     *     
+     */
+    public void setContentClarity(Boolean value) {
+        this.contentClarity = value;
+    }
+
+    /**
+     * Get the value of presentationClarity.
+     * 
+     * @return
+     *     possible object is
+     *     {@link Boolean }
+     *     
+     */
+    public Boolean isPresentationClarity() {
+        return presentationClarity;
+    }
+
+    /**
+     * Set the value of presentationClarity.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link Boolean }
+     *     
+     */
+    public void setPresentationClarity(Boolean value) {
+        this.presentationClarity = value;
+    }
+
+    /**
+     * Get the value of completeness.
+     * 
+     * @return
+     *     possible object is
+     *     {@link Boolean }
+     *     
+     */
+    public Boolean isCompleteness() {
+        return completeness;
+    }
+
+    /**
+     * Set the value of completeness.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link Boolean }
+     *     
+     */
+    public void setCompleteness(Boolean value) {
+        this.completeness = value;
+    }
+
+    /**
+     * Get the value of correctness.
+     * 
+     * @return
+     *     possible object is
+     *     {@link Boolean }
+     *     
+     */
+    public Boolean isCorrectness() {
+        return correctness;
+    }
+
+    /**
+     * Set the value of correctness.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link Boolean }
+     *     
+     */
+    public void setCorrectness(Boolean value) {
+        this.correctness = value;
+    }
+
+	@Override
+	public String toString() {
+		return "QualityCriteria [simplicity=" + simplicity + ", nonAmbiguity="
+				+ nonAmbiguity + ", contentClarity=" + contentClarity
+				+ ", presentationClarity=" + presentationClarity
+				+ ", completeness=" + completeness + ", correctness="
+				+ correctness + "]";
+	}
+    
+    
+
+}

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/ca/rest/data/collaborative/AnnotateCollaborativeContentAnalysis.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/ca/rest/data/collaborative/AnnotateCollaborativeContentAnalysis.java
@@ -1,0 +1,243 @@
+package eu.learnpad.ca.rest.data.collaborative;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElementWrapper;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+
+import eu.learnpad.ca.rest.data.Annotation;
+import eu.learnpad.ca.rest.data.Content;
+
+/**
+ * This class contains the data structure with all the informations returned by
+ * the API about a given Annotate Collaborative Content Analysis.
+ *
+ * @author ISTI CNR
+ *
+*/
+
+
+
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "", propOrder = {
+    "collaborativeContent",
+    "annotations",
+    "overallQuality",
+    "overallQualityMeasure",
+    "overallRecommendations"
+})
+@XmlRootElement(name = "annotateCollaborativeContentAnalysis")
+public class AnnotateCollaborativeContentAnalysis {
+
+	@XmlElement(name = "CollaborativeContent", required = true)
+    protected CollaborativeContent collaborativeContent;
+    @XmlElementWrapper(name = "Annotations", required = true)
+    @XmlElement(name = "Annotation", required = true)
+    protected List<Annotation> annotations;
+    @XmlElement(name = "OverallQuality", required = true)
+    protected String overallQuality;
+    @XmlElement(name = "OverallQualityMeasure", required = true)
+    protected String overallQualityMeasure;
+    @XmlElement(name = "OverallRecommendations", required = true)
+    protected String overallRecommendations;
+    @XmlAttribute(name = "id", required = true)
+    protected Integer id;
+    @XmlAttribute(name = "type", required = true)
+    protected String type;
+
+   
+
+    /**
+     * get the value of CollaborativeContent.
+     * 
+     * @return
+     *     possible object is
+     *     {@link AnnotateStaticContentAnalysis.Content }
+     *     
+     */
+    public CollaborativeContent getCollaborativeContent() {
+        return collaborativeContent;
+    }
+
+    /**
+     * set the value of collaborativeContent.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link AnnotateStaticContentAnalysis.Content }
+     *     
+     */
+    public void setCollaborativeContent(CollaborativeContent value) {
+        this.collaborativeContent = value;
+    }
+
+    /**
+     * get the value of annotations.
+     * 
+     * @return
+     *     possible object is
+     *     {@link AnnotateStaticContentAnalysis.Annotations }
+     *     
+     */
+    public List<Annotation> getAnnotations() {
+    	if (annotations == null) {
+    		annotations = new ArrayList<Annotation>();
+        }
+        return annotations;
+    }
+
+    /**
+     * set the value of annotations.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link AnnotateStaticContentAnalysis.Annotations }
+     *     
+     */
+    public void setAnnotations(Annotation value) {
+    	if (annotations == null) {
+            annotations = new ArrayList<Annotation>();
+            
+        }
+        annotations.add(value);
+    }
+
+    /**
+     * get the value of overallQuality.
+     * 
+     * @return
+     *     possible object is
+     *     {@link String }
+     *     
+     */
+    public String getOverallQuality() {
+        return overallQuality;
+    }
+
+    /**
+     * set the value of overallQuality.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link String }
+     *     
+     */
+    public void setOverallQuality(String value) {
+        this.overallQuality = value;
+    }
+
+    /**
+     * get the value of overallQualityMeasure.
+     * 
+     * @return
+     *     possible object is
+     *     {@link String }
+     *     
+     */
+    public String getOverallQualityMeasure() {
+        return overallQualityMeasure;
+    }
+
+    /**
+     * set the value of overallQualityMeasure.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link String }
+     *     
+     */
+    public void setOverallQualityMeasure(String value) {
+        this.overallQualityMeasure = value;
+    }
+
+    /**
+     * get the value of overallRecommendations.
+     * 
+     * @return
+     *     possible object is
+     *     {@link String }
+     *     
+     */
+    public String getOverallRecommendations() {
+        return overallRecommendations;
+    }
+
+    /**
+     * set the value of overallRecommendations.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link String }
+     *     
+     */
+    public void setOverallRecommendations(String value) {
+        this.overallRecommendations = value;
+    }
+
+    /**
+     * get the value of id.
+     * 
+     * @return
+     *     possible object is
+     *     {@link Integer }
+     *     
+     */
+    public Integer getId() {
+        return id;
+    }
+
+    /**
+     * set the value of id.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link Integer }
+     *     
+     */
+    public void setId(Integer value) {
+        this.id = value;
+    }
+
+    /**
+     * get the value of type.
+     * 
+     * @return
+     *     possible object is
+     *     {@link String }
+     *     
+     */
+    public String getType() {
+        return type;
+    }
+
+    /**
+     * set the value of type.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link String }
+     *     
+     */
+    public void setType(String value) {
+        this.type = value;
+    }
+
+	@Override
+	public String toString() {
+		return "ContentAnalysis [ type=" + type+ ", id=" + id 
+				+ ", collaborativeContent=" + collaborativeContent + ", annotations=" + annotations
+				+ ", overallQuality=" + overallQuality
+				+ ", overallQualityMeasure=" + overallQualityMeasure
+				+ ", overallRecommendations=" + overallRecommendations
+				+  "]\n";
+	}
+
+    
+
+}

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/ca/rest/data/collaborative/CollaborativeContent.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/ca/rest/data/collaborative/CollaborativeContent.java
@@ -1,0 +1,105 @@
+package eu.learnpad.ca.rest.data.collaborative;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+
+import eu.learnpad.ca.rest.data.Content;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "", propOrder = {
+    "title",
+    "content"
+})
+public class CollaborativeContent {
+
+    @XmlElement(name = "Title", required = true)
+    protected String title;
+    @XmlElement(name = "Content", required = true)
+    protected Content content;
+    @XmlAttribute(name = "id")
+    protected String id;
+
+    /**
+     * Get the value of title.
+     * 
+     * @return
+     *     possible object is
+     *     {@link String }
+     *     
+     */
+    public String getTitle() {
+        return title;
+    }
+
+    /**
+     * Set the value of title.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link String }
+     *     
+     */
+    public void setTitle(String value) {
+        this.title = value;
+    }
+
+    /**
+     * Get the value of content.
+     * 
+     * @return
+     *     possible object is
+     *     {@link String }
+     *     
+     */
+    public Content getContent() {
+        return content;
+    }
+
+    /**
+     * Set the value of content.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link String }
+     *     
+     */
+    public void setContent(Content value) {
+        this.content = value;
+    }
+
+    /**
+     * Get the value of id.
+     * 
+     * @return
+     *     possible object is
+     *     {@link String }
+     *     
+     */
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * Set the value of id.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link String }
+     *     
+     */
+    public void setId(String value) {
+        this.id = value;
+    }
+
+	@Override
+	public String toString() {
+		return "CollaborativeContent"+ ", id=" + id + " [title=" + title + ", content=" + content
+				+ "]";
+	}
+    
+    
+
+}

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/ca/rest/data/collaborative/CollaborativeContentAnalysis.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/ca/rest/data/collaborative/CollaborativeContentAnalysis.java
@@ -1,0 +1,85 @@
+package eu.learnpad.ca.rest.data.collaborative;
+
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+
+import eu.learnpad.ca.rest.data.QualityCriteria;
+
+
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "", propOrder = {
+    "collaborativeContent",
+    "qualityCriteria"
+})
+@XmlRootElement(name = "CollaborativeContentAnalysis")
+public class CollaborativeContentAnalysis {
+
+    @XmlElement(name = "CollaborativeContent", required = true)
+    protected CollaborativeContent collaborativeContent;
+    @XmlElement(name = "QualityCriteria", required = true)
+    protected QualityCriteria qualityCriteria;
+
+    /**
+     * Get the value of collaborativeContent.
+     * 
+     * @return
+     *     possible object is
+     *     {@link CollaborativeContent }
+     *     
+     */
+    public CollaborativeContent getCollaborativeContent() {
+        return collaborativeContent;
+    }
+
+    /**
+     * Set the value of collaborativeContent.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link CollaborativeContent }
+     *     
+     */
+    public void setCollaborativeContent(CollaborativeContent value) {
+        this.collaborativeContent = value;
+    }
+
+    /**
+     * Get the value of qualityCriteria.
+     * 
+     * @return
+     *     possible object is
+     *     {@link QualityCriteria }
+     *     
+     */
+    public QualityCriteria getQualityCriteria() {
+        return qualityCriteria;
+    }
+
+    /**
+     * Set the value of qualityCriteria.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link QualityCriteria }
+     *     
+     */
+    public void setQualityCriteria(QualityCriteria value) {
+        this.qualityCriteria = value;
+    }
+
+	@Override
+	public String toString() {
+		return "CollaborativeContentAnalysis [collaborativeContent="
+				+ collaborativeContent + ", qualityCriteria=" + qualityCriteria
+				+ "]";
+	}
+
+    
+
+
+}

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/ca/rest/data/stat/AnnotateStaticContentAnalysis.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/ca/rest/data/stat/AnnotateStaticContentAnalysis.java
@@ -1,0 +1,243 @@
+package eu.learnpad.ca.rest.data.stat;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElementWrapper;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+
+import eu.learnpad.ca.rest.data.Annotation;
+import eu.learnpad.ca.rest.data.Content;
+
+/**
+ * This class contains the data structure with all the informations returned by
+ * the API about a given Annotate Collaborative Content Analysis.
+ *
+ * @author ISTI CNR
+ *
+*/
+
+
+
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "", propOrder = {
+    "staticContent",
+    "annotations",
+    "overallQuality",
+    "overallQualityMeasure",
+    "overallRecommendations"
+})
+@XmlRootElement(name = "annotateStaticContentAnalysis")
+public class AnnotateStaticContentAnalysis {
+
+	@XmlElement(name = "StaticContent", required = true)
+    protected StaticContent staticContent;
+    @XmlElementWrapper(name = "Annotations", required = true)
+    @XmlElement(name = "Annotation", required = true)
+    protected List<Annotation> annotations;
+    @XmlElement(name = "OverallQuality", required = true)
+    protected String overallQuality;
+    @XmlElement(name = "OverallQualityMeasure", required = true)
+    protected String overallQualityMeasure;
+    @XmlElement(name = "OverallRecommendations", required = true)
+    protected String overallRecommendations;
+    @XmlAttribute(name = "id", required = true)
+    protected Integer id;
+    @XmlAttribute(name = "type", required = true)
+    protected String type;
+
+   
+
+    /**
+     * get the value of StaticContent.
+     * 
+     * @return
+     *     possible object is
+     *     {@link AnnotateStaticContentAnalysis.Content }
+     *     
+     */
+    public StaticContent getStaticContent() {
+        return staticContent;
+    }
+
+    /**
+     * set the value of staticContent.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link AnnotateStaticContentAnalysis.Content }
+     *     
+     */
+    public void setStaticContent(StaticContent value) {
+        this.staticContent = value;
+    }
+
+    /**
+     * get the value of annotations.
+     * 
+     * @return
+     *     possible object is
+     *     {@link AnnotateStaticContentAnalysis.Annotations }
+     *     
+     */
+    public List<Annotation> getAnnotations() {
+    	if (annotations == null) {
+    		annotations = new ArrayList<Annotation>();
+        }
+        return annotations;
+    }
+
+    /**
+     * set the value of annotations.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link AnnotateStaticContentAnalysis.Annotations }
+     *     
+     */
+    public void setAnnotations(Annotation value) {
+    	if (annotations == null) {
+            annotations = new ArrayList<Annotation>();
+            
+        }
+        annotations.add(value);
+    }
+
+    /**
+     * get the value of overallQuality.
+     * 
+     * @return
+     *     possible object is
+     *     {@link String }
+     *     
+     */
+    public String getOverallQuality() {
+        return overallQuality;
+    }
+
+    /**
+     * set the value of overallQuality.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link String }
+     *     
+     */
+    public void setOverallQuality(String value) {
+        this.overallQuality = value;
+    }
+
+    /**
+     * get the value of overallQualityMeasure.
+     * 
+     * @return
+     *     possible object is
+     *     {@link String }
+     *     
+     */
+    public String getOverallQualityMeasure() {
+        return overallQualityMeasure;
+    }
+
+    /**
+     * set the value of overallQualityMeasure.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link String }
+     *     
+     */
+    public void setOverallQualityMeasure(String value) {
+        this.overallQualityMeasure = value;
+    }
+
+    /**
+     * get the value of overallRecommendations.
+     * 
+     * @return
+     *     possible object is
+     *     {@link String }
+     *     
+     */
+    public String getOverallRecommendations() {
+        return overallRecommendations;
+    }
+
+    /**
+     * set the value of overallRecommendations.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link String }
+     *     
+     */
+    public void setOverallRecommendations(String value) {
+        this.overallRecommendations = value;
+    }
+
+    /**
+     * get the value of id.
+     * 
+     * @return
+     *     possible object is
+     *     {@link Integer }
+     *     
+     */
+    public Integer getId() {
+        return id;
+    }
+
+    /**
+     * set the value of id.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link Integer }
+     *     
+     */
+    public void setId(Integer value) {
+        this.id = value;
+    }
+
+    /**
+     * get the value of type.
+     * 
+     * @return
+     *     possible object is
+     *     {@link String }
+     *     
+     */
+    public String getType() {
+        return type;
+    }
+
+    /**
+     * set the value of type.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link String }
+     *     
+     */
+    public void setType(String value) {
+        this.type = value;
+    }
+
+	@Override
+	public String toString() {
+		return "ContentAnalysis [ type=" + type+ ", id=" + id 
+				+ ", staticContent=" + staticContent + ", annotations=" + annotations
+				+ ", overallQuality=" + overallQuality
+				+ ", overallQualityMeasure=" + overallQualityMeasure
+				+ ", overallRecommendations=" + overallRecommendations
+				+  "]\n";
+	}
+
+    
+
+}

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/ca/rest/data/stat/StaticContent.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/ca/rest/data/stat/StaticContent.java
@@ -1,0 +1,105 @@
+package eu.learnpad.ca.rest.data.stat;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+
+import eu.learnpad.ca.rest.data.Content;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "", propOrder = {
+    "title",
+    "content"
+})
+public class StaticContent {
+
+    @XmlElement(name = "Title", required = true)
+    protected String title;
+    @XmlElement(name = "Content", required = true)
+    protected Content content;
+    @XmlAttribute(name = "id")
+    protected String id;
+
+    /**
+     * Get the value of title.
+     * 
+     * @return
+     *     possible object is
+     *     {@link String }
+     *     
+     */
+    public String getTitle() {
+        return title;
+    }
+
+    /**
+     * Set the value of title.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link String }
+     *     
+     */
+    public void setTitle(String value) {
+        this.title = value;
+    }
+
+    /**
+     * Get the value of content.
+     * 
+     * @return
+     *     possible object is
+     *     {@link String }
+     *     
+     */
+    public Content getContent() {
+        return content;
+    }
+
+    /**
+     * Set the value of content.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link String }
+     *     
+     */
+    public void setContent(Content value) {
+        this.content = value;
+    }
+
+    /**
+     * Get the value of id.
+     * 
+     * @return
+     *     possible object is
+     *     {@link String }
+     *     
+     */
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * Set the value of id.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link String }
+     *     
+     */
+    public void setId(String value) {
+        this.id = value;
+    }
+
+	@Override
+	public String toString() {
+		return "StaticContent"+ ", id=" + id + " [title=" + title + ", content=" + content
+				+ "]";
+	}
+    
+    
+
+}

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/ca/rest/data/stat/StaticContentAnalysis.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/ca/rest/data/stat/StaticContentAnalysis.java
@@ -1,0 +1,86 @@
+package eu.learnpad.ca.rest.data.stat;
+
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+
+import eu.learnpad.ca.rest.data.QualityCriteria;
+import eu.learnpad.ca.rest.data.collaborative.CollaborativeContent;
+
+
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "", propOrder = {
+    "staticContent",
+    "qualityCriteria"
+})
+@XmlRootElement(name = "StaticContentAnalysis")
+public class StaticContentAnalysis {
+
+    @XmlElement(name = "StaticContent", required = true)
+    protected StaticContent staticContent;
+    @XmlElement(name = "QualityCriteria", required = true)
+    protected QualityCriteria qualityCriteria;
+
+    /**
+     * Get the value of staticContent.
+     * 
+     * @return
+     *     possible object is
+     *     {@link CollaborativeContent }
+     *     
+     */
+    public StaticContent getStaticContent() {
+        return staticContent;
+    }
+
+    /**
+     * Set the value of staticContent.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link CollaborativeContent }
+     *     
+     */
+    public void setStaticContent(StaticContent value) {
+        this.staticContent = value;
+    }
+
+    /**
+     * Get the value of qualityCriteria.
+     * 
+     * @return
+     *     possible object is
+     *     {@link QualityCriteria }
+     *     
+     */
+    public QualityCriteria getQualityCriteria() {
+        return qualityCriteria;
+    }
+
+    /**
+     * Set the value of qualityCriteria.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link QualityCriteria }
+     *     
+     */
+    public void setQualityCriteria(QualityCriteria value) {
+        this.qualityCriteria = value;
+    }
+
+	@Override
+	public String toString() {
+		return "StaticContentAnalysis [staticContent="
+				+ staticContent + ", qualityCriteria=" + qualityCriteria
+				+ "]";
+	}
+
+    
+
+
+}


### PR DESCRIPTION
  Bridge and Core interfaces added for the Content Analysis component, with REST API description and associated data format.  The ca.rest.data package contains the description of the different data structures required for creating Static or Collaborative Content. The classes contained in this package are annotated with JAXB for marshalling and  unmarshalling XML file.  other information are present in  wiki page: http://wiki.learnpad.eu/LearnPAdWiki/bin/view/Component/Content+Analysis