### PR TITLE
Small fix on the exceptions

### DIFF
--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/exception/impl/LpRestExceptionXWikiImpl.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/exception/impl/LpRestExceptionXWikiImpl.java
@@ -55,12 +55,12 @@ public final class LpRestExceptionXWikiImpl extends LpRestException {
     }
     
     /**
-     * It converts back an LpRestExceptionXWikiImpl caused by an XWikiRestException
+     * It extracts back an LpRestExceptionXWikiImpl caused by an XWikiRestException
      * into the original XWikiRestException.
      * 
      * @param e the exception cause.
      * @return the original XWikiRestException
-     * @throws  RuntimeException if the conversion fails
+     * @throws  RuntimeException if the extraction fails
      */
     public static XWikiRestException extractXWikiRestException (LpRestException e) throws RuntimeException{
     	if (e instanceof LpRestExceptionXWikiImpl) {

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/exception/impl/LpRestExceptionXWikiImpl.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/exception/impl/LpRestExceptionXWikiImpl.java
@@ -4,7 +4,7 @@ import eu.learnpad.exception.LpRestException;
 
 import org.xwiki.rest.XWikiRestException;
 
-public class LpRestExceptionXWikiImpl extends LpRestException {
+public final class LpRestExceptionXWikiImpl extends LpRestException {
 
 	boolean isXWikiRestException;
 	
@@ -62,13 +62,13 @@ public class LpRestExceptionXWikiImpl extends LpRestException {
      * @return the original XWikiRestException
      * @throws  RuntimeException if the conversion fails
      */
-    public static XWikiRestException convertToXWikiRestException (LpRestException e) throws RuntimeException{
+    public static XWikiRestException extractXWikiRestException (LpRestException e) throws RuntimeException{
     	if (e instanceof LpRestExceptionXWikiImpl) {
     		LpRestExceptionXWikiImpl e1 = (LpRestExceptionXWikiImpl) e;
     		if (e1.isXWikiRestException)
     	    	return (XWikiRestException) e1.getCause();    				
 		}
-		throw new RuntimeException("Cannot convert LpRestException into XWikiRestException");
+		throw new RuntimeException("Cannot extract LpRestException into XWikiRestException");
     }
     
 }


### PR DESCRIPTION
Made the class eu.learnpad.exception.impl.LpRestExceptionXWikiImpl.java
more robust by promoting it to Final, and changing the name of its
static method to a more proper one.