### PR TITLE
[sim] Overhaul of the build system

### DIFF
--- a/lp-simulation-environment/build
+++ b/lp-simulation-environment/build
@@ -21,6 +21,7 @@ declare -r __MVN_PROFILE__="-Pkeep-license-files"
 
 ### BUILD ###
 function component_build() {
+    rm -rf $__OUT_PATH__
     mvn $__MVN_PROFILE__ clean
     # skip tests as we will do them in the component_test stage
     mvn $__MVN_PROFILE__ package -Dmaven.test.skip=true
@@ -37,7 +38,7 @@ function component_install() {
     mkdir -p ${__OUT_PATH__}
     cp "scripts/start" "${__OUT_START_FILE__}"
     cp "scripts/stop" "${__OUT_STOP_FILE__}"
-    cp "target/simulator-"*"-jar-with-dependencies.jar" "${__OUT_PATH__}/"
+    unzip "target/simulator-"*".zip" -d "${__OUT_PATH__}/"
     # There is no run dependencies for this component
     #cp <path_to>/rundeps.txt ${__OUT_RUNDEPS_FILE__}
     # These is no configuration file to copy

--- a/lp-simulation-environment/pom.xml
+++ b/lp-simulation-environment/pom.xml
@@ -159,41 +159,72 @@
 				</configuration>
 			</plugin>
 
+			<!-- This set of plugins is used to create an uber jar
+				see http://stackoverflow.com/questions/13021423/invalid-or-corrupt-jar-file-built-by-maven-shade-plugin
+				and https://ath3nd.wordpress.com/2013/12/25/packaging-a-multimodule-maven-spring-app-in-a-standalone-jar/
+			-->
+
+			<!-- Copy jar dependencies into build folder -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<version>2.10</version>
+				<executions>
+					<execution>
+						<id>copy</id>
+						<phase>package</phase>
+						<goals>
+							<goal>copy-dependencies</goal>
+						</goals>
+						<configuration>
+							<overWriteReleases>true</overWriteReleases>
+							<overWriteSnapshots>true</overWriteSnapshots>
+							<overWriteIfNewer>true</overWriteIfNewer>
+							<prependGroupId>true</prependGroupId>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+
+			<!-- Add dependencies into MANIFEST.MF as Class-Path -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
-				<version>2.4</version>
 				<configuration>
 					<archive>
 						<manifest>
+							<addClasspath>true</addClasspath>
 							<mainClass>eu.learnpad.simulator.Main</mainClass>
+							<classpathLayoutType>custom</classpathLayoutType>
+							<customClasspathLayout>lib/${artifact.groupId}.${artifact.artifactId}-${artifact.version}${dashClassifier?}.${artifact.extension}</customClasspathLayout>
 						</manifest>
+
 					</archive>
 				</configuration>
 			</plugin>
 
 			<plugin>
 				<artifactId>maven-assembly-plugin</artifactId>
-				<configuration>
-					<archive>
-						<manifest>
-							<mainClass>eu.learnpad.simulator.Main</mainClass>
-						</manifest>
-					</archive>
-					<descriptorRefs>
-						<descriptorRef>jar-with-dependencies</descriptorRef>
-					</descriptorRefs>
-				</configuration>
 				<executions>
 					<execution>
-						<id>make-assembly</id> <!-- this is used for inheritance merges -->
-						<phase>package</phase> <!-- bind to the packaging phase -->
+						<id>assembly:package</id>
+						<phase>package</phase>
 						<goals>
 							<goal>single</goal>
 						</goals>
+						<configuration>
+							<appendAssemblyId>false</appendAssemblyId>
+							<descriptors>
+								<descriptor>src/main/resources/assembly.xml</descriptor>
+							</descriptors>
+						</configuration>
 					</execution>
 				</executions>
 			</plugin>
+
+			<!--
+			End of uber jar creation
+			 -->
 
 			<plugin>
 				<!-- handle license files -->
@@ -210,6 +241,7 @@
 						<exclude>main/resources/static/lib/**</exclude>
 						<exclude>main/resources/license/**</exclude>
 						<exclude>main/resources/validation_db.json</exclude>
+						<exclude>main/resources/assembly.xml</exclude>
 					</excludes>
 					<licenseMerges>
 						<licenseMerge>

--- a/lp-simulation-environment/scripts/start
+++ b/lp-simulation-environment/scripts/start
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 cd $( dirname "${BASH_SOURCE[0]}")
 {
-	java -jar "./simulator-"*"-jar-with-dependencies.jar" > /dev/null
+	java -jar "simulator-"*"/simulator-"*".jar" > /dev/null
 }&

--- a/lp-simulation-environment/scripts/stop
+++ b/lp-simulation-environment/scripts/stop
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-pkill -f "java -jar ./simulator" || exit 0
+pkill -f "java -jar simulator-" || exit 0

--- a/lp-simulation-environment/src/main/resources/assembly.xml
+++ b/lp-simulation-environment/src/main/resources/assembly.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<assembly>
+	<id>package</id>
+	<formats>
+		<format>zip</format>
+	</formats>
+	<includeBaseDirectory>true</includeBaseDirectory>
+	<fileSets>
+		<fileSet>
+			<directory>target/dependency</directory>
+			<outputDirectory>/lib</outputDirectory>
+			<includes>
+				<include>**/*</include>
+			</includes>
+		</fileSet>
+		<fileSet>
+			<directory>${project.build.directory}/</directory>
+			<outputDirectory>/</outputDirectory>
+			<includes>
+				<include>*.jar</include>
+			</includes>
+		</fileSet>
+	</fileSets>
+</assembly>


### PR DESCRIPTION
The previous system to generate uber jar had several limitations, which
threatened to cause problems (and actually started to do so in the REST
branch).

The initial plan was to replace assembly with the shade plugin, but we
reached a limit in the number of files which can be contained into a jar
file(!).

The current solution is described here:
http://stackoverflow.com/questions/13021423/invalid-or-corrupt-jar-file-built-by-maven-shade-plugin
and here:
https://ath3nd.wordpress.com/2013/12/25/packaging-a-multimodule-maven-spring-app-in-a-standalone-jar/