### PR TITLE
[sim] Add Simulator REST API impl

### DIFF
--- a/lp-simulation-environment/pom.xml
+++ b/lp-simulation-environment/pom.xml
@@ -35,6 +35,7 @@
 		<underscorejs.version>1.7.0-1</underscorejs.version>
 		<spectrum.version>1.6.0</spectrum.version>
 		<license-maven-plugin.version>1.8</license-maven-plugin.version>
+		<resteasy.version>3.0.11.Final</resteasy.version>
 	</properties>
 
 	<repositories>
@@ -45,6 +46,26 @@
 	</repositories>
 
 	<dependencies>
+		<dependency>
+			<groupId>eu.learnpad</groupId>
+			<artifactId>lp-cp-apis</artifactId>
+			<version>1.0-SNAPSHOT</version>
+			<exclusions>
+				<exclusion>
+					<groupId>javax.ws.rs</groupId>
+					<artifactId>jsr311-api</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.xwiki.commons</groupId>
+					<artifactId>*</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.xwiki.platform</groupId>
+					<artifactId>*</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+
 		<dependency>
 			<groupId>org.activiti</groupId>
 			<artifactId>activiti-engine</artifactId>
@@ -91,6 +112,18 @@
 			<artifactId>jackson-databind</artifactId>
 			<version>${jackson.version}</version>
 		</dependency>
+
+		<dependency>
+			<groupId>org.jboss.resteasy</groupId>
+			<artifactId>resteasy-client</artifactId>
+			<version>${resteasy.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.jboss.resteasy</groupId>
+			<artifactId>resteasy-jackson-provider</artifactId>
+			<version>${resteasy.version}</version>
+		</dependency>
+
 
 		<!-- Web dependencies (yes that's a thing) -->
 

--- a/lp-simulation-environment/src/main/java/eu/learnpad/simulator/Simulator.java
+++ b/lp-simulation-environment/src/main/java/eu/learnpad/simulator/Simulator.java
@@ -64,7 +64,7 @@ public class Simulator implements IProcessManagerProvider,
 
 		// create users ui handler
 		uiHandler = new UIHandlerWebImpl(new WebServer(webserverPort, "ui",
-				"tasks"), new ArrayList<String>(), this,
+				"tasks", this), new ArrayList<String>(), this,
 				new ActivitiToJsonFormFormHandler(processEngine
 						.getFormService()));
 	}

--- a/lp-simulation-environment/src/main/java/eu/learnpad/simulator/api/impl/ResourceNotFoundExceptionMapper.java
+++ b/lp-simulation-environment/src/main/java/eu/learnpad/simulator/api/impl/ResourceNotFoundExceptionMapper.java
@@ -1,0 +1,50 @@
+/**
+ *
+ */
+package eu.learnpad.simulator.api.impl;
+
+/*
+ * #%L
+ * LearnPAd Simulator
+ * %%
+ * Copyright (C) 2014 - 2015 Linagora
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import javax.ws.rs.ext.ExceptionMapper;
+
+/**
+ * Response to send when throwing a {@link NotFoundException}
+ *
+ * @author Tom Jorquera - Linagora
+ *
+ */
+public class ResourceNotFoundExceptionMapper implements
+		ExceptionMapper<NotFoundException> {
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see javax.ws.rs.ext.ExceptionMapper#toResponse(java.lang.Throwable)
+	 */
+	public Response toResponse(NotFoundException exception) {
+		return Response.status(Status.NOT_FOUND).build();
+	}
+
+}

--- a/lp-simulation-environment/src/main/java/eu/learnpad/simulator/api/impl/SimulatorBridgeApplication.java
+++ b/lp-simulation-environment/src/main/java/eu/learnpad/simulator/api/impl/SimulatorBridgeApplication.java
@@ -1,0 +1,56 @@
+/**
+ *
+ */
+package eu.learnpad.simulator.api.impl;
+
+/*
+ * #%L
+ * LearnPAd Simulator
+ * %%
+ * Copyright (C) 2014 - 2015 Linagora
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.ws.rs.core.Application;
+
+/**
+ * @author Tom Jorquera - Linagora
+ *
+ */
+public class SimulatorBridgeApplication extends Application {
+
+	private Set<Object> singletons = new HashSet<Object>();
+	private Set<Class<?>> classes = new HashSet<Class<?>>();
+
+	public SimulatorBridgeApplication() {
+		classes.add(SimulatorBridgeImpl.class);
+		classes.add(ResourceNotFoundExceptionMapper.class);
+
+	}
+
+	@Override
+	public Set<Object> getSingletons() {
+		return singletons;
+	}
+
+	@Override
+	public Set<Class<?>> getClasses() {
+		return classes;
+	}
+}

--- a/lp-simulation-environment/src/main/java/eu/learnpad/simulator/api/impl/SimulatorBridgeImpl.java
+++ b/lp-simulation-environment/src/main/java/eu/learnpad/simulator/api/impl/SimulatorBridgeImpl.java
@@ -1,0 +1,193 @@
+/**
+ *
+ */
+package eu.learnpad.simulator.api.impl;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collection;
+
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response.Status;
+import javax.ws.rs.core.UriInfo;
+
+import eu.learnpad.sim.BridgeInterface;
+import eu.learnpad.sim.rest.data.ProcessData;
+import eu.learnpad.sim.rest.data.ProcessInstanceData;
+import eu.learnpad.simulator.Simulator;
+
+/*
+ * #%L
+ * LearnPAd Simulator
+ * %%
+ * Copyright (C) 2014 - 2015 Linagora
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+/**
+ * @author Tom Jorquera - Linagora
+ *
+ */
+@Path("/")
+public class SimulatorBridgeImpl implements BridgeInterface {
+
+	// this will allow us to return specific response codes (specifically for
+	// POST methods)
+	@Context
+	private HttpServletResponse response;
+	@Context
+	private UriInfo infos;
+
+	private final Simulator simulator;
+
+	public SimulatorBridgeImpl(@Context Simulator simulator) {
+		this.simulator = simulator;
+	}
+
+	/**
+	 * Configure the response to signal a created resource (set status to
+	 * created + return new resource location)
+	 *
+	 * @param relativePath
+	 */
+	private void setResponseToCreated(String relativePath) {
+		response.setStatus(Status.CREATED.getStatusCode());
+		response.setHeader("Location", infos.getAbsolutePath() + relativePath);
+
+		try {
+			response.flushBuffer();
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+
+	}
+
+	// Process handling
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see eu.learnpad.simulator.api.functionalities.IProcessesHandlingBridge#
+	 * getProcessDefinitions()
+	 */
+	public Collection<String> getProcessDefinitions() {
+
+		return simulator.processManager().getAvailableProcessDefintion();
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see eu.learnpad.simulator.api.functionalities.IProcessesHandlingBridge#
+	 * addProcessDefinition(java.lang.String)
+	 */
+	public Collection<String> addProcessDefinition(
+			String processDefinitionFilePath) {
+
+		// since we are potentially creating several resources we do not return
+		// the location of a specific one.
+		setResponseToCreated("");
+
+		return simulator.processManager().addProjectDefinitions(
+				processDefinitionFilePath);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see eu.learnpad.simulator.api.functionalities.IProcessesHandlingBridge#
+	 * getProcessInfos(java.lang.String)
+	 */
+	public ProcessData getProcessInfos(String processId) {
+		if (simulator.processManager().getAvailableProcessDefintion()
+				.contains(processId)) {
+
+			return new ProcessData(simulator.processManager()
+					.getProcessDefinitionName(processId), simulator
+					.processManager()
+					.getProcessDefinitionDescription(processId), simulator
+					.processManager()
+					.getProcessDefinitionSingleRoles(processId), simulator
+					.processManager().getProcessDefinitionGroupRoles(processId));
+		} else {
+			throw new NotFoundException();
+		}
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see eu.learnpad.simulator.api.functionalities.IProcessesHandlingBridge#
+	 * getProcessInstances()
+	 */
+	public Collection<String> getProcessInstances() {
+		return simulator.processManager().getCurrentProcessInstances();
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see eu.learnpad.simulator.api.functionalities.IProcessesHandlingBridge#
+	 * addProcessInstance(eu.learnpad.simulator.api.msg.ProcessInstanceData)
+	 */
+	public String addProcessInstance(ProcessInstanceData data) {
+		String id = simulator.processManager().startProjectInstance(
+				data.processartifactid, data.parameters, data.users,
+				data.routes);
+		setResponseToCreated(id);
+		return id;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see eu.learnpad.simulator.api.functionalities.IProcessesHandlingBridge#
+	 * getProcessInstanceInfos(java.lang.String)
+	 */
+	public ProcessInstanceData getProcessInstanceInfos(String processInstanceId) {
+		if (simulator.processManager().getCurrentProcessInstances()
+				.contains(processInstanceId)) {
+			return new ProcessInstanceData("", null, simulator.processManager()
+					.getProcessInstanceInvolvedUsers(processInstanceId), null);
+		} else {
+			throw new NotFoundException();
+		}
+	}
+
+	// simulation monitoring
+
+	public InputStream getProcessInstanceResults(String arg0) {
+		// TODO Proper Implementation of Simulation Monitoring API
+		return this.getClass().getClassLoader()
+				.getResourceAsStream("validation_db.json");
+	}
+
+	public InputStream getProcessResults(String arg0) {
+		// TODO Proper Implementation of Simulation Monitoring API
+		return this.getClass().getClassLoader()
+				.getResourceAsStream("validation_db.json");
+	}
+
+	public InputStream getUserResults(String arg0) {
+		// TODO Proper Implementation of Simulation Monitoring API
+		return this.getClass().getClassLoader()
+				.getResourceAsStream("validation_db.json");
+	}
+
+}

--- a/lp-simulation-environment/src/main/java/eu/learnpad/simulator/api/impl/SimulatorBridgeServletHolder.java
+++ b/lp-simulation-environment/src/main/java/eu/learnpad/simulator/api/impl/SimulatorBridgeServletHolder.java
@@ -1,0 +1,64 @@
+/**
+ *
+ */
+package eu.learnpad.simulator.api.impl;
+
+/*
+ * #%L
+ * LearnPAd Simulator
+ * %%
+ * Copyright (C) 2014 - 2015 Linagora
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+import javax.servlet.ServletContextEvent;
+
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.servlet.ServletHolder;
+import org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher;
+import org.jboss.resteasy.plugins.server.servlet.ResteasyBootstrap;
+
+import eu.learnpad.simulator.Simulator;
+
+/**
+ * Helper class to instantiate REST API servlet
+ *
+ * @author Tom Jorquera - Linagora
+ *
+ */
+public class SimulatorBridgeServletHolder extends ServletHolder {
+
+	public SimulatorBridgeServletHolder(final Simulator simulator,
+			ServletContextHandler context, String path) {
+		super(new HttpServletDispatcher());
+
+		context.addEventListener(new ResteasyBootstrap() {
+
+			@Override
+			public void contextInitialized(ServletContextEvent event) {
+				super.contextInitialized(event);
+				this.deployment.getDispatcher().getDefaultContextObjects()
+						.put(Simulator.class, simulator);
+			}
+
+		});
+
+		this.setInitParameter("javax.ws.rs.Application",
+				SimulatorBridgeApplication.class.getName());
+		this.setInitParameter("resteasy.servlet.mapping.prefix", path);
+	}
+
+}

--- a/lp-simulation-environment/src/main/java/eu/learnpad/simulator/uihandler/webserver/WebServer.java
+++ b/lp-simulation-environment/src/main/java/eu/learnpad/simulator/uihandler/webserver/WebServer.java
@@ -42,6 +42,7 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.Path;
 
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Server;
@@ -55,6 +56,9 @@ import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.servlet.ServletMapping;
 import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.websocket.servlet.WebSocketServlet;
+
+import eu.learnpad.simulator.Simulator;
+import eu.learnpad.simulator.api.impl.SimulatorBridgeServletHolder;
 
 /**
  * @author Tom Jorquera - Linagora
@@ -73,8 +77,8 @@ public class WebServer {
 	private final String uiPath;
 	private final String tasksPath;
 
-	public WebServer(final int port, String uiPath, String tasksPath)
-			throws Exception {
+	public WebServer(final int port, String uiPath, String tasksPath,
+			final Simulator simulator) throws Exception {
 		this.server = new Server();
 		final ServerConnector connector = new ServerConnector(server);
 
@@ -122,6 +126,14 @@ public class WebServer {
 		contexts.setHandlers(new Handler[] { webjarsContext, resourcesContext,
 				context });
 		server.setHandler(contexts);
+
+		context.setContextPath("/");
+
+		// add REST bridge servlet
+		String apiBasePath = eu.learnpad.sim.BridgeInterface.class
+				.getAnnotation(Path.class).value();
+		context.addServlet(new SimulatorBridgeServletHolder(simulator, context,
+				apiBasePath), apiBasePath + "*");
 
 		// start server
 		this.server.start();

--- a/lp-simulation-environment/src/test/java/eu/learnpad/simulator/uihandler/webserver/WebServerTest.java
+++ b/lp-simulation-environment/src/test/java/eu/learnpad/simulator/uihandler/webserver/WebServerTest.java
@@ -26,6 +26,7 @@ package eu.learnpad.simulator.uihandler.webserver;
 
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
 
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
@@ -49,6 +50,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import eu.learnpad.simulator.MainTest;
+import eu.learnpad.simulator.Simulator;
 
 /**
  *
@@ -66,7 +68,7 @@ public class WebServerTest {
 	public void init() {
 		try {
 
-			server = new WebServer(MainTest.PORT, "ui", "tasks");
+			server = new WebServer(MainTest.PORT, "ui", "tasks", mock(Simulator.class));
 		} catch (Exception e) {
 			System.err.println(e);
 			fail("got exception during setup");


### PR DESCRIPTION
The simulator module now implements and exposes the rest API defined in [lp-cp-apis](https://github.com/LearnPAd/learnpad/tree/d202cae6ceda0482b42c1bb2edd08a46b3360c9b/lp-core-platform/lp-cp-apis)