### PR TITLE
Minor corrections to Sim REST API

### DIFF
--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/IProcessHandlingAPI.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/IProcessHandlingAPI.java
@@ -27,6 +27,7 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
 import eu.learnpad.sim.rest.data.ProcessData;
@@ -105,9 +106,10 @@ public interface IProcessHandlingAPI {
 	 *         the base url to access the simulator)
 	 */
 	@POST
-	@Path("/instances")
-	public String addProcessInstance(String processId,
-			Collection<UserData> potentialUsers, String currentUser);
+	@Path("/instances/{artifactid:.*}")
+	public String addProcessInstance(@PathParam("artifactid") String processId,
+			Collection<UserData> potentialUsers,
+			@QueryParam("currentuser") String currentUser);
 
 	/**
 	 *


### PR DESCRIPTION
It seems that some of the lastest modifications to the REST API have been a little hasty. As it turns out, making a REST API via JAX-RS is not as simple as defining a Java interface.

This should not really create a problem (and require no actual change in the implementation since it only modify some annotations). But I still created a PR to make you aware of the change, since it concerns the API.

Also, maybe it will allow you to avoid those easy mistakes I made.

Here are the actual changes:

    The following shortcomings have been corrected:
    
    - No longer use the same path for several POST requests (`/instances`).
      REST API do not support "method overloading", making one of the two
      methods being shadowed by the other and causing HTTP errors as the
      parameters would not correspond.
      Note: using the `processId` field to disambiguate make it easier to
      solve the second point.
    
    - Pass `currentUser` as a query parameter. This allows the
      `potentialUsers` object to be the sole body of the POST request.
      Otherwise the content could not be converted properly (need to have
      only one java object as body).