### PR TITLE
Add Titolo Unico process in the transformer

### DIFF
--- a/lp-collaborative-workspace/lp-cw-bridge/lp-cw-bridge-transformer/resources/model/TitoloUnico.xmi
+++ b/lp-collaborative-workspace/lp-cw-bridge/lp-cw-bridge-transformer/resources/model/TitoloUnico.xmi
@@ -1,0 +1,14156 @@
+<?xml version="1.0" encoding="ASCII"?>
+<ado:ADOXMLType
+    xmi:version="2.0"
+    xmlns:xmi="http://www.omg.org/XMI"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:ado="http://www.ado.org"
+    xsi:schemaLocation="http://www.ado.org /Adoxx2XWiki/models/ado.ecore">
+<mODELS>
+<mODEL id="mod.16855" name="Org Model Sarnano Municipality" version="1" modeltype="Organizational structure" libtype="we" applib="LearnPAd Prototype Static Library 0.21">
+<mODELATTRIBUTES>
+<aTTRIBUTE name="Contact person" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Keywords" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Copyright info" type="STRING">Edit the model attributes to display your copyright info</aTTRIBUTE>
+<aTTRIBUTE name="Copyright info position" type="ENUMERATION">Bottom right</aTTRIBUTE>
+<aTTRIBUTE name="Model type" type="ENUMERATION">Current model</aTTRIBUTE>
+<aTTRIBUTE name="State" type="ENUMERATION">In process</aTTRIBUTE>
+<aTTRIBUTE name="Reviewed on" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Reviewed by" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Author" type="STRING">test</aTTRIBUTE>
+<aTTRIBUTE name="Creation date" type="STRING">16.02.2015, 09:38</aTTRIBUTE>
+<aTTRIBUTE name="Last user" type="STRING">congyu</aTTRIBUTE>
+<aTTRIBUTE name="Date last changed" type="STRING">03.09.2015, 15:24:47</aTTRIBUTE>
+<aTTRIBUTE name="Number of objects and relations" type="INTEGER">43</aTTRIBUTE>
+<aTTRIBUTE name="Context of version" type="STRING"></aTTRIBUTE>
+<rECORD name="Change history"></rECORD>
+<aTTRIBUTE name="Position" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-01] Internal error!  \&quot;fontcolor\&quot; (WEModel)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<rECORD name="Technical Attributes"></rECORD>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Keine Modellbezeichnung vergeben</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Pool Term" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="ParticipantType" type="ENUMERATION">Role</aTTRIBUTE>
+<aTTRIBUTE name="Role" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Entity" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="BoundaryVisible" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="BPD Model Attributes" type="STRING">NOTEBOOK
+
+CHAPTER &quot;Business Process Diagram Attributes&quot;
+ATTR &quot;Name&quot; write-protected
+ATTR &quot;Contact person&quot;
+ATTR &quot;Author&quot; write-protected
+ATTR &quot;Language (BPMN)&quot;
+ATTR &quot;ExpressionLanguage&quot;
+ATTR &quot;QueryLanguage&quot;
+ATTR &quot;Creation date&quot; write-protected
+ATTR &quot;Date last changed&quot; write-protected
+ATTR &quot;Documentation (Model)&quot;
+ATTR &quot;State&quot;
+
+GROUP &quot;Copyright&quot;
+ATTR &quot;Copyright info&quot; 
+ATTR &quot;Copyright info position&quot; 
+ENDGROUP
+
+CHAPTER &quot;Process Attributes&quot;
+ATTR &quot;Name&quot; write-protected
+ATTR &quot;Process Term&quot;
+ATTR &quot;ProcessType&quot;
+ATTR &quot;Status&quot;
+ATTR &quot;Assignments&quot; lines:5
+ATTR &quot;Properties (BPMN)&quot; lines:5
+ATTR &quot;AdHoc&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+GROUP &quot;AdHoc = True&quot;
+ATTR &quot;AdHocOrdering&quot;
+ATTR &quot;AdHocCompletionCondition&quot;
+ENDGROUP
+ATTR &quot;SuppressJoinFailure&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ATTR &quot;EnableInstanceCompensation&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ATTR &quot;Categories (Process)&quot;
+ATTR &quot;Documentation (Process)&quot;
+
+CHAPTER &quot;Pool Attributes&quot;
+GROUP &quot;Common Graphical Object Attributes&quot;
+ATTR &quot;Name&quot; write-protected
+ATTR &quot;Categories (Pool)&quot;
+ATTR &quot;Documentation (Pool)&quot;
+ENDGROUP
+GROUP &quot;Common Swimlane Attributes&quot;
+ATTR &quot;Pool Term&quot;
+ENDGROUP
+GROUP &quot;Pool Attributes&quot;
+ATTR &quot;ParticipantType&quot;
+ATTR &quot;Role&quot;
+ATTR &quot;Entity&quot;
+ATTR &quot;BoundaryVisible&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot; write-protected
+ENDGROUP</aTTRIBUTE>
+<aTTRIBUTE name="Language" type="ENUMERATION">System</aTTRIBUTE>
+<aTTRIBUTE name="ExpressionLanguage" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="QueryLanguage" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Process Term" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="BPD Term" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="ProcessType" type="ENUMERATION">None</aTTRIBUTE>
+<aTTRIBUTE name="Status" type="ENUMERATION">None</aTTRIBUTE>
+<rECORD name="Assignments"></rECORD>
+<aTTRIBUTE name="AdHoc" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="AdHocOrdering" type="ENUMERATION">None</aTTRIBUTE>
+<aTTRIBUTE name="AdHocCompletionCondition" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="EnableInstanceCompensation" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Categories (Process)" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation (Process)" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation (Pool)" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Categories (Pool)" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="SuppressJoinFailure" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="RACI/DEMI visualisation" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Modelling direction" type="ENUMERATION">vertical</aTTRIBUTE>
+<aTTRIBUTE name="IT systems" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Responsible role" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Input/Output" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Products" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Use cases" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Products color" type="STRING">whitesmoke</aTTRIBUTE>
+<aTTRIBUTE name="RACI/DEMI color" type="STRING">whitesmoke</aTTRIBUTE>
+<aTTRIBUTE name="Responsible role color" type="STRING">whitesmoke</aTTRIBUTE>
+<aTTRIBUTE name="Input/Output color" type="STRING">whitesmoke</aTTRIBUTE>
+<aTTRIBUTE name="Use cases color" type="STRING">whitesmoke</aTTRIBUTE>
+<aTTRIBUTE name="IT systems color" type="STRING">whitesmoke</aTTRIBUTE>
+<aTTRIBUTE name="_ToggleModelInfo_" type="PROGRAMCALL">ITEM &quot;_ToggleModelInfo_&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Display modelling information" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Documentation (Model)" type="STRING"></aTTRIBUTE>
+<rECORD name="Properties (BPMN)"></rECORD>
+<aTTRIBUTE name="CreationDate" type="EXPRESSION">EXPR val:&quot;16.02.2015, 09:38&quot;</aTTRIBUTE>
+<aTTRIBUTE name="ModificationDate" type="EXPRESSION">EXPR val:&quot;03.09.2015, 08:32:17&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Language (BPMN)" type="STRING">English</aTTRIBUTE>
+<aTTRIBUTE name="BPMN20 Model Attributes" type="LONGSTRING">NOTEBOOK
+# TODO AVAL sMfbRegistration:&quot;_MFB-Registration_&quot;
+CHAPTER &quot;Description&quot;
+ATTR &quot;Contact person&quot;
+ATTR &quot;Keywords&quot; lines:2
+ATTR &quot;Description&quot; lines:3
+ATTR &quot;Comment&quot; lines:3
+
+GROUP &quot;Copyright&quot;
+ATTR &quot;Copyright info&quot; 
+ATTR &quot;Copyright info position&quot; 
+ENDGROUP
+ATTR &quot;Name&quot; write-protected
+ATTR &quot;Id&quot; write-protected
+
+
+
+#---------------------------------------------
+CHAPTER &quot;Process properties&quot;
+#---------------------------------------------
+GROUP &quot;Process attributes&quot;
+ATTR &quot;Process type&quot; #None, Private, Public 
+ATTR &quot;Executable&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ATTR &quot;Closed&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ENDGROUP
+
+GROUP &quot;Process relevance&quot;
+ATTR &quot;Auditing&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ATTR &quot;Monitoring&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ENDGROUP
+
+CHAPTER &quot;User attributes&quot;
+ATTR &quot;Model type&quot;
+ATTR &quot;State&quot;
+ATTR &quot;Reviewed on&quot;
+ATTR &quot;Reviewed by&quot;
+
+CHAPTER &quot;System attributes&quot;
+ATTR &quot;Author&quot; write-protected
+ATTR &quot;Creation date&quot; write-protected
+ATTR &quot;Last user&quot; write-protected
+# ATTR &quot;Date last changed from&quot; write-protected
+ATTR &quot;Date last changed&quot; write-protected
+ATTR &quot;Number of objects and relations&quot; write-protected
+ATTR &quot;Context of version&quot; write-protected
+
+CHAPTER &quot;People-like view&quot;
+ATTR &quot;Action&quot;
+ATTR &quot;People-like view&quot;
+
+CHAPTER &quot;BAR Display&quot;
+ATTR &quot;BAR Display active&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot;
+AVAL s_Aktiv: &quot;BAR Display active&quot;
+ATTR &quot;Modelling direction&quot; ctrltype: radio enabled: (s_Aktiv = &quot;Yes&quot;)
+ATTR &quot;Modelling_size&quot;
+GROUP &quot;Actor&quot;
+ATTR &quot;Actor_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_Actor_display: &quot;Actor_display&quot;
+ATTR &quot;Actor_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_Actor_display = &quot;Yes&quot;))
+ATTR &quot;Actor_size&quot;
+ENDGROUP
+GROUP &quot;Description&quot;
+ATTR &quot;Description_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_Description_display: &quot;Description_display&quot;
+ATTR &quot;Description_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_Description_display = &quot;Yes&quot;))
+ATTR &quot;Description_size&quot;
+ENDGROUP
+
+CHAPTER &quot;Change history&quot;
+ATTR &quot;Change history&quot; lines:30
+
+</aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;97740&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Auditing" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Monitoring" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Process type" type="ENUMERATION">None</aTTRIBUTE>
+<aTTRIBUTE name="Executable" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Closed" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="_GoToAceHp_" type="PROGRAMCALL">ITEM &quot;_GoToAceHp_&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="__GfxThumb__" type="LONGSTRING">iVBORw0KGgoAAAANSUhEUgAAAQAAAADWCAIAAACxAMu3AAAACXBIWXMAAAsTAAALEwEAmpwYAAAeH0lEQVR4nO2df4zj5nnnv3IW+SNAGiBx616QteN4RGdprbe39iY7HLvJNWhijdIBGxjc4HoHXd0J99K79Si2dcG2hBMEzAXFdAJOAxsZxXWsBjlgWNfRytE76SXu2rWX48Dxxj+4tM1Xu469u2299vqCAoHXM0Py/qCk1cxoNJRESiPx/fyxS3HI53neV++X7/vyFfkkPM+7cOHC008/Dcbwc+nSJUmSBh3FMJE4e/bsyZMn9+/fv2vXrp///Ofr/pZIAPjEJz6xtrYG4CNXXdWp9XNvvOFvdHFu1EQd2z89+SR3PQfAfsX+g1tvjcKFT6MgAE6ePMk00BnHjh07ffrM6dNnHnvssddacfz48dOnT3srK97KimfNkelxuWxp4+OaZWnj09rctDw9rVkrdG5as1bI9LgwPq5ZK7XjV1bq51rauO9wWp6GMGd5K5Y2PUfL08J47US5bNG5ac2ySLmsjQPTZTIN35c8PQ5ALltkelwu+75qp8tli5TLpFz2LZCyRefGhbmyNj6uWStkGnK5LE9Py+PjWtkiZYtMXw5vXWzjc2RuWrPKpGzRclmbnm4UsB6eb7NMyhYpW97KCp3zqwLAuDAOAMLctDw9R8o1+8vLy8vLy759Yc4i05DLl6uiVgnjEObK/p56wCvN+4U5y7PKZBp+RXnWXOPgy5V8xv8OTx87dmxxcdFjBGYXgEuX3gHw3HPP+Vf6Dbz//e9/551L/nYVSXvP7SKqOHoU1SqOTtnfmiosQ9gzhYcfsJJ34dSysYxUFRirnf7OJf/cMe4GYHlcLk+JmBIBANyel7LlU1he1pempFPL5p5q5eEHrORdnH/mqXIJMPdUxaNHQcsClk1a5ffcLuInlYcf0DGl7HkpW4YyBftbU/rtZckPDKg8vGzcQJWjR1H9iX0K5h6awh7+9imOfhvp+9N3HW0U7dI77/gb3FHLuw3zn7pbx13KS3+WxQ2pUw+gepd4dMr+1pRfLnMPeCzrS2MKvo30/UCVJv9WpN8uARi/Xbph2Vgex8MPFJaBqSNpAMD73ve+poqs2qdg7qlibKlpX5W7AankGABheo6rHfOTpiP8yhuzT8EAlCpw2xHuhrvl28tc098bBWF0SuLYsWO7d+8GsGvXrhdeeGHzEQcOHPjNb37zH1Oppn3V+U/9Gf72iZmxzYdv5Jemuf5cLP35p+y7Ap3bA5sjrM7/+VLm/iPNbk+a5v71sQWyvMnOloe+9hqAsWuu6dBFx/zSNP2Ns2fPsiFQRySOHTt2VX0QfM0111y4cOGKK654z3vec8UVVwD4wAc+8Nrrr3uel/DwyZv2d2r95ydP+huf3N/xuVETdWz/8uabZ8+eBbB79+4P//ZvR+HC5+l6QQBceOMNJoCOSHieVy6XBx0GIzSYADpiF4CpqSld1wcdCYMxABKe5w06BgZjYOwadAAMxiBhAmDEGiYARqxhAmDEGiYARqxhAmDEGiYARqxhAmDEGiYARqxhAmDEGiYARqxhAmDEGiYARqxhAmDEGiYARqxhAmDEGiaAMDHrD6d3Tarjh/QZPcEEEDJ79+7t7sTz58+//fbb4QbD2BYmgJBZXV31PM913ea3LzV/bPOnQcceR5gAQqbr1u+67qBjjyNMACHTdetnPcBAYAIIma5bPxPAQGACCJmuWz8TwEBgAgiZrls/E8BAYAIIma5bP5sEDwQmgJDpuvWzHmAgMAGETNetnwlgIDABhEzXrZ8JYCAwAYRM162fzQEGAhNAyJw7d27QITA6gL0enRFrWA/AiDVMAGFRnZ9I5qARybIzeWSzVirF5/McpQBQUlUzJRUXZsaq8xPJXIoQTE4WBFkGxBNiKVESqVjK1o8ZdFHiBBNAWIxxKaCgqzAAUVEUDjYobHVSl4jEp1AoWHShlj3WLJUAyBLPg8OSbcLkKc+nUCjolfwMU0AfYXMARqxhPQAj1jABREsikVhcXGyZt7TNnxh9gwkgQhKJRBd/YvQTJoDIOXToEIANV3rP85gGdgJMABHit/LFxcVBB8LYEiaAfsAG+jsWJgBGrGECYMQaJgBGrGECYMQaJgBGrGECYMQaJgBGrGECYMSaDgTAlu4Zo0dQAYS+pH/o0CH2GwHGwOlsCBTikn7Ln4gxGH2GzQEYsYYJgBFrmACCEsU9gEOHDvlDQUbX9PhUHRNAB7DbADuN3i8fTACdMaS3Afr5/HE/fTEBMBg9wQTAiDVMAIxYwwTAiDVMAIxYwwTAiDVMAIxYwwQQFM/zdF3fyQaZry4I+nr00Fc3dtqrYU3T7N1IKpWKzn6kxtvbH2FfgXqAHz5/sfjsG79xnN6jichgKOzdu7eX01988cXo7EdqPIj9UfXVTgB/b/274zqO4zqO89iTBoCV1f2O4ziOe+TT13URTegGGYwe2VIAfmNdeuwJ/+OtnzzguI7xzEn/49zKyt2f3dORp9ANhs7KykrLbL4t92ze+etf/zqI/Tapgtu4Dmg8uuBH1VdrATQa62duFfwrtOM6juPcvG+v4ziO47zw0iv/e3X1LzI3BixG6AajoJeK9gJMpTafFbD1BzQeafCj6qu1AC431te+q37ha2caf8h876/vnFhz3evHPvZK9QwQtL2GbjAKeqnoIHneu279Qb7IqIMfVV+tBXD5Ur3mYeqh++75fcdxHefM8Tu/+vi58fGrHMdxrr16d3a+VJwRgxQjdINR0EtFe4Ev0i2NbOt64MGPqq8t5wC1gYrneZ7rT1sdx3Xhef6m4zod3sMJ3WDo9FLRQep6KyPbfsdBrmRRBz+qvtoIwHVcx3FdPHrHnY/W99523zd+p9ZYHbdTAYRsMHR6qeggdd3SSJDWH9x4dMGPqq+tBVC7MHtebZj+xD985dWJL483GqvjdDaYC91g6PRS0UHqevMpAVt/QOORBj+qvloLQDiw33jm5M379jqOC89dc13HEf7o0M/uve9J5UsH/cb6bxfeDD5eD91gFPRS0UHquuvWH8R41MGPqq/WAjgsXL2ysvqL51+88be8xiDd2Xf0i8bN3/+x/ief+3CnjTV0g1HQS0V3OkzvqPUH+SKjDn5UfW05BDry6evmVlZeeAmf+hxeqZ659urdjuO8N/OjzwDdNdbQDYZOLxXt9TZK2fYO6cCDH1Vf7X4Kcfdn9+CzewB8/UfPvvr6WQA9NtPQDYZLLxUdpK4D2ux9EhxF8KPqK9CP4b7+xzcBN3UUd58NhsL58+eH137UwY+qr80/h67OTyRzKUL5UiWzwM0mVJ5IegmSmdMlLZWzRMqrWR2QiidmxoI78s1qRORQUicLkElRLCVLope3D89a4PMLnVhjMMJhix7ALM2aBXB5TiQKAEW01QJSEkyYPBUVCZM5vVKd6bTNmpYtcuBTAgqmTXkTJr9U0QsFAwKf79ha+DRUmkmDztuqxRV5NZmDRk9kKhPJnAEIgoCUpOQz9mww3VaXlpDGbEI1BaRSMPlikaNI2rOVTB7ZZA4akSw7k0c2a6VSfL62AYDP55GdhQRk8shmsc0VZ50jScln7GwWxSJmK5mFmTG/aLJQKEAQpGKRoxQoTU6Cegud1/t2hapdQHk9qaeIIgK2OplLEW8h3bGrLVxPqAXDkIkGO1DlbM3mMVYzRBY02v6QUYJqAiBomgwIskYo0WSN1MpPZACyRimlhBCiCQAgk+2NEhkQNEIprZmvnS5olMjwJeXvJEQjhBJCCJEFQCa0fqR/4jbfRJOjeoSy5jvyPM+jlHpEru2pmxW07mpq60IRTQAEWRYgEyoDGqX1YAJUVgeuiaZpwStnK4I+EcZgjCatVFEXtSZrlGqCIMuyRikhmgzIxCMyZEI1oafOAcDi4mL35/eL/sQ5LLUxerQeArXsmjUBgNzcKffSp+3Mr3xzVM17oos5JMvU/1aoJmvUo5qsUUpkQRCaL2T+9YsIQM+DW6o1WojsNw5KZEEmtTDqjoTehj6UEOoRTRAEQRD8+AFBJpQQSmRBoxogE61RNL/gQa23ngSnFzxvYd0OAOm0N+N/8DdmZnrsfHZUlqQRSgFoV/SCDhF6QYco8SkUCnpFVBSFgw1atU2YvG0A6OI2xno4hZ5IY2mJ2nxKgGHalOclEdQGANt3lJKV3ma+YyglEqasKQrUSb2yJJkAUiIoANs0LKoIgmX7ha3fVrG4BQQsWU/i7I3FxcUd0gk0amNDSM37m7cjCmCH1Eas6CxLZLhX6x1y7QfgeV6jB9gqKv+YIU1pMar5AXpnYC/G2lHV1KZlb94fUcxDKq2IqS4tIZ0eWzqcKIlERBJA0s4mc5CJwquTOciaInKAraooFpFN6hJRuGTSDro00IEAdtSQPQq2KlrfijzCdds1tposwV8zTYpW1s4XbdWArIkAFOqlMT+RVCUiwdArVAIMywaHim4YKYog84Dgo6XQh+w7ZMiLTUP/DX/a6mPoMURh2Vs/k4nIxUB8hUIHPUDo16edcMFrDH52QjCMTul9ID2wSfCOmgPskDAiwuvj9L2fvkIh1m+HHq6vqnf6qfNhuaYEFYA3zC8Hb8m2g5+4yWPo8O9c93hvJu5zgG1j2AlBMqIjpnOA7q7uXn29jKliJxDKfCOOcwB252fE6MddoJGZA7DWz2gmpnMA1voZPvGaAwQfMrJbQDEhRnOALgY/rKMYeWI3B2BtmtFMXOYAbEjDaEks5gDszg9jK2I0B2Ctn7GZ0Z8DdDH4YeOl+DDic4BeBj+sx4gDozwH2PY5dwZjkM8E9+EhYzaSYbRnRCbBP3z+op916U8P/IfGTn+aEVxgP/jlm/U8fn1do/jh8xeLz76B6uMR2f/BL9/8/jP/ijP/HJH9ofa1TgDt347mX023OsZr9ZLd0A1u4O+tf/cT7DmO89iTBoCV1f1+1uEjn74OwbqXRfPXfs5ix3GOn3gawMrqqnPVzfP/RGf+ILnt6V2zKfj3/j/j9ebge2RTud578alf+e5CL9fw+lr3duhEInH++ILnrHnOqueuuf6Gs+Y5a5676jn+ntq2f5jrrHnu2r5caSsBhGuwGb8BLT32hP/x1k8ecFzHeOak//HGPdff/dk925bfr81/fPxJ/+PEJ25yHOfpZ5/zP6Y+zuU/x28oUShTl1CCb0On5Yqtr40C6DqyLnqALgw2aDSgz9wq1BLNN2WcdxznhZdeuX7sY3+RubGNkUZt/qeJg42LSj1vses4jvmyzV137V9+fl9ziXoXQCjBh1uurhl2XxvnAGd/+je7//DONo0vkUic++l3PvKHRwCceeRed/XdsUN/1eb40A36XG5Ar31X/cLXzjT+UMvC7V4/9rFXqmeAdm2oVpvXvPDNA39cvWzhgbncLX5D5K671j79KhDClxd68O3s97Fcw+5rowDc1Xe3Pcdde/dX5W+6a++6q++6a9scH7pBn8uXzzUPUw/dd8/vO47rOGeO3/nVx8+Nj1/lOI5z7dW7s/OlrRJR/p/nL9auJa8974rF+++uWXj8yP96/PVx4XdrF5WP7v5IGyPd0XvwbehnuUbA12YBXNr2nKvT9wSPO3SDDWrdn+d5nlsfPLguGnm4Xcdx2p3uujUjLuC6l3tSeJ7X1L267Yx0TY/Bt7Pcx3KNgK9uBHDmkXs/9oVv+NvW9+7gv/Rgm4NDN9igNnR2XTx6x52P1vfedt83fqcxLmwrAMcB4Liu47pe+U+PlBsW7levulybjtNZZvOA9Bh8W8v9K9cI+OpqCNR0TDhDoE4MNqjPGD2vNnR+4h++8urEl8cbDah9Xfy3m3/3+AnULfjjyMcfzp255X80T0y7vxJHGnwb+lmuEfDVTQ8wduivGtupL/+w/cGhG/QRDuw3njl58769juPCc9dc13GEPzr0s3vve1L50kG/Lv7twpvtx4IHb/q9p599bv8HXcBvj8LUF3+mfOef7z083qjNN958K/R09qEEv0PKNey+Ou4BNtyf2fZGZ+gGfQ4LV6+srP7i+Rdv/C2vMXB29h39onHz93+s/8nnPhykAX35lo+urKyePP6o5+6uDSh/7+h/PnHTg48+/F9u+3DL2gzl1UChBB9uuWLra+M6wKnv/tcb/vsPgqzCNk7B1vfsQze4gbn/+9ILL73ib1979W7HcV4//y/+x+AVMfuPlvmy7W9/dPdHHNc5e/5f2xgJay0slODb0Gm54umr9UJYiAII1+BWfP1Hz776+ln0Vt1fe+QXvzp7blsjof+ONZTg2xCwXPH0xRJld8yOerE7o1daZc2ghPj57WuJZv3k2H5yVk0IkiW7lkFWE2RZrqWPFYRG8traAQA0SjVB1upJXus5boncOgWxn4BWI4R6hGhaPSWtoNG6QQiCIMgaofVcuS3TGddyHtf9CuvygdfLK2hEE2p/ai4sukx/EsTp5Ty4mv8NdJCNPGr7o+mr5c+hx5L2RBaKpBcsLg9eErFk15Oz2gBAdcNon2W2lkGWE6EWdJ7y9Wy10As68jMzY1wKMKBXqKKItjppcXlO1OSSn+OWT4HbUrImbCQnTVlTiqI9ayvUS48B4FKAIWvFfAaUUlrPlWugVZ5aTqHUns3qhRSXh2lYFKIi6ZM5kxelenkN2BIMvVJB4HxT7Qng1LBoFSYAQ69QhbODp7rqg/3R9NWFJCPC1/GA2LZPuwxCS4DVgdMdaX8UfLE5QMewOcAo0XIIVJ2fSOZShPKlSibPUQokUcqqJqRiEdmspShiaXISxFvYPLgYGJ20S7+AGhEzadB5W7W4Iq8mc9DoiRnMH65kRCurmkhJSj5jz85a4PMLAXLOtva1tIQ0ZhOqKSCVgskXixxF0p6tZPLIJnPQiGTZmTyyWSuV4vO1DQB8Po/sLCQgk8f2eW/XOZKUfMbOZlEsYraSWZgZ84ssC4UCBEEqFjlKgdLkJKi30HnJtitUrfHwelJPEUUEbHUylwqlwdRcT6gFw5CJBjtQ5WzJ1o9EmqVZs2BClPRJXSKSaRgGUhSionCAzcuy1XUZdgat5xLVeb2gI18sFlGfSxQMyOJCt3OAMZQSCVMjxXwSlWyyYFaowqGiF3TklRRQ0FUYgKgoCgcbFFAUDiV1sgAxLyqirU7q4LHdpGu9Iz9yw0hVKmZt0jVTpJkxOgueN3N6hUr6pC5pgtBdsdoUSpRQazzgaAo5PpkEpd3VXVvXxK7Ytp4LVjlbMjpDIH8BoQ+DEzYEGiVG5KF47ICse4yhJJy59IiCVjd8Wu6MwlHn1JY96msgtTvlgiA33Tv3iAyZEAHo+UZKbbWHEEJkAagt+NQWZ2RSdyS0XNMJ7oUQ6hFNEARBuHy/XyaUEEpkQaMaIBOtUbTGWlMgRqcHYCOTOnZ9DaSgQ5TqKzD1OUbVNmHytgF0PW5uUFvtWaI2nxJgmDbleam+WGT7jlKt1mE6wR/0y5qiQJ3UK0tSfUkKgG0aFlUEwbL9wpow+aWKXrC4wHO2nsS5k0A0F+bNZvvmiNEHRqcH8CKYA3j1Hz9HTRTBMwIxYAEOA33oAaKmnzGH6osSQj2vNm8hhBJC/Z9/yYT4//tzkPqvtvw5yabfb23N6PQA0c0B+vYWazaB2YytJkugvAmTT4pW1s4XbdWArIkAFOqlMT+RVCUiwdArVAIMywaHSvAfA4Wk1MGDyC5yGyxH4Si64L2mdZ4+dAL99BUKo9MDeMM8jI40+H7WjOd5Q5ZeZLD6Gxai7gGipp8xD5ev0ekBIh1Gs59XBMcbqq54dAQQKcPeQPvcKPuW/BM9p1kZHQEM14VnA30Ivm/q7dvFIpxKC2EgFg+GehrQz4CHq3JGpweI+sITdT6/oR5iNeP1sSvuvd5GRwBRM9RttJ+NEkOVlnN0BBD1d+yF8VLENsbZHKALeq+30REAov+OI22mbIjVHT0WanQE0J/vOCL7o9RA2RxgZBneZsrmAFsxOgLow3fsRfZ4AJsDdAebA6xjaBZfWsHmAN3B5gA1+vYd+2vv4TJKDXS45gCjsxLsFyfSNcjmegvXUR+CH6LV2YCE8l2MTg/QB7x+PSIcBSM5B+idIRNA+/bnP4ex1TFeh+/A28pO42mPNsG09NXP4De7btkoe9Rzj1EFIUiltTls2wiH7NWIiUTi/PEFz1nznFXPXXP9DWfNc9Y8d9Vz/D21bf8w11nz3LV9uVIXAgjXVz+D3+x6KwGcP77guWv1MGobbiOG9X9yndXGnn1fObZVVLquh9UDRBThZftDJ4Cuzw2rB+jaVz+D30zLRjnsPcC2bB9h17OHgQDg7E//pn3YAM799Dt+6c48cm918avdFTN0X/0MPjhBmkGnxYziDkGIETYzZHMABEw9v/bur8rfdNfedVffDZ56vg+++hl8M5uHQI0r6+LiYpAbu5uj6tvruAPSXb0NowC2Tz1/dfqenemrn8Fvppcm2z6qZsvegB7N67LeQuii+giA0w//ZfuwAZx55N5GAa3v3dFdMUP31c/gN+MPSxYXF/2Nhgv/Rkr7c1tG1Ti9YT+69zJ1F2EQ48PYAwQYRTQdE/kQqBNf/Qx+A/5Vv3Ht9zq8Tm+OaoOFgQ+Euqy33gXaTwC88nf/s33YYRUzdF/9DD44QVwMtuVEGuEI9gAbqqOX+2ih++pn8CGyM6NqpusIh1EA288jd6yvfgbPCMKwLoQFD9s/pYtihu6rn8EHpwsXfYiqR3fBTxkyATAYIdPFpGRn0JyJjWoC/KQJ9WxtPVkmRJMFWZP9TGyk9pHU8rPJhBKikVoyNiIATcnnaD2FW4twGznkiCzIpHa8JmuUyP7HRhHqae3QSDjXS3mCFFkTAFlbn0iPEhmQ/XwTtTR7PefV6zgsv7ZlQfPT5MnEI7LQSAG4vg3Isuwn0qOE+LFv72L45gDrMEslwOQpD0CWRKCera2KdPfp32zVggQLkghqq5O6RCQJUJMJAxBkEdRWc5aS4fWCxYkpWRNF1JPPUZ6XBQEiquuzM1QpVxTt2ZKfQ46XRCz5x4u8lS1BEau2ebkIflq7/t9W5NYl0qM8Lwu5SZUnkl6wONEMnHQiJGqVZnP5fJFWsoZhyAqWbNOwaBV6QUf+RJFmxlCZgMlTURGhFgoGUhQcbBNAgGbAhkCMWDPkPQCD0RvDKIDq0lKlpFq8InKArao5w5AJFVEBZpL2RBZFhaNAMmnPVjILvWXCjQnV+YlkDrIME0pRLGXt/IlM5XBWN6WiYmVtUbLsTB7ZrJWCyRdPjFCdDqMA6mN0dVKXiKJIwqRh2pTX/XG5YRhJm1KO0ope0JHvMRd0PBjjUkDBBFFE0MYg2zCQoklesv001IqicCjBHnSwoTL8c4Dq/DydmektGTkjtgy/ABiMHhjKIRCDERZMAIxYwwTAiDVMAIxYwwTAiDVMAIxYwwTAiDVMAIxYwwTAiDVMAIxYwwTAiDVMAIxYwwTAiDVMAIxYwwTAiDVMAIx2VOcnkrkUIbxqcwpn26quI5VKFUyenuBmD2NBtCdsK2WJCws4fBgLC5ifsLkTXClREr2FNJYOH4ZYmJwUZAFQFEyWRE/EvDqZU4hcwkLenpjlirw6yykoYWEhDSzNJ1SLSuYsd0K0LxvLJ6uU0nQ6Xa1WKaVplBIlkYiArdrciRkcPlwCxAX/lEyySiktqZN8SrPEjFhKqjyR9JKliKKtlqDw+qQu0RMzY0wAjDZUK7oBWbLVHCQCcJyiKAAgiqDzasGURBGSxVsiqv7HeT0HicyrBaRE1HbysqyJPGwOtgqTX+L1nCFrtpozJbGiG1DAKaKtTppSHmnMqzmktIpegFIFJGBeLQB8FZi1sZAGQGdt5G21AKOg8kSBkklX5ycKBQMCL4qQgCrorA0RkC0eIihEogBQRA4AJJ6zdQPwXzsT8auNGIyuIZqsEdrY9jcbG21OaRyz/cu82CORjFjDhkCMYeHt+YkHc7iFSG/Zmes5+qEkLlZKryAvIGtAAjKf52YfKokTvHoCxQmOfghAOv3B6vxDs9wUrz6YM64UhLcMA4L28ZR1pSgeTKeZABjDA6fc4aUxP/GUDkGxyllcmTJfBhVE5XpbPWZxAsy3TB483tIrH1JgIPN54G3KTYm2UQIgfFxKPWUYV0J/uWAA4sE0eysEY0R5e/6wnVk4uO07oZgAGLGGDYEYsYYJgDG80KWlDyVhzNpCnvP/vUiTScz+dUm8Ryw9pJqQilMctQEOsIGD6TSq8z+uZAQ9+SC0O07MfJAJgDG8JFF6KIuPSyhnrdq/xfzFip/cwHzLMIDKRUl/ylI4Xn3KUg6mq09X9Jd1XJmSb/FXxdgcgBFr/j9Mw3VXPWTMrgAAAABJRU5ErkJggg==</aTTRIBUTE>
+<aTTRIBUTE name="NT Model Attributes" type="LONGSTRING">NOTEBOOK
+CHAPTER &quot;Description&quot;
+#ATTR &quot;Shared&quot;
+ATTR &quot;Model state&quot; enabled:(cond(search (sMfbRegistration, &quot;MFB_VERS&quot;, 0) = -1, 1, 0))
+ATTR &quot;Description&quot;
+ATTR &quot;Show State&quot; ctrltype:check unchecked-value:&quot;No&quot; checked-value:&quot;Yes&quot; 
+ATTR &quot;Last user&quot; write-protected
+ATTR &quot;Date last changed&quot; write-protected
+#CHAPTER &quot;Suggestion for improvement&quot;
+#ATTR &quot;Suggestion for improvement&quot;
+</aTTRIBUTE>
+<aTTRIBUTE name="Model state" type="ENUMERATION">Draft</aTTRIBUTE>
+<aTTRIBUTE name="People-like view" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Action" type="ENUMERATION">Fill in</aTTRIBUTE>
+<aTTRIBUTE name="Keywords" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Description" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Model type" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Show State" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="BAR Display active" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Actor_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="Actor_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Actor_size" type="ENUMERATION">5</aTTRIBUTE>
+<aTTRIBUTE name="Description_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="Description_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Description_size" type="ENUMERATION">5</aTTRIBUTE>
+<aTTRIBUTE name="ModelingAreaSize" type="ENUMERATION">15</aTTRIBUTE>
+<aTTRIBUTE name="Modelling_size" type="ENUMERATION">10</aTTRIBUTE>
+<aTTRIBUTE name="DrawingAreaWidth" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="DrawingAreaHeight" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Reference overview settings" type="LONGSTRING">Actor|Actors
+Modelling|Modelling
+Description|Description</aTTRIBUTE>
+<aTTRIBUTE name="Data Object_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="Data Object_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Data Object_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="Knowledge Product_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="Knowledge Product_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Knowledge Product_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="Documents and Resources_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Documents and Resources_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="Documents and Resources_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="Responsible for execution_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="Responsible for execution_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Responsible for execution_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="Accountable for approving results_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="Accountable for approving results_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Accountable for approving results_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="Cooperation/participation_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="Cooperation/participation_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Cooperation/participation_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="To inform_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="To inform_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="To inform_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="Incoming Data Object_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="Incoming Data Object_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Incoming Data Object_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="Outgoing Data Object_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="Outgoing Data Object_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Outgoing Data Object_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="id_bpmndi_diagram" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="id_bpmndi_plane" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="id_bpmndi_collaboration" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="CommentModellingAreaSize" type="ENUMERATION">3</aTTRIBUTE>
+<aTTRIBUTE name="CommentTypeSize" type="ENUMERATION">8</aTTRIBUTE>
+<aTTRIBUTE name="CommentAreaSize" type="ENUMERATION">2</aTTRIBUTE>
+<aTTRIBUTE name="Comment Mode" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="CommentxCoorTextBox" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="CommentyCoorTextBox" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="CommentModellingDirection" type="ENUMERATION">vertical</aTTRIBUTE>
+</mODELATTRIBUTES>
+<iNSTANCE id="obj.16856" class="Organizational unit" name="Comune Sarnano">
+<aTTRIBUTE name="Position" type="STRING">NODE x:13.5cm y:3.5cm w:2.4cm h:1.5cm index:1</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Model reference"></iNTERREF>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Organisationseinheit</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Submodelname" type="EXPRESSION">EXPR val:&quot;Bezeichnung&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Type" type="ENUMERATION">Standard</aTTRIBUTE>
+<aTTRIBUTE name="Functional unit" type="ENUMERATION">no</aTTRIBUTE>
+<aTTRIBUTE name="Manager" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Function" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Level" type="INTEGER">0</aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16859" class="Organizational unit" name="Ufficio Commercio">
+<aTTRIBUTE name="Position" type="STRING">NODE x:14.5cm y:9cm index:2</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Model reference"></iNTERREF>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Organisationseinheit</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Submodelname" type="EXPRESSION">EXPR val:&quot;Bezeichnung&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Type" type="ENUMERATION">Standard</aTTRIBUTE>
+<aTTRIBUTE name="Functional unit" type="ENUMERATION">no</aTTRIBUTE>
+<aTTRIBUTE name="Manager" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Function" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Level" type="INTEGER">0</aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16862" class="Organizational unit" name="Ufficio Tributi Economato">
+<aTTRIBUTE name="Position" type="STRING">NODE x:18cm y:9cm w:2.4cm h:1.5cm index:3</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Model reference"></iNTERREF>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Organisationseinheit</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Submodelname" type="EXPRESSION">EXPR val:&quot;Bezeichnung&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Type" type="ENUMERATION">Standard</aTTRIBUTE>
+<aTTRIBUTE name="Functional unit" type="ENUMERATION">no</aTTRIBUTE>
+<aTTRIBUTE name="Manager" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Function" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Level" type="INTEGER">0</aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16865" class="Organizational unit" name="Ufficio Servizi Finanziari">
+<aTTRIBUTE name="Position" type="STRING">NODE x:22cm y:9cm w:2.4cm h:1.5cm index:4</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Model reference"></iNTERREF>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Organisationseinheit</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Submodelname" type="EXPRESSION">EXPR val:&quot;Bezeichnung&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Type" type="ENUMERATION">Standard</aTTRIBUTE>
+<aTTRIBUTE name="Functional unit" type="ENUMERATION">no</aTTRIBUTE>
+<aTTRIBUTE name="Manager" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Function" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Level" type="INTEGER">0</aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16868" class="Organizational unit" name="Ufficio Urbanistica e Lavori Pubblici">
+<aTTRIBUTE name="Position" type="STRING">NODE x:26cm y:9cm w:2.4cm h:1.5cm index:5</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Model reference"></iNTERREF>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Organisationseinheit</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Submodelname" type="EXPRESSION">EXPR val:&quot;Bezeichnung&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Type" type="ENUMERATION">Standard</aTTRIBUTE>
+<aTTRIBUTE name="Functional unit" type="ENUMERATION">no</aTTRIBUTE>
+<aTTRIBUTE name="Manager" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Function" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Level" type="INTEGER">0</aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16871" class="Performer" name="Venanzio Scuderini">
+<aTTRIBUTE name="Position" type="STRING">NODE x:1.5cm y:14cm index:6</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Hourly wages" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Calendar" type="LONGSTRING">B@Working day@b@32400-43200@T@45000-59400@T@Free day@c@@@$cbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbcbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbcbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbcccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbccbbccb</aTTRIBUTE>
+<aTTRIBUTE name="Availability" type="EXPRESSION">EXPR expr:(round(paval(&quot;Presence&quot;,&quot;Hours per day&quot;)*paval(&quot;Presence&quot;,&quot;Days per week&quot;)/40*100)) val:100</aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Time dependent costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Info on results" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Workload" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Capacity" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Personnel costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Bearbeiter</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<rECORD name="Further education"></rECORD>
+<aTTRIBUTE name="Presence" type="ATTRPROFREF"></aTTRIBUTE>
+<aTTRIBUTE name="E-Mail" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16874" class="Performer" name="Franco Ceregioli">
+<aTTRIBUTE name="Position" type="STRING">NODE x:4.5cm y:14cm index:7</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Hourly wages" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Calendar" type="LONGSTRING">B@Working day@b@32400-43200@T@45000-59400@T@Free day@c@@@$cbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbcbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbcbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbcccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbccbbccb</aTTRIBUTE>
+<aTTRIBUTE name="Availability" type="EXPRESSION">EXPR expr:(round(paval(&quot;Presence&quot;,&quot;Hours per day&quot;)*paval(&quot;Presence&quot;,&quot;Days per week&quot;)/40*100)) val:100</aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Time dependent costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Info on results" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Workload" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Capacity" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Personnel costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Bearbeiter</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<rECORD name="Further education"></rECORD>
+<aTTRIBUTE name="Presence" type="ATTRPROFREF"></aTTRIBUTE>
+<aTTRIBUTE name="E-Mail" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16877" class="Performer" name="Anna Marinozzi">
+<aTTRIBUTE name="Position" type="STRING">NODE x:14.5cm y:19cm index:14</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Hourly wages" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Calendar" type="LONGSTRING">B@Working day@b@32400-43200@T@45000-59400@T@Free day@c@@@$cbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbcbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbcbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbcccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbccbbccb</aTTRIBUTE>
+<aTTRIBUTE name="Availability" type="EXPRESSION">EXPR expr:(round(paval(&quot;Presence&quot;,&quot;Hours per day&quot;)*paval(&quot;Presence&quot;,&quot;Days per week&quot;)/40*100)) val:100</aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Time dependent costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Info on results" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Workload" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Capacity" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Personnel costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Bearbeiter</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<rECORD name="Further education"></rECORD>
+<aTTRIBUTE name="Presence" type="ATTRPROFREF"></aTTRIBUTE>
+<aTTRIBUTE name="E-Mail" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16880" class="Performer" name="Emanuele Crisostomi">
+<aTTRIBUTE name="Position" type="STRING">NODE x:20cm y:19cm index:15</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Hourly wages" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Calendar" type="LONGSTRING">B@Working day@b@32400-43200@T@45000-59400@T@Free day@c@@@$cbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbcbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbcbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbcccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbccbbccb</aTTRIBUTE>
+<aTTRIBUTE name="Availability" type="EXPRESSION">EXPR expr:(round(paval(&quot;Presence&quot;,&quot;Hours per day&quot;)*paval(&quot;Presence&quot;,&quot;Days per week&quot;)/40*100)) val:100</aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Time dependent costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Info on results" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Workload" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Capacity" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Personnel costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Bearbeiter</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<rECORD name="Further education"></rECORD>
+<aTTRIBUTE name="Presence" type="ATTRPROFREF"></aTTRIBUTE>
+<aTTRIBUTE name="E-Mail" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16883" class="Performer" name="Alfonso Tardella">
+<aTTRIBUTE name="Position" type="STRING">NODE x:26cm y:19cm index:16</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Hourly wages" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Calendar" type="LONGSTRING">B@Working day@b@32400-43200@T@45000-59400@T@Free day@c@@@$cbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbcbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbcbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbcccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbccbbccb</aTTRIBUTE>
+<aTTRIBUTE name="Availability" type="EXPRESSION">EXPR expr:(round(paval(&quot;Presence&quot;,&quot;Hours per day&quot;)*paval(&quot;Presence&quot;,&quot;Days per week&quot;)/40*100)) val:100</aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Time dependent costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Info on results" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Workload" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Capacity" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Personnel costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Bearbeiter</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<rECORD name="Further education"></rECORD>
+<aTTRIBUTE name="Presence" type="ATTRPROFREF"></aTTRIBUTE>
+<aTTRIBUTE name="E-Mail" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16886" class="Role" name="Segretario Comunale">
+<aTTRIBUTE name="Position" type="STRING">NODE x:1.5cm y:9cm index:17</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Rolle</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16889" class="Role" name="Sindaco">
+<aTTRIBUTE name="Position" type="STRING">NODE x:4.5cm y:9cm index:18</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Rolle</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16892" class="Role" name="Responsabile Ufficio Commercio">
+<aTTRIBUTE name="Position" type="STRING">NODE x:14.5cm y:14cm index:19</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Rolle</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16895" class="Role" name="Responsabile Ufficio Tributi Economato">
+<aTTRIBUTE name="Position" type="STRING">NODE x:18cm y:14cm index:20</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Rolle</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16898" class="Role" name="Responsabile Ufficio Servizi Finanziari">
+<aTTRIBUTE name="Position" type="STRING">NODE x:22cm y:14cm index:21</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Rolle</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16901" class="Role" name="Responsabile Ufficio Urbanistica e Lavori Pubblici">
+<aTTRIBUTE name="Position" type="STRING">NODE x:26cm y:14cm index:22</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Rolle</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16904" class="Organizational unit" name="SUAP Office">
+<aTTRIBUTE name="Position" type="STRING">NODE x:11cm y:9cm index:33</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Model reference"></iNTERREF>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Organisationseinheit</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Submodelname" type="EXPRESSION">EXPR val:&quot;Bezeichnung&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Type" type="ENUMERATION">Standard</aTTRIBUTE>
+<aTTRIBUTE name="Functional unit" type="ENUMERATION">no</aTTRIBUTE>
+<aTTRIBUTE name="Manager" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Function" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Level" type="INTEGER">0</aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16907" class="Role" name="SUAP Officer">
+<aTTRIBUTE name="Position" type="STRING">NODE x:7.5cm y:14cm index:34</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Rolle</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16910" class="Performer" name="Sabrina Kurjakovic ">
+<aTTRIBUTE name="Position" type="STRING">NODE x:7.5cm y:19cm index:35</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Hourly wages" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Calendar" type="LONGSTRING">B@Working day@b@32400-43200@T@45000-59400@T@Free day@c@@@$cbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbcbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbcbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbcccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbccbbccb</aTTRIBUTE>
+<aTTRIBUTE name="Availability" type="EXPRESSION">EXPR expr:(round(paval(&quot;Presence&quot;,&quot;Hours per day&quot;)*paval(&quot;Presence&quot;,&quot;Days per week&quot;)/40*100)) val:100</aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Time dependent costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Info on results" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Workload" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Capacity" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Personnel costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Bearbeiter</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<rECORD name="Further education"></rECORD>
+<aTTRIBUTE name="Presence" type="ATTRPROFREF"></aTTRIBUTE>
+<aTTRIBUTE name="E-Mail" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16913" class="Role" name="Responsible SUAP office">
+<aTTRIBUTE name="Position" type="STRING">NODE x:10cm y:14cm index:38</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Rolle</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16916" class="Performer" name="Knut Hinkelmann">
+<aTTRIBUTE name="Position" type="STRING">NODE x:11.5cm y:19cm index:40</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Hourly wages" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Calendar" type="LONGSTRING">B@Working day@b@32400-43200@T@45000-59400@T@Free day@c@@@$cbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbcbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbcbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbcccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbccbbccb</aTTRIBUTE>
+<aTTRIBUTE name="Availability" type="EXPRESSION">EXPR expr:(round(paval(&quot;Presence&quot;,&quot;Hours per day&quot;)*paval(&quot;Presence&quot;,&quot;Days per week&quot;)/40*100)) val:100</aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Time dependent costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Info on results" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Workload" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Capacity" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Personnel costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Bearbeiter</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<rECORD name="Further education"></rECORD>
+<aTTRIBUTE name="Presence" type="ATTRPROFREF"></aTTRIBUTE>
+<aTTRIBUTE name="E-Mail" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<cONNECTOR id="con.16919" class="Is subordinated">
+<fROM instance="Ufficio Commercio" class="Organizational unit"></fROM>
+<tO instance="Comune Sarnano" class="Organizational unit"></tO>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 1 x1:14cm y1:7cm index:44</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Representation" type="ENUMERATION">with arrow</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16920" class="Is subordinated">
+<fROM instance="Ufficio Tributi Economato" class="Organizational unit"></fROM>
+<tO instance="Comune Sarnano" class="Organizational unit"></tO>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 2 x1:18cm y1:7cm x2:14cm y2:7cm index:45</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Representation" type="ENUMERATION">with arrow</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16921" class="Is subordinated">
+<fROM instance="Ufficio Servizi Finanziari" class="Organizational unit"></fROM>
+<tO instance="Comune Sarnano" class="Organizational unit"></tO>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 2 x1:22cm y1:7cm x2:14cm y2:7cm index:46</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Representation" type="ENUMERATION">with arrow</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16922" class="Is subordinated">
+<fROM instance="Ufficio Urbanistica e Lavori Pubblici" class="Organizational unit"></fROM>
+<tO instance="Comune Sarnano" class="Organizational unit"></tO>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 2 x1:26cm y1:7cm x2:14cm y2:7cm index:47</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Representation" type="ENUMERATION">with arrow</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16923" class="Has role">
+<fROM instance="Venanzio Scuderini" class="Performer"></fROM>
+<tO instance="Segretario Comunale" class="Role"></tO>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 0 index:23</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">6</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16924" class="Has role">
+<fROM instance="Franco Ceregioli" class="Performer"></fROM>
+<tO instance="Sindaco" class="Role"></tO>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 0 index:24</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">8</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16925" class="Has role">
+<fROM instance="Anna Marinozzi" class="Performer"></fROM>
+<tO instance="Responsabile Ufficio Commercio" class="Role"></tO>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 0 index:25</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">9</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16926" class="Has role">
+<fROM instance="Emanuele Crisostomi" class="Performer"></fROM>
+<tO instance="Responsabile Ufficio Tributi Economato" class="Role"></tO>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 1 x1:18cm y1:19cm index:26</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">11</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16927" class="Has role">
+<fROM instance="Emanuele Crisostomi" class="Performer"></fROM>
+<tO instance="Responsabile Ufficio Servizi Finanziari" class="Role"></tO>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 1 x1:22cm y1:19cm index:27</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">12</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16928" class="Has role">
+<fROM instance="Alfonso Tardella" class="Performer"></fROM>
+<tO instance="Responsabile Ufficio Urbanistica e Lavori Pubblici" class="Role"></tO>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 0 index:28</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">15</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16929" class="belongs to">
+<fROM instance="Segretario Comunale" class="Role"></fROM>
+<tO instance="Comune Sarnano" class="Organizational unit"></tO>
+<aTTRIBUTE name="Connector number" type="INTEGER">5</aTTRIBUTE>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 2 x1:1.5cm y1:6.5cm x2:13cm y2:6.5cm index:12</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16930" class="belongs to">
+<fROM instance="Sindaco" class="Role"></fROM>
+<tO instance="Comune Sarnano" class="Organizational unit"></tO>
+<aTTRIBUTE name="Connector number" type="INTEGER">7</aTTRIBUTE>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 2 x1:4.5cm y1:6.5cm x2:13cm y2:6.5cm index:13</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16931" class="belongs to">
+<fROM instance="Responsabile Ufficio Commercio" class="Role"></fROM>
+<tO instance="Ufficio Commercio" class="Organizational unit"></tO>
+<aTTRIBUTE name="Connector number" type="INTEGER">10</aTTRIBUTE>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 0 index:29</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16932" class="belongs to">
+<fROM instance="Responsabile Ufficio Tributi Economato" class="Role"></fROM>
+<tO instance="Ufficio Tributi Economato" class="Organizational unit"></tO>
+<aTTRIBUTE name="Connector number" type="INTEGER">13</aTTRIBUTE>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 0 index:30</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16933" class="belongs to">
+<fROM instance="Responsabile Ufficio Servizi Finanziari" class="Role"></fROM>
+<tO instance="Ufficio Servizi Finanziari" class="Organizational unit"></tO>
+<aTTRIBUTE name="Connector number" type="INTEGER">14</aTTRIBUTE>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 0 index:31</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16934" class="belongs to">
+<fROM instance="Responsabile Ufficio Urbanistica e Lavori Pubblici" class="Role"></fROM>
+<tO instance="Ufficio Urbanistica e Lavori Pubblici" class="Organizational unit"></tO>
+<aTTRIBUTE name="Connector number" type="INTEGER">16</aTTRIBUTE>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 0 index:32</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16935" class="Is subordinated">
+<fROM instance="SUAP Office" class="Organizational unit"></fROM>
+<tO instance="Comune Sarnano" class="Organizational unit"></tO>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 2 x1:11cm y1:7cm x2:14cm y2:7cm index:43</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Representation" type="ENUMERATION">with arrow</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16936" class="belongs to">
+<fROM instance="SUAP Officer" class="Role"></fROM>
+<tO instance="SUAP Office" class="Organizational unit"></tO>
+<aTTRIBUTE name="Connector number" type="INTEGER">2</aTTRIBUTE>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 0 index:37</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16937" class="Has role">
+<fROM instance="Sabrina Kurjakovic " class="Performer"></fROM>
+<tO instance="SUAP Officer" class="Role"></tO>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 0 index:36</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">1</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16938" class="belongs to">
+<fROM instance="Responsible SUAP office" class="Role"></fROM>
+<tO instance="SUAP Office" class="Organizational unit"></tO>
+<aTTRIBUTE name="Connector number" type="INTEGER">16</aTTRIBUTE>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 0 index:39</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16939" class="Has role">
+<fROM instance="Knut Hinkelmann" class="Performer"></fROM>
+<tO instance="Responsible SUAP office" class="Role"></tO>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 0 index:41</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">17</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16940" class="Is manager">
+<fROM instance="Knut Hinkelmann" class="Performer"></fROM>
+<tO instance="SUAP Office" class="Organizational unit"></tO>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 0 index:42</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">19</aTTRIBUTE>
+</cONNECTOR>
+</mODEL>
+<mODEL id="mod.16637" name="Org Model Senigallia Municipality" version="1" modeltype="Organizational structure" libtype="we" applib="LearnPAd Prototype Static Library 0.21">
+<mODELATTRIBUTES>
+<aTTRIBUTE name="Contact person" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Keywords" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Copyright info" type="STRING">Edit the model attributes to display your copyright info</aTTRIBUTE>
+<aTTRIBUTE name="Copyright info position" type="ENUMERATION">Bottom right</aTTRIBUTE>
+<aTTRIBUTE name="Model type" type="ENUMERATION">Current model</aTTRIBUTE>
+<aTTRIBUTE name="State" type="ENUMERATION">In process</aTTRIBUTE>
+<aTTRIBUTE name="Reviewed on" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Reviewed by" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Author" type="STRING">learnpad</aTTRIBUTE>
+<aTTRIBUTE name="Creation date" type="STRING">16.02.2015, 11:15</aTTRIBUTE>
+<aTTRIBUTE name="Last user" type="STRING">congyu</aTTRIBUTE>
+<aTTRIBUTE name="Date last changed" type="STRING">03.09.2015, 08:37:38</aTTRIBUTE>
+<aTTRIBUTE name="Number of objects and relations" type="INTEGER">108</aTTRIBUTE>
+<aTTRIBUTE name="Context of version" type="STRING"></aTTRIBUTE>
+<rECORD name="Change history"></rECORD>
+<aTTRIBUTE name="Position" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-01] Internal error!  \&quot;fontcolor\&quot; (WEModel)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<rECORD name="Technical Attributes"></rECORD>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Keine Modellbezeichnung vergeben</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Pool Term" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="ParticipantType" type="ENUMERATION">Role</aTTRIBUTE>
+<aTTRIBUTE name="Role" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Entity" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="BoundaryVisible" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="BPD Model Attributes" type="STRING">NOTEBOOK
+
+CHAPTER &quot;Business Process Diagram Attributes&quot;
+ATTR &quot;Name&quot; write-protected
+ATTR &quot;Contact person&quot;
+ATTR &quot;Author&quot; write-protected
+ATTR &quot;Language (BPMN)&quot;
+ATTR &quot;ExpressionLanguage&quot;
+ATTR &quot;QueryLanguage&quot;
+ATTR &quot;Creation date&quot; write-protected
+ATTR &quot;Date last changed&quot; write-protected
+ATTR &quot;Documentation (Model)&quot;
+ATTR &quot;State&quot;
+
+GROUP &quot;Copyright&quot;
+ATTR &quot;Copyright info&quot; 
+ATTR &quot;Copyright info position&quot; 
+ENDGROUP
+
+CHAPTER &quot;Process Attributes&quot;
+ATTR &quot;Name&quot; write-protected
+ATTR &quot;Process Term&quot;
+ATTR &quot;ProcessType&quot;
+ATTR &quot;Status&quot;
+ATTR &quot;Assignments&quot; lines:5
+ATTR &quot;Properties (BPMN)&quot; lines:5
+ATTR &quot;AdHoc&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+GROUP &quot;AdHoc = True&quot;
+ATTR &quot;AdHocOrdering&quot;
+ATTR &quot;AdHocCompletionCondition&quot;
+ENDGROUP
+ATTR &quot;SuppressJoinFailure&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ATTR &quot;EnableInstanceCompensation&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ATTR &quot;Categories (Process)&quot;
+ATTR &quot;Documentation (Process)&quot;
+
+CHAPTER &quot;Pool Attributes&quot;
+GROUP &quot;Common Graphical Object Attributes&quot;
+ATTR &quot;Name&quot; write-protected
+ATTR &quot;Categories (Pool)&quot;
+ATTR &quot;Documentation (Pool)&quot;
+ENDGROUP
+GROUP &quot;Common Swimlane Attributes&quot;
+ATTR &quot;Pool Term&quot;
+ENDGROUP
+GROUP &quot;Pool Attributes&quot;
+ATTR &quot;ParticipantType&quot;
+ATTR &quot;Role&quot;
+ATTR &quot;Entity&quot;
+ATTR &quot;BoundaryVisible&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot; write-protected
+ENDGROUP</aTTRIBUTE>
+<aTTRIBUTE name="Language" type="ENUMERATION">System</aTTRIBUTE>
+<aTTRIBUTE name="ExpressionLanguage" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="QueryLanguage" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Process Term" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="BPD Term" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="ProcessType" type="ENUMERATION">None</aTTRIBUTE>
+<aTTRIBUTE name="Status" type="ENUMERATION">None</aTTRIBUTE>
+<rECORD name="Assignments"></rECORD>
+<aTTRIBUTE name="AdHoc" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="AdHocOrdering" type="ENUMERATION">None</aTTRIBUTE>
+<aTTRIBUTE name="AdHocCompletionCondition" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="EnableInstanceCompensation" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Categories (Process)" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation (Process)" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation (Pool)" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Categories (Pool)" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="SuppressJoinFailure" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="RACI/DEMI visualisation" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Modelling direction" type="ENUMERATION">vertical</aTTRIBUTE>
+<aTTRIBUTE name="IT systems" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Responsible role" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Input/Output" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Products" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Use cases" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Products color" type="STRING">whitesmoke</aTTRIBUTE>
+<aTTRIBUTE name="RACI/DEMI color" type="STRING">whitesmoke</aTTRIBUTE>
+<aTTRIBUTE name="Responsible role color" type="STRING">whitesmoke</aTTRIBUTE>
+<aTTRIBUTE name="Input/Output color" type="STRING">whitesmoke</aTTRIBUTE>
+<aTTRIBUTE name="Use cases color" type="STRING">whitesmoke</aTTRIBUTE>
+<aTTRIBUTE name="IT systems color" type="STRING">whitesmoke</aTTRIBUTE>
+<aTTRIBUTE name="_ToggleModelInfo_" type="PROGRAMCALL">ITEM &quot;_ToggleModelInfo_&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Display modelling information" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Documentation (Model)" type="STRING"></aTTRIBUTE>
+<rECORD name="Properties (BPMN)"></rECORD>
+<aTTRIBUTE name="CreationDate" type="EXPRESSION">EXPR val:&quot;16.02.2015, 11:15&quot;</aTTRIBUTE>
+<aTTRIBUTE name="ModificationDate" type="EXPRESSION">EXPR val:&quot;03.09.2015, 08:12:03&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Language (BPMN)" type="STRING">English</aTTRIBUTE>
+<aTTRIBUTE name="BPMN20 Model Attributes" type="LONGSTRING">NOTEBOOK
+# TODO AVAL sMfbRegistration:&quot;_MFB-Registration_&quot;
+CHAPTER &quot;Description&quot;
+ATTR &quot;Contact person&quot;
+ATTR &quot;Keywords&quot; lines:2
+ATTR &quot;Description&quot; lines:3
+ATTR &quot;Comment&quot; lines:3
+
+GROUP &quot;Copyright&quot;
+ATTR &quot;Copyright info&quot; 
+ATTR &quot;Copyright info position&quot; 
+ENDGROUP
+ATTR &quot;Name&quot; write-protected
+ATTR &quot;Id&quot; write-protected
+
+
+
+#---------------------------------------------
+CHAPTER &quot;Process properties&quot;
+#---------------------------------------------
+GROUP &quot;Process attributes&quot;
+ATTR &quot;Process type&quot; #None, Private, Public 
+ATTR &quot;Executable&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ATTR &quot;Closed&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ENDGROUP
+
+GROUP &quot;Process relevance&quot;
+ATTR &quot;Auditing&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ATTR &quot;Monitoring&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ENDGROUP
+
+CHAPTER &quot;User attributes&quot;
+ATTR &quot;Model type&quot;
+ATTR &quot;State&quot;
+ATTR &quot;Reviewed on&quot;
+ATTR &quot;Reviewed by&quot;
+
+CHAPTER &quot;System attributes&quot;
+ATTR &quot;Author&quot; write-protected
+ATTR &quot;Creation date&quot; write-protected
+ATTR &quot;Last user&quot; write-protected
+# ATTR &quot;Date last changed from&quot; write-protected
+ATTR &quot;Date last changed&quot; write-protected
+ATTR &quot;Number of objects and relations&quot; write-protected
+ATTR &quot;Context of version&quot; write-protected
+
+CHAPTER &quot;People-like view&quot;
+ATTR &quot;Action&quot;
+ATTR &quot;People-like view&quot;
+
+CHAPTER &quot;BAR Display&quot;
+ATTR &quot;BAR Display active&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot;
+AVAL s_Aktiv: &quot;BAR Display active&quot;
+ATTR &quot;Modelling direction&quot; ctrltype: radio enabled: (s_Aktiv = &quot;Yes&quot;)
+ATTR &quot;Modelling_size&quot;
+
+GROUP &quot;Responsible for execution&quot;
+ATTR &quot;Responsible for execution_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_Responsible_for_execution_display: &quot;Responsible for execution_display&quot;
+ATTR &quot;Responsible for execution_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_Responsible_for_execution_display = &quot;Yes&quot;))
+ATTR &quot;Responsible for execution_size&quot;
+ENDGROUP
+
+GROUP &quot;Accountable for approving results&quot;
+ATTR &quot;Accountable for approving results_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_Accountableforapprovingresults_display: &quot;Actor_display&quot;
+ATTR &quot;Accountable for approving results_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_Accountableforapprovingresults_display = &quot;Yes&quot;))
+ATTR &quot;Accountable for approving results_size&quot;
+ENDGROUP
+
+GROUP &quot;Cooperation/participation&quot;
+ATTR &quot;Cooperation/participation_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_Cooperationparticipation_display: &quot;Cooperation/participation_display&quot;
+ATTR &quot;Cooperation/participation_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_Cooperationparticipation_display = &quot;Yes&quot;))
+ATTR &quot;Cooperation/participation_size&quot;
+ENDGROUP
+
+GROUP &quot;To inform&quot;
+ATTR &quot;To inform_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_Toinform_display: &quot;To inform_display&quot;
+ATTR &quot;To inform_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_Toinform_display = &quot;Yes&quot;))
+ATTR &quot;To inform_size&quot;
+ENDGROUP
+
+GROUP &quot;Knowledge Product&quot;
+ATTR &quot;Knowledge Product_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_KnowledgeProduct_display: &quot;Knowledge Product_display&quot;
+ATTR &quot;Knowledge Product_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_KnowledgeProduct_display = &quot;Yes&quot;))
+ATTR &quot;Knowledge Product_size&quot;
+ENDGROUP
+
+GROUP &quot;Documents and Resources&quot;
+ATTR &quot;Documents and Resources_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_DocumentsandResources_display: &quot;Documents and Resources_display&quot;
+ATTR &quot;Documents and Resources_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_DocumentsandResources_display = &quot;Yes&quot;))
+ATTR &quot;Documents and Resources_size&quot;
+ENDGROUP
+
+GROUP &quot;Incoming Data Object&quot;
+ATTR &quot;Incoming Data Object_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_IncomingDataObject_display: &quot;Incoming Data Object_display&quot;
+ATTR &quot;Incoming Data Object_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_IncomingDataObject_display = &quot;Yes&quot;))
+ATTR &quot;Incoming Data Object_size&quot;
+ENDGROUP
+
+GROUP &quot;Outgoing Data Object&quot;
+ATTR &quot;Outgoing Data Object_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_OutgoingDataObject_display: &quot;Outgoing Data Object_display&quot;
+ATTR &quot;Outgoing Data Object_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_OutgoingDataObject_display = &quot;Yes&quot;))
+ATTR &quot;Outgoing Data Object_size&quot;
+ENDGROUP
+
+GROUP &quot;Description&quot;
+ATTR &quot;Description_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_Description_display: &quot;Description_display&quot;
+ATTR &quot;Description_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_Description_display = &quot;Yes&quot;))
+ATTR &quot;Description_size&quot;
+ENDGROUP
+
+CHAPTER &quot;Change history&quot;
+ATTR &quot;Change history&quot; lines:30
+
+</aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;97522&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Auditing" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Monitoring" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Process type" type="ENUMERATION">None</aTTRIBUTE>
+<aTTRIBUTE name="Executable" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Closed" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="_GoToAceHp_" type="PROGRAMCALL">ITEM &quot;_GoToAceHp_&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="__GfxThumb__" type="LONGSTRING">iVBORw0KGgoAAAANSUhEUgAAAQAAAABkCAIAAADmAnnJAAAACXBIWXMAAAsTAAALEwEAmpwYAAANjElEQVR4nO2db2gcxxXA3xl/KJR+ihtLEaKxczJRLJqPicbtlzQQbIrj0KIrBOQU3A2lNKdCSimOTWndP9ioHZV+kQoFQ0NyMq58wl7bxK4bEx/BbamNZDnV2nGwZftLsb+0yL4gbT/s3u7e/pl9uzu3u3f7foRg3c6+efNm3szc3nuzpfv371+5cmVwcBAAAGBlZeWVl16CbmP+9OlHjx6NjY1lrQjRZWy8fPny3bt3N2zYYPx969atbBUiiFSp1+u3b9+en58/efLkqVOnVlZW9OaStrTER0fZqF1MbTb15hIfBTY5r85PKrBPbS5xu0BbYWXevGR/ODrJJye1lhADtm8UAPjSPACozXnzw8lJR3WW2FG2b1+rIuO/fcqkcXtTbzbr9XqtVtMJIiKler0u2aUygrZARAw27t69e3Z2Nms1CCIbSrquZ6vB4uJiuVxeX19fW1uz/m/94+HDhyMjI9lqSPQwG7NWAAAgaPSvra1lrRrR4+TCAYJG//r6etaqET1OLhwgaPTTCkB0mlw4wJ07d7JWgSgo2X8JbnFjasfQRIMx1mg0AAC4plfLWStF9Dr5cQCTUqlUq9XoiT6RDrnYAhFEVpADEIWGHIAoNOQARKEhByAKTYgDlEqldPTISb1EDxDpKWL4ClCr1ZLpE4dMKiV6gEqlEu0GcboAAKScaJJ+jb1BD9hNShOiCqHvAEShIQcgio3cBSUGCwsLAvUWFhY6Wnv3IrZb1tqhkNX1SYTQCkAUmlw4wOrqqiAlMmvt8svq6qplNKf1Hjx4kLVqWKR0/cLCQrlcjmeKXDgApUTGw7fLu8tosro+tilCHEDX9RTOjKCUyHj4dnl3OYCsro9tikAH2Dt1AgCOVvekEJpPKZHx8O3y7po1ZHV9bFP4OMDLO0rnG7D1rQ/f2vPU3qkTR6t7IqkSA0qJjMfKykrWKiRFVtfHN4X3wdA3GAAA+7V2+My1Q/NXxvlc1MdbEdE4A8a5Aowxxpitm9rhirscw24KAHBNNSxmdF0X2s3ZliT3cgBgijmGMKJ8UiJffvPgwHOwfHbgm99/cfnTW/2bn/zNdxgQRE/i6xaHz1wb53PjfO4n712K6o+x0LgxdymWpyldOI2ljD3zMc4Vu0u7yHRGE1RVbalv7wBitgIi/nQbmBR/8Pjfm59/TnM/0V0YgfQRIqJdDtFyRdMT05pLWiuAPZF10TSWJaoCjNn9FX0DnQfM3ldUJfmQM0Y/fhEIDBqBjMJrs6q3O9E4s7cNCmcpzlmyMEZ/28OPJG4cdfz4/w5ACVldQrl6Sa86/p6uBhbNK+4mpIztAL6D3vpQz9n5WYSLnjlQLOWGBP4STEmJXQSt2PFx7Z9cf/oWC92EdRHI/WLWaqLI1ZwV4Wuo371RRQluF4sKjwZdfndi2+sc3fAQDQCgUqkICoivSsfIocYsuLkaXkHkR0mkYY0Nj/dz54ehorxCguzgI8rlRkFehfRmHfE1XFwg9HZ8MVll8MWSk1pF8cCrl2Y/JtGqbQVYmnnDNeiB9pdET9PmAMPf2z+1ozQ7po7NHpqFRqNhPpHNSjmC6DQS3g+wuLgoLjAyMiIuE1ogTSG+n3fu2Vw8fdIEqaFEw0YVJeidcFGO7ZAZmcSZMyJJYWFRCYLc/nv37hlp+QIljAL5ESLACBDE7DXxJNEnHZAaCowvaIivSaOKEvRLqPLOLVDrN7nqzrZf5hArhCC12aosNG05P0K8dC5JKElCdzrgNYyUpL936sTd2dfON+DpH5zzmhQpSiwEo7ycpHhManNo2nJ+hATR1/9Us9nctnWLXB+IrU9qIDWM2pDhTXAeoK+vf9vWTS6T4kUJhGBEyXGAoDHnTMoMTVvOjxAfRg6Mj8Hy2fPN7WaSkBS7xdcnXZAaRm3I9b4Dh88MHPvdheUvDbhMihclEIIRJXkFcI0519D0KuEdl3kQ4uXc9M+PnF0CWO5EilwMfVIGqWGkhhyt7jlydtviJ8vDO8FrUqQosRCMKDkOgEltDk1bzo8QX378ynMH//u/TiQJ5T+3Halh1IYITIoXFdovIaLiPBcoFma6RitmnTJ1EtJKAFAUKwGWmelQ+DwAKUJ0XZAQEx2NMwCFq5yBJ6fBSjRTVENh+0mr2rpXUQAAuNbKD2olhzlEaZxZecOKogAonLdlQjnlmAcEuB7jqo7kWasuZDoVdCZOwakS46qar7wWp80ZY6CoRhe6JoK23ldbjYqVp+aqkRmZYorKQ5/I+4pyjEmf7k7uABpnZi4S49zoQu5Yi1zD1+xm/5ZgEiOtM1QguIxJ0HhVFXPyUDVulEFOG51wAKMNltgO+VgyNM6AtS2DQcO6LUOtVqsJk9RCj0Ixp3kwg9ucHR3tKBRzijEVaxswGWyBMH0sZRx0oiK5o9Ma/YZYlzPkELx6wSUjnwQRWmkSo8lyAHOtsX5FNvwyXnuEZdwHqAjmbozh5A44iI4x+mPcGK+u5A3ER+dLMSxSVHABTdM0zpi5UNjbE9PZZJ0ObWV2VieMwIzyWDU41RMfhR9UUSYZgJhK8aPZmflg/aNz6RCR3x4nlJPY8jemdgxNNEBRlZldM6qu70wgKyipAAAAyuUyVC9dAgBzQLaPy2yOR5fSx8l7Qtf1TgR7I1Xy1V/S8AqsLjmYvkMY1s6Fn9ank4kScfrN0q4ZYAwaDUVRZmZm7Etc06vl7N4PkLyP85P9FAPhpJV3JE3/jLFGo2F+ZAzHeOjBh/jvnNYd/jU9M+New3PxgozYpLAF8k4/yU/KsEZ/DxziEAt7+pe1lcVI8F1J5DvAOJ87dR8E6oQWSE0Isgw4xrphxJvH33nmW4fiSROPfqQ+MZAiGS9EYkNCRSG9yH+hSP493cI4V33rjz76w4ef+sZnj/M5s0z1YlAAdzpC7DLVi1MXNEGUv8tKQabDaGVJ8H1kgdQnBpZuW354IbZkvBCM8S0MSwY9w0GKEgsRi5K/AvT3P/W42RweesY3NvX5PjgP0NffP/LsE4Kg4hSEGPT19z9+3Bza8nTyCGeMVqFbf4n6ONm+2YwZHh4SWUyiEIHxBUew6X67Sl9R8c5x84qS6gAjB8bHQPvgXHP7i9e1mwN9m71Frm46MHXhK+8dPr/4hc2DA/0ZCrEinB8Pv6Dd+gw5JvTggwJCtQrZ+sfSB8m1Lx+Y/GCwNvnX61/s97eGRCEY4zsQzQhoUeFPFAJEScgJdvLbc/++eu06AAz0bf5VZdRb4Pd/u/HPq4sAMDjQf+jbL2QoBACOnF1a/GQZAJ7c9MSR17+OaJ+IUK1Ct6py9XGCsYZEIeKSrsneOZt4R2OQqEhCRKLEW7QY/GzuHz99vyEo8Iv6v/Yf+zgPQnRd33/s47f/fDH4uuaMazJ+RxREZQm0Atyx3WH6xAdjDYlCBCVdA8/4c/ndiaDR6CsqqpAgUZJXAMKXwj/3bCPG5N0hIWbpxIQGZ2Oit6WUkVWRxLbrengIjR1R2yL5i+6s0NpW9AtTWqHWABFClPHmwpYMGnhLM2/gRSGEoERRPoBtkbjvZXA33A5zNEwc5Z0lYa4SnwSS3SkBBu27QHw+gCMqnkHr/TZOn8fnA7gP8vH0YBr5APmlc4MJX2OM0Z8/B+hlKCHGnqqT46oxxoBOOEzB8UDQlWMguBRWr29CTHAPOl53lOytTa63JwUNhraj3HwVSyEhJo/5ADoif0X6vOh1gEi3J9fHuN3peNa/BZd0XK4PXj2Jhk0mKiQfIJstEKY9KazXKWw5fIUHTcMGgnk6D+D9RFZCTOf6SO+EA4T2VrIVQKYQZBk8rh1F0OivtTA+cf7bkuAtkLA54tuRdui6FcDxXVxRHPtma+/Q3eHQOUfw1N95ybeYt4CsjJZCkdN8ACl5T8mFdCIdrFKpxE5rDNVH3OSEtyPBCJFo2E6LkuMAoVkjrgLG+DA+vMpf+2r1L7kSEglfgQBQqVSevf9+qFYuXPo8PzEXdDW0OVGFg8dWggb6WsxZ0qWJUyAGWaLE9tFlfQewxDn/vHn8HdeHrls+m/+l9648CIlKQq0Et8drjlUmtN5Q4fhiYk30iKQmSk4sECYwo1Rqq8vr0PkREpWEWgluT9Ic35KuekOFhyqPsYO3ZCipiaIvwUSh6YgD6H7bU99XUF7/43fzLySUhFrhb7dmMudV/Ls9fW/H3IgUIvEto6mJonBoothE/UrhxQitUdT2nxnMwE/FCva0foVuBaOa8TxWLIMVMaq2p6G0Qje8gR9mMI91arn3V49WWBHjmqqqZi2KasWGgB1qwtxxo2g0zpiiWpoA+MSAeAOeQQ2/5H/VG15l2VZR1VaEJajCq0rwJb/gTaM3TVsx/+hLjSuKwoz4TZUzowvMgREl2Mrb0c4QVLMfI0rjCjClLRDYvEwrAFFsInkTEYCxCJgLUNyVhOgQdlSpNxiOVgCi0NBjUKLQkAMQhYYcgCg05ABEoSEHIAoNOQBRaMgBiEJDDkAUGnIAotCQAxDFJtsoDYIIxo5mVVUOnsM9AcCKQWaMMaXt9F8zaNUMjFWdd1mRyDrFAhEFh7ZARE/yYGrHnyYaAABM2dSY+Q/XXp0Yqqv6q7tKdQBg/GuNiY90/W1aAYhCQysAUWj+D//cKR3k9XGpAAAAAElFTkSuQmCC</aTTRIBUTE>
+<aTTRIBUTE name="NT Model Attributes" type="LONGSTRING">NOTEBOOK
+CHAPTER &quot;Description&quot;
+#ATTR &quot;Shared&quot;
+ATTR &quot;Model state&quot; enabled:(cond(search (sMfbRegistration, &quot;MFB_VERS&quot;, 0) = -1, 1, 0))
+ATTR &quot;Description&quot;
+ATTR &quot;Show State&quot; ctrltype:check unchecked-value:&quot;No&quot; checked-value:&quot;Yes&quot; 
+ATTR &quot;Last user&quot; write-protected
+ATTR &quot;Date last changed&quot; write-protected
+#CHAPTER &quot;Suggestion for improvement&quot;
+#ATTR &quot;Suggestion for improvement&quot;
+</aTTRIBUTE>
+<aTTRIBUTE name="Model state" type="ENUMERATION">Draft</aTTRIBUTE>
+<aTTRIBUTE name="People-like view" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Action" type="ENUMERATION">Fill in</aTTRIBUTE>
+<aTTRIBUTE name="Keywords" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Description" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Model type" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Show State" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="BAR Display active" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Actor_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="Actor_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Actor_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="Description_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="Description_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Description_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="ModelingAreaSize" type="ENUMERATION">15</aTTRIBUTE>
+<aTTRIBUTE name="Modelling_size" type="ENUMERATION">3</aTTRIBUTE>
+<aTTRIBUTE name="DrawingAreaWidth" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="DrawingAreaHeight" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Reference overview settings" type="LONGSTRING">Responsible for execution|Responsible for execution
+Accountable for approving results|Accountable for approving results
+Cooperation/participation|Cooperation/participation
+To inform|To inform
+Modelling|Modelling
+Knowledge Product|Knowledge Product
+Documents and Resources|Documents and Resources
+#Data Object|Data Object
+Incoming Data Object|Incoming Data Object
+Outgoing Data Object|Outgoing Data Object
+Description|Description</aTTRIBUTE>
+<aTTRIBUTE name="Data Object_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="Data Object_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Data Object_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="Knowledge Product_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="Knowledge Product_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Knowledge Product_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="Documents and Resources_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Documents and Resources_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="Documents and Resources_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="Responsible for execution_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="Responsible for execution_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Responsible for execution_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="Accountable for approving results_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="Accountable for approving results_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Accountable for approving results_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="Cooperation/participation_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="Cooperation/participation_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Cooperation/participation_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="To inform_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="To inform_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="To inform_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="Incoming Data Object_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="Incoming Data Object_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Incoming Data Object_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="Outgoing Data Object_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="Outgoing Data Object_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Outgoing Data Object_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="id_bpmndi_diagram" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="id_bpmndi_plane" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="id_bpmndi_collaboration" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="CommentModellingAreaSize" type="ENUMERATION">3</aTTRIBUTE>
+<aTTRIBUTE name="CommentTypeSize" type="ENUMERATION">8</aTTRIBUTE>
+<aTTRIBUTE name="CommentAreaSize" type="ENUMERATION">2</aTTRIBUTE>
+<aTTRIBUTE name="Comment Mode" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="CommentxCoorTextBox" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="CommentyCoorTextBox" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="CommentModellingDirection" type="ENUMERATION">vertical</aTTRIBUTE>
+</mODELATTRIBUTES>
+<iNSTANCE id="obj.16638" class="Organizational unit" name="Comune">
+<aTTRIBUTE name="Position" type="STRING">NODE x:12.5cm y:1.5cm w:2.4cm h:1.5cm index:1</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Model reference"></iNTERREF>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Organisationseinheit</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Submodelname" type="EXPRESSION">EXPR val:&quot;Bezeichnung&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Type" type="ENUMERATION">Standard</aTTRIBUTE>
+<aTTRIBUTE name="Functional unit" type="ENUMERATION">no</aTTRIBUTE>
+<aTTRIBUTE name="Manager" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Function" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Level" type="INTEGER">0</aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16641" class="Role" name="Sindaco">
+<aTTRIBUTE name="Position" type="STRING">NODE x:2cm y:7.5cm w:1.5cm h:1.47cm index:2</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Rolle</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16644" class="Performer" name="Maurizio Mangialardi">
+<aTTRIBUTE name="Position" type="STRING">NODE x:2cm y:10cm w:2.2cm h:1.15cm index:4</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Hourly wages" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Calendar" type="LONGSTRING">B@Working day@b@32400-43200@T@45000-59400@T@Free day@c@@@$cbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbcbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbcbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbcccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbccbbccb</aTTRIBUTE>
+<aTTRIBUTE name="Availability" type="EXPRESSION">EXPR expr:(round(paval(&quot;Presence&quot;,&quot;Hours per day&quot;)*paval(&quot;Presence&quot;,&quot;Days per week&quot;)/40*100)) val:100</aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Time dependent costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Info on results" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Workload" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Capacity" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Personnel costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Bearbeiter</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<rECORD name="Further education"></rECORD>
+<aTTRIBUTE name="Presence" type="ATTRPROFREF"></aTTRIBUTE>
+<aTTRIBUTE name="E-Mail" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16647" class="Organizational unit" name="Area Tecnica Territorio e Ambiente">
+<aTTRIBUTE name="Position" type="STRING">NODE x:12.5cm y:6.5cm w:2.4cm h:1.5cm index:6</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Model reference"></iNTERREF>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Organisationseinheit</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Submodelname" type="EXPRESSION">EXPR val:&quot;Bezeichnung&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Type" type="ENUMERATION">Standard</aTTRIBUTE>
+<aTTRIBUTE name="Functional unit" type="ENUMERATION">no</aTTRIBUTE>
+<aTTRIBUTE name="Manager" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Function" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Level" type="INTEGER">0</aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16650" class="Organizational unit" name="Area Turismo Promozione e Sviluppo Econmico">
+<aTTRIBUTE name="Position" type="STRING">NODE x:39.5cm y:6.5cm w:2.4cm h:1.5cm index:7</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Model reference"></iNTERREF>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Organisationseinheit</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Submodelname" type="EXPRESSION">EXPR val:&quot;Bezeichnung&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Type" type="ENUMERATION">Standard</aTTRIBUTE>
+<aTTRIBUTE name="Functional unit" type="ENUMERATION">no</aTTRIBUTE>
+<aTTRIBUTE name="Manager" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Function" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Level" type="INTEGER">0</aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16653" class="Organizational unit" name="Area Organizzativa e Risorse Finanziarie">
+<aTTRIBUTE name="Position" type="STRING">NODE x:56.5cm y:6.5cm w:2.4cm h:1.5cm index:8</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Model reference"></iNTERREF>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Organisationseinheit</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Submodelname" type="EXPRESSION">EXPR val:&quot;Bezeichnung&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Type" type="ENUMERATION">Standard</aTTRIBUTE>
+<aTTRIBUTE name="Functional unit" type="ENUMERATION">no</aTTRIBUTE>
+<aTTRIBUTE name="Manager" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Function" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Level" type="INTEGER">0</aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16656" class="Organizational unit" name="Area Persona">
+<aTTRIBUTE name="Position" type="STRING">NODE x:62.5cm y:6.5cm w:2.4cm h:1.5cm index:9</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Model reference"></iNTERREF>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Organisationseinheit</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Submodelname" type="EXPRESSION">EXPR val:&quot;Bezeichnung&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Type" type="ENUMERATION">Standard</aTTRIBUTE>
+<aTTRIBUTE name="Functional unit" type="ENUMERATION">no</aTTRIBUTE>
+<aTTRIBUTE name="Manager" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Function" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Level" type="INTEGER">0</aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16659" class="Organizational unit" name="Ufficio Programmazione Urbanistica">
+<aTTRIBUTE name="Position" type="STRING">NODE x:7cm y:12cm w:2.4cm h:1.5cm index:10</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Model reference"></iNTERREF>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Organisationseinheit</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Submodelname" type="EXPRESSION">EXPR val:&quot;Bezeichnung&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Type" type="ENUMERATION">Standard</aTTRIBUTE>
+<aTTRIBUTE name="Functional unit" type="ENUMERATION">no</aTTRIBUTE>
+<aTTRIBUTE name="Manager" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Function" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Level" type="INTEGER">0</aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16662" class="Organizational unit" name="Sportello Unico Edilizia">
+<aTTRIBUTE name="Position" type="STRING">NODE x:10cm y:12cm w:2.4cm h:1.5cm index:12</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Model reference"></iNTERREF>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Organisationseinheit</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Submodelname" type="EXPRESSION">EXPR val:&quot;Bezeichnung&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Type" type="ENUMERATION">Standard</aTTRIBUTE>
+<aTTRIBUTE name="Functional unit" type="ENUMERATION">no</aTTRIBUTE>
+<aTTRIBUTE name="Manager" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Function" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Level" type="INTEGER">0</aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16665" class="Organizational unit" name="Ufficio Gestione Ambiente">
+<aTTRIBUTE name="Position" type="STRING">NODE x:13cm y:12cm w:2.4cm h:1.5cm index:13</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Model reference"></iNTERREF>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Organisationseinheit</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Submodelname" type="EXPRESSION">EXPR val:&quot;Bezeichnung&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Type" type="ENUMERATION">Standard</aTTRIBUTE>
+<aTTRIBUTE name="Functional unit" type="ENUMERATION">no</aTTRIBUTE>
+<aTTRIBUTE name="Manager" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Function" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Level" type="INTEGER">0</aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16668" class="Organizational unit" name="Ufficio Strade Mobilità e Territorio">
+<aTTRIBUTE name="Position" type="STRING">NODE x:16cm y:12cm w:2.4cm h:1.5cm index:14</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Model reference"></iNTERREF>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Organisationseinheit</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Submodelname" type="EXPRESSION">EXPR val:&quot;Bezeichnung&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Type" type="ENUMERATION">Standard</aTTRIBUTE>
+<aTTRIBUTE name="Functional unit" type="ENUMERATION">no</aTTRIBUTE>
+<aTTRIBUTE name="Manager" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Function" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Level" type="INTEGER">0</aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16671" class="Organizational unit" name="Ufficio Porto">
+<aTTRIBUTE name="Position" type="STRING">NODE x:19cm y:12cm w:2.4cm h:1.5cm index:15</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Model reference"></iNTERREF>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Organisationseinheit</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Submodelname" type="EXPRESSION">EXPR val:&quot;Bezeichnung&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Type" type="ENUMERATION">Standard</aTTRIBUTE>
+<aTTRIBUTE name="Functional unit" type="ENUMERATION">no</aTTRIBUTE>
+<aTTRIBUTE name="Manager" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Function" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Level" type="INTEGER">0</aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16674" class="Organizational unit" name="Sviluppo Urbano Sostenibile">
+<aTTRIBUTE name="Position" type="STRING">NODE x:22cm y:12cm w:2.4cm h:1.5cm index:16</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Model reference"></iNTERREF>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Organisationseinheit</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Submodelname" type="EXPRESSION">EXPR val:&quot;Bezeichnung&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Type" type="ENUMERATION">Standard</aTTRIBUTE>
+<aTTRIBUTE name="Functional unit" type="ENUMERATION">no</aTTRIBUTE>
+<aTTRIBUTE name="Manager" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Function" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Level" type="INTEGER">0</aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16677" class="Role" name="Responsabile Ufficio Programmazione Urbanistica">
+<aTTRIBUTE name="Position" type="STRING">NODE x:7cm y:16cm w:1.5cm h:1.47cm index:26</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Rolle</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16680" class="Performer" name="Serenalli Roberto">
+<aTTRIBUTE name="Position" type="STRING">NODE x:7cm y:20cm w:2.2cm h:1.15cm index:27</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Hourly wages" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Calendar" type="LONGSTRING">B@Working day@b@32400-43200@T@45000-59400@T@Free day@c@@@$cbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbcbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbcbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbcccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbccbbccb</aTTRIBUTE>
+<aTTRIBUTE name="Availability" type="EXPRESSION">EXPR expr:(round(paval(&quot;Presence&quot;,&quot;Hours per day&quot;)*paval(&quot;Presence&quot;,&quot;Days per week&quot;)/40*100)) val:100</aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Time dependent costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Info on results" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Workload" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Capacity" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Personnel costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Bearbeiter</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<rECORD name="Further education"></rECORD>
+<aTTRIBUTE name="Presence" type="ATTRPROFREF"></aTTRIBUTE>
+<aTTRIBUTE name="E-Mail" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16683" class="Role" name="Responsabile Sportello Unico Edilizia">
+<aTTRIBUTE name="Position" type="STRING">NODE x:10cm y:16cm w:1.5cm h:1.47cm index:30</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Rolle</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16686" class="Role" name="Responsabile Ufficio Gestione Ambiente">
+<aTTRIBUTE name="Position" type="STRING">NODE x:13cm y:16cm w:1.5cm h:1.47cm index:31</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Rolle</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16689" class="Role" name="Responsabile Ufficio Strade Mobilità e Territorio">
+<aTTRIBUTE name="Position" type="STRING">NODE x:16cm y:16cm w:1.5cm h:1.47cm index:32</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Rolle</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16692" class="Role" name="Responsabile Ufficio Porto">
+<aTTRIBUTE name="Position" type="STRING">NODE x:19cm y:16cm w:1.5cm h:1.47cm index:33</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Rolle</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16695" class="Role" name="Responsabile Sviluppo Urbano Sostenibile">
+<aTTRIBUTE name="Position" type="STRING">NODE x:22cm y:16cm w:1.5cm h:1.47cm index:34</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Rolle</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16698" class="Performer" name="Mario Partenico">
+<aTTRIBUTE name="Position" type="STRING">NODE x:10cm y:20cm w:2.2cm h:1.15cm index:35</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Hourly wages" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Calendar" type="LONGSTRING">B@Working day@b@32400-43200@T@45000-59400@T@Free day@c@@@$cbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbcbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbcbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbcccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbccbbccb</aTTRIBUTE>
+<aTTRIBUTE name="Availability" type="EXPRESSION">EXPR expr:(round(paval(&quot;Presence&quot;,&quot;Hours per day&quot;)*paval(&quot;Presence&quot;,&quot;Days per week&quot;)/40*100)) val:100</aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Time dependent costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Info on results" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Workload" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Capacity" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Personnel costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Bearbeiter</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<rECORD name="Further education"></rECORD>
+<aTTRIBUTE name="Presence" type="ATTRPROFREF"></aTTRIBUTE>
+<aTTRIBUTE name="E-Mail" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16701" class="Performer" name="Sara Giorgetti">
+<aTTRIBUTE name="Position" type="STRING">NODE x:13cm y:20cm w:2.2cm h:1.15cm index:36</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Hourly wages" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Calendar" type="LONGSTRING">B@Working day@b@32400-43200@T@45000-59400@T@Free day@c@@@$cbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbcbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbcbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbcccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbccbbccb</aTTRIBUTE>
+<aTTRIBUTE name="Availability" type="EXPRESSION">EXPR expr:(round(paval(&quot;Presence&quot;,&quot;Hours per day&quot;)*paval(&quot;Presence&quot;,&quot;Days per week&quot;)/40*100)) val:100</aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Time dependent costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Info on results" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Workload" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Capacity" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Personnel costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Bearbeiter</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<rECORD name="Further education"></rECORD>
+<aTTRIBUTE name="Presence" type="ATTRPROFREF"></aTTRIBUTE>
+<aTTRIBUTE name="E-Mail" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16704" class="Performer" name="Maurizio Piccini">
+<aTTRIBUTE name="Position" type="STRING">NODE x:16cm y:20cm w:2.2cm h:1.15cm index:37</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Hourly wages" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Calendar" type="LONGSTRING">B@Working day@b@32400-43200@T@45000-59400@T@Free day@c@@@$cbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbcbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbcbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbcccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbccbbccb</aTTRIBUTE>
+<aTTRIBUTE name="Availability" type="EXPRESSION">EXPR expr:(round(paval(&quot;Presence&quot;,&quot;Hours per day&quot;)*paval(&quot;Presence&quot;,&quot;Days per week&quot;)/40*100)) val:100</aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Time dependent costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Info on results" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Workload" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Capacity" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Personnel costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Bearbeiter</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<rECORD name="Further education"></rECORD>
+<aTTRIBUTE name="Presence" type="ATTRPROFREF"></aTTRIBUTE>
+<aTTRIBUTE name="E-Mail" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16707" class="Performer" name="Silvano Simonetti">
+<aTTRIBUTE name="Position" type="STRING">NODE x:19cm y:20cm w:2.2cm h:1.15cm index:38</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Hourly wages" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Calendar" type="LONGSTRING">B@Working day@b@32400-43200@T@45000-59400@T@Free day@c@@@$cbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbcbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbcbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbcccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbccbbccb</aTTRIBUTE>
+<aTTRIBUTE name="Availability" type="EXPRESSION">EXPR expr:(round(paval(&quot;Presence&quot;,&quot;Hours per day&quot;)*paval(&quot;Presence&quot;,&quot;Days per week&quot;)/40*100)) val:100</aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Time dependent costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Info on results" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Workload" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Capacity" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Personnel costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Bearbeiter</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<rECORD name="Further education"></rECORD>
+<aTTRIBUTE name="Presence" type="ATTRPROFREF"></aTTRIBUTE>
+<aTTRIBUTE name="E-Mail" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16710" class="Performer" name="Stefano Giacai">
+<aTTRIBUTE name="Position" type="STRING">NODE x:22cm y:20cm w:2.2cm h:1.15cm index:39</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Hourly wages" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Calendar" type="LONGSTRING">B@Working day@b@32400-43200@T@45000-59400@T@Free day@c@@@$cbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbcbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbcbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbcccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbccbbccb</aTTRIBUTE>
+<aTTRIBUTE name="Availability" type="EXPRESSION">EXPR expr:(round(paval(&quot;Presence&quot;,&quot;Hours per day&quot;)*paval(&quot;Presence&quot;,&quot;Days per week&quot;)/40*100)) val:100</aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Time dependent costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Info on results" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Workload" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Capacity" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Personnel costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Bearbeiter</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<rECORD name="Further education"></rECORD>
+<aTTRIBUTE name="Presence" type="ATTRPROFREF"></aTTRIBUTE>
+<aTTRIBUTE name="E-Mail" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16713" class="Role" name="Dirigente">
+<aTTRIBUTE name="Position" type="STRING">NODE x:26cm y:12cm w:1.5cm h:1.47cm index:50</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Rolle</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16716" class="Performer" name="Paolo Mattei">
+<aTTRIBUTE name="Position" type="STRING">NODE x:26cm y:15.5cm w:2.2cm h:1.15cm index:51</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Hourly wages" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Calendar" type="LONGSTRING">B@Working day@b@32400-43200@T@45000-59400@T@Free day@c@@@$cbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbcbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbcbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbcccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbccbbccb</aTTRIBUTE>
+<aTTRIBUTE name="Availability" type="EXPRESSION">EXPR expr:(round(paval(&quot;Presence&quot;,&quot;Hours per day&quot;)*paval(&quot;Presence&quot;,&quot;Days per week&quot;)/40*100)) val:100</aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Time dependent costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Info on results" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Workload" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Capacity" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Personnel costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Bearbeiter</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<rECORD name="Further education"></rECORD>
+<aTTRIBUTE name="Presence" type="ATTRPROFREF"></aTTRIBUTE>
+<aTTRIBUTE name="E-Mail" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16719" class="Organizational unit" name="SUAP Office">
+<aTTRIBUTE name="Position" type="STRING">NODE x:34.5cm y:12cm w:2.4cm h:1.5cm index:54</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Model reference"></iNTERREF>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Organisationseinheit</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Submodelname" type="EXPRESSION">EXPR val:&quot;Bezeichnung&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Type" type="ENUMERATION">Standard</aTTRIBUTE>
+<aTTRIBUTE name="Functional unit" type="ENUMERATION">no</aTTRIBUTE>
+<aTTRIBUTE name="Manager" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Function" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Level" type="INTEGER">0</aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16722" class="Role" name="Geometra">
+<aTTRIBUTE name="Position" type="STRING">NODE x:34.5cm y:16cm w:1.5cm h:1.47cm index:55</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Rolle</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16725" class="Role" name="Responsabile Ufficio SUAP">
+<aTTRIBUTE name="Position" type="STRING">NODE x:29cm y:16cm w:1.5cm h:1.47cm index:56</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Rolle</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16728" class="Role" name="Amministrazione">
+<aTTRIBUTE name="Position" type="STRING">NODE x:42.5cm y:16cm w:1.5cm h:1.47cm index:57</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Rolle</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16731" class="Performer" name="Francesca Freschi">
+<aTTRIBUTE name="Position" type="STRING">NODE x:29cm y:20cm w:2.2cm h:1.15cm index:62</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Hourly wages" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Calendar" type="LONGSTRING">B@Working day@b@32400-43200@T@45000-59400@T@Free day@c@@@$cbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbcbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbcbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbcccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbccbbccb</aTTRIBUTE>
+<aTTRIBUTE name="Availability" type="EXPRESSION">EXPR expr:(round(paval(&quot;Presence&quot;,&quot;Hours per day&quot;)*paval(&quot;Presence&quot;,&quot;Days per week&quot;)/40*100)) val:100</aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Time dependent costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Info on results" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Workload" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Capacity" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Personnel costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Bearbeiter</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<rECORD name="Further education"></rECORD>
+<aTTRIBUTE name="Presence" type="ATTRPROFREF"></aTTRIBUTE>
+<aTTRIBUTE name="E-Mail" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16734" class="Performer" name="Geometra1">
+<aTTRIBUTE name="Position" type="STRING">NODE x:32cm y:20cm w:2.2cm h:1.15cm index:63</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Hourly wages" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Calendar" type="LONGSTRING">B@Working day@b@32400-43200@T@45000-59400@T@Free day@c@@@$cbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbcbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbcbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbcccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbccbbccb</aTTRIBUTE>
+<aTTRIBUTE name="Availability" type="EXPRESSION">EXPR expr:(round(paval(&quot;Presence&quot;,&quot;Hours per day&quot;)*paval(&quot;Presence&quot;,&quot;Days per week&quot;)/40*100)) val:100</aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Time dependent costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Info on results" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Workload" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Capacity" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Personnel costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Bearbeiter</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<rECORD name="Further education"></rECORD>
+<aTTRIBUTE name="Presence" type="ATTRPROFREF"></aTTRIBUTE>
+<aTTRIBUTE name="E-Mail" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16737" class="Performer" name="Amministrativo2">
+<aTTRIBUTE name="Position" type="STRING">NODE x:42.5cm y:20cm w:2.2cm h:1.15cm index:64</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Hourly wages" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Calendar" type="LONGSTRING">B@Working day@b@32400-43200@T@45000-59400@T@Free day@c@@@$cbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbcbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbcbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbcccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbccbbccb</aTTRIBUTE>
+<aTTRIBUTE name="Availability" type="EXPRESSION">EXPR expr:(round(paval(&quot;Presence&quot;,&quot;Hours per day&quot;)*paval(&quot;Presence&quot;,&quot;Days per week&quot;)/40*100)) val:100</aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Time dependent costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Info on results" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Workload" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Capacity" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Personnel costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Bearbeiter</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<rECORD name="Further education"></rECORD>
+<aTTRIBUTE name="Presence" type="ATTRPROFREF"></aTTRIBUTE>
+<aTTRIBUTE name="E-Mail" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16740" class="Performer" name="Geometra2">
+<aTTRIBUTE name="Position" type="STRING">NODE x:34.5cm y:20cm w:2.2cm h:1.15cm index:65</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Hourly wages" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Calendar" type="LONGSTRING">B@Working day@b@32400-43200@T@45000-59400@T@Free day@c@@@$cbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbcbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbcbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbcccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbccbbccb</aTTRIBUTE>
+<aTTRIBUTE name="Availability" type="EXPRESSION">EXPR expr:(round(paval(&quot;Presence&quot;,&quot;Hours per day&quot;)*paval(&quot;Presence&quot;,&quot;Days per week&quot;)/40*100)) val:100</aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Time dependent costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Info on results" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Workload" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Capacity" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Personnel costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Bearbeiter</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<rECORD name="Further education"></rECORD>
+<aTTRIBUTE name="Presence" type="ATTRPROFREF"></aTTRIBUTE>
+<aTTRIBUTE name="E-Mail" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16743" class="Performer" name="Geometra3">
+<aTTRIBUTE name="Position" type="STRING">NODE x:37cm y:20cm w:2.2cm h:1.15cm index:66</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Hourly wages" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Calendar" type="LONGSTRING">B@Working day@b@32400-43200@T@45000-59400@T@Free day@c@@@$cbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbcbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbcbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbcccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbccbbccb</aTTRIBUTE>
+<aTTRIBUTE name="Availability" type="EXPRESSION">EXPR expr:(round(paval(&quot;Presence&quot;,&quot;Hours per day&quot;)*paval(&quot;Presence&quot;,&quot;Days per week&quot;)/40*100)) val:100</aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Time dependent costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Info on results" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Workload" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Capacity" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Personnel costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Bearbeiter</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<rECORD name="Further education"></rECORD>
+<aTTRIBUTE name="Presence" type="ATTRPROFREF"></aTTRIBUTE>
+<aTTRIBUTE name="E-Mail" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16746" class="Performer" name="Amministrativo1">
+<aTTRIBUTE name="Position" type="STRING">NODE x:40cm y:20cm w:2.2cm h:1.15cm index:70</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Hourly wages" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Calendar" type="LONGSTRING">B@Working day@b@32400-43200@T@45000-59400@T@Free day@c@@@$cbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbcbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbcbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbcccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbccbbccb</aTTRIBUTE>
+<aTTRIBUTE name="Availability" type="EXPRESSION">EXPR expr:(round(paval(&quot;Presence&quot;,&quot;Hours per day&quot;)*paval(&quot;Presence&quot;,&quot;Days per week&quot;)/40*100)) val:100</aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Time dependent costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Info on results" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Workload" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Capacity" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Personnel costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Bearbeiter</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<rECORD name="Further education"></rECORD>
+<aTTRIBUTE name="Presence" type="ATTRPROFREF"></aTTRIBUTE>
+<aTTRIBUTE name="E-Mail" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16749" class="Performer" name="Amministrativo3">
+<aTTRIBUTE name="Position" type="STRING">NODE x:45cm y:20cm w:2.2cm h:1.15cm index:71</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Hourly wages" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Calendar" type="LONGSTRING">B@Working day@b@32400-43200@T@45000-59400@T@Free day@c@@@$cbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbcbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbcbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbcccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbccbbccb</aTTRIBUTE>
+<aTTRIBUTE name="Availability" type="EXPRESSION">EXPR expr:(round(paval(&quot;Presence&quot;,&quot;Hours per day&quot;)*paval(&quot;Presence&quot;,&quot;Days per week&quot;)/40*100)) val:100</aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Time dependent costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Info on results" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Workload" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Capacity" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Personnel costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Bearbeiter</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<rECORD name="Further education"></rECORD>
+<aTTRIBUTE name="Presence" type="ATTRPROFREF"></aTTRIBUTE>
+<aTTRIBUTE name="E-Mail" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16752" class="Organizational unit" name="Ufficio Attività Economiche">
+<aTTRIBUTE name="Position" type="STRING">NODE x:48.5cm y:12cm w:2.4cm h:1.5cm index:76</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Model reference"></iNTERREF>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Organisationseinheit</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Submodelname" type="EXPRESSION">EXPR val:&quot;Bezeichnung&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Type" type="ENUMERATION">Standard</aTTRIBUTE>
+<aTTRIBUTE name="Functional unit" type="ENUMERATION">no</aTTRIBUTE>
+<aTTRIBUTE name="Manager" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Function" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Level" type="INTEGER">0</aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16755" class="Organizational unit" name="Ufficio Sviluppo Economico">
+<aTTRIBUTE name="Position" type="STRING">NODE x:52cm y:12cm w:2.4cm h:1.5cm index:77</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Model reference"></iNTERREF>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Organisationseinheit</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Submodelname" type="EXPRESSION">EXPR val:&quot;Bezeichnung&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Type" type="ENUMERATION">Standard</aTTRIBUTE>
+<aTTRIBUTE name="Functional unit" type="ENUMERATION">no</aTTRIBUTE>
+<aTTRIBUTE name="Manager" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Function" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Level" type="INTEGER">0</aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16758" class="Role" name="Responsabile Ufficio Tributi Economato">
+<aTTRIBUTE name="Position" type="STRING">NODE x:48.5cm y:16cm w:1.5cm h:1.47cm index:80</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Rolle</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16761" class="Performer" name="Perini Rosanna">
+<aTTRIBUTE name="Position" type="STRING">NODE x:48.5cm y:20cm w:2.2cm h:1.15cm index:82</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Hourly wages" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Calendar" type="LONGSTRING">B@Working day@b@32400-43200@T@45000-59400@T@Free day@c@@@$cbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbcbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbcbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbcccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbccbbccb</aTTRIBUTE>
+<aTTRIBUTE name="Availability" type="EXPRESSION">EXPR expr:(round(paval(&quot;Presence&quot;,&quot;Hours per day&quot;)*paval(&quot;Presence&quot;,&quot;Days per week&quot;)/40*100)) val:100</aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Time dependent costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Info on results" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Workload" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Capacity" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Personnel costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Bearbeiter</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<rECORD name="Further education"></rECORD>
+<aTTRIBUTE name="Presence" type="ATTRPROFREF"></aTTRIBUTE>
+<aTTRIBUTE name="E-Mail" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16764" class="Role" name="Responsabile Ufficio Sviluppo Economico">
+<aTTRIBUTE name="Position" type="STRING">NODE x:52cm y:16cm w:1.5cm h:1.47cm index:84</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Rolle</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16767" class="Performer" name="Laura Sorellini">
+<aTTRIBUTE name="Position" type="STRING">NODE x:52cm y:20cm w:2.2cm h:1.15cm index:85</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Hourly wages" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Calendar" type="LONGSTRING">B@Working day@b@32400-43200@T@45000-59400@T@Free day@c@@@$cbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbcbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbcbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbcccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbccbbccb</aTTRIBUTE>
+<aTTRIBUTE name="Availability" type="EXPRESSION">EXPR expr:(round(paval(&quot;Presence&quot;,&quot;Hours per day&quot;)*paval(&quot;Presence&quot;,&quot;Days per week&quot;)/40*100)) val:100</aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Time dependent costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Info on results" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Workload" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Capacity" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Personnel costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Bearbeiter</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<rECORD name="Further education"></rECORD>
+<aTTRIBUTE name="Presence" type="ATTRPROFREF"></aTTRIBUTE>
+<aTTRIBUTE name="E-Mail" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16770" class="Organizational unit" name="Ufficio Tributi e Canoni">
+<aTTRIBUTE name="Position" type="STRING">NODE x:58.5cm y:12cm w:2.4cm h:1.5cm index:88</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Model reference"></iNTERREF>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Organisationseinheit</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Submodelname" type="EXPRESSION">EXPR val:&quot;Bezeichnung&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Type" type="ENUMERATION">Standard</aTTRIBUTE>
+<aTTRIBUTE name="Functional unit" type="ENUMERATION">no</aTTRIBUTE>
+<aTTRIBUTE name="Manager" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Function" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Level" type="INTEGER">0</aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16773" class="Role" name="Responsabile Ufficio Tributi e Canoni">
+<aTTRIBUTE name="Position" type="STRING">NODE x:58.5cm y:16cm w:1.5cm h:1.47cm index:89</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Rolle</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16776" class="Performer" name="Gabriele Paoletti">
+<aTTRIBUTE name="Position" type="STRING">NODE x:58.5cm y:20cm w:2.2cm h:1.15cm index:90</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Hourly wages" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Calendar" type="LONGSTRING">B@Working day@b@32400-43200@T@45000-59400@T@Free day@c@@@$cbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbcbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbcbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbcccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbccbbccb</aTTRIBUTE>
+<aTTRIBUTE name="Availability" type="EXPRESSION">EXPR expr:(round(paval(&quot;Presence&quot;,&quot;Hours per day&quot;)*paval(&quot;Presence&quot;,&quot;Days per week&quot;)/40*100)) val:100</aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Time dependent costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Info on results" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Workload" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Capacity" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Personnel costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Bearbeiter</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<rECORD name="Further education"></rECORD>
+<aTTRIBUTE name="Presence" type="ATTRPROFREF"></aTTRIBUTE>
+<aTTRIBUTE name="E-Mail" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16779" class="Role" name="Responsabile Area Organizzativa e Risorse Finanziarie">
+<aTTRIBUTE name="Position" type="STRING">NODE x:55.5cm y:12cm w:1.5cm h:1.47cm index:94</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Rolle</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16782" class="Performer" name="Fiorenzi Laura">
+<aTTRIBUTE name="Position" type="STRING">NODE x:55.5cm y:16.5cm w:2.2cm h:1.15cm index:95</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Hourly wages" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Calendar" type="LONGSTRING">B@Working day@b@32400-43200@T@45000-59400@T@Free day@c@@@$cbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbcbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbcbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbcccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbccbbccb</aTTRIBUTE>
+<aTTRIBUTE name="Availability" type="EXPRESSION">EXPR expr:(round(paval(&quot;Presence&quot;,&quot;Hours per day&quot;)*paval(&quot;Presence&quot;,&quot;Days per week&quot;)/40*100)) val:100</aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Time dependent costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Info on results" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Workload" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Capacity" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Personnel costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Bearbeiter</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<rECORD name="Further education"></rECORD>
+<aTTRIBUTE name="Presence" type="ATTRPROFREF"></aTTRIBUTE>
+<aTTRIBUTE name="E-Mail" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16785" class="Role" name="Responsabile Area Persona">
+<aTTRIBUTE name="Position" type="STRING">NODE x:61.5cm y:12cm w:1.5cm h:1.47cm index:98</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Rolle</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16788" class="Organizational unit" name="Ufficio Politiche Sociali e Integrazioni Socio Sanitarie">
+<aTTRIBUTE name="Position" type="STRING">NODE x:65cm y:12cm w:2.4cm h:1.5cm index:100</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Model reference"></iNTERREF>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Organisationseinheit</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Submodelname" type="EXPRESSION">EXPR val:&quot;Bezeichnung&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Type" type="ENUMERATION">Standard</aTTRIBUTE>
+<aTTRIBUTE name="Functional unit" type="ENUMERATION">no</aTTRIBUTE>
+<aTTRIBUTE name="Manager" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Function" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Level" type="INTEGER">0</aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16791" class="Performer" name="Maurizio Mandolini">
+<aTTRIBUTE name="Position" type="STRING">NODE x:61.5cm y:16.5cm w:2.2cm h:1.15cm index:102</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Hourly wages" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Calendar" type="LONGSTRING">B@Working day@b@32400-43200@T@45000-59400@T@Free day@c@@@$cbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbcbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbcbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbcccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbccbbccb</aTTRIBUTE>
+<aTTRIBUTE name="Availability" type="EXPRESSION">EXPR expr:(round(paval(&quot;Presence&quot;,&quot;Hours per day&quot;)*paval(&quot;Presence&quot;,&quot;Days per week&quot;)/40*100)) val:100</aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Time dependent costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Info on results" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Workload" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Capacity" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Personnel costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Bearbeiter</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<rECORD name="Further education"></rECORD>
+<aTTRIBUTE name="Presence" type="ATTRPROFREF"></aTTRIBUTE>
+<aTTRIBUTE name="E-Mail" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16794" class="Role" name="Responsabile Ufficio Politiche Sociali e Integrazioni Socio Sanitarie">
+<aTTRIBUTE name="Position" type="STRING">NODE x:65cm y:16cm w:1.5cm h:1.47cm index:104</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Rolle</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16797" class="Performer" name="Giuseppina Campolini">
+<aTTRIBUTE name="Position" type="STRING">NODE x:65cm y:20cm w:2.2cm h:1.15cm index:106</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Hourly wages" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Calendar" type="LONGSTRING">B@Working day@b@32400-43200@T@45000-59400@T@Free day@c@@@$cbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbcbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbcbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbcccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbccbbccb</aTTRIBUTE>
+<aTTRIBUTE name="Availability" type="EXPRESSION">EXPR expr:(round(paval(&quot;Presence&quot;,&quot;Hours per day&quot;)*paval(&quot;Presence&quot;,&quot;Days per week&quot;)/40*100)) val:100</aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Time dependent costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Info on results" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Workload" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Capacity" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Personnel costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Bearbeiter</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<rECORD name="Further education"></rECORD>
+<aTTRIBUTE name="Presence" type="ATTRPROFREF"></aTTRIBUTE>
+<aTTRIBUTE name="E-Mail" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<cONNECTOR id="con.16800" class="belongs to">
+<fROM instance="Sindaco" class="Role"></fROM>
+<tO instance="Comune" class="Organizational unit"></tO>
+<aTTRIBUTE name="Connector number" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 2 x1:2.5cm y1:4.5cm x2:12.5cm y2:4.5cm index:3</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16801" class="Has role">
+<fROM instance="Maurizio Mangialardi" class="Performer"></fROM>
+<tO instance="Sindaco" class="Role"></tO>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 0 index:5</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">0</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16802" class="Is subordinated">
+<fROM instance="Area Tecnica Territorio e Ambiente" class="Organizational unit"></fROM>
+<tO instance="Comune" class="Organizational unit"></tO>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 0 index:22</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Representation" type="ENUMERATION">with arrow</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16803" class="Is subordinated">
+<fROM instance="Area Turismo Promozione e Sviluppo Econmico" class="Organizational unit"></fROM>
+<tO instance="Comune" class="Organizational unit"></tO>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 2 x1:39.5cm y1:4.5cm x2:12.5cm y2:4.5cm index:23</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Representation" type="ENUMERATION">with arrow</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16804" class="Is subordinated">
+<fROM instance="Area Organizzativa e Risorse Finanziarie" class="Organizational unit"></fROM>
+<tO instance="Comune" class="Organizational unit"></tO>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 2 x1:56.5cm y1:4.5cm x2:12.5cm y2:4.5cm index:24</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Representation" type="ENUMERATION">with arrow</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16805" class="Is subordinated">
+<fROM instance="Area Persona" class="Organizational unit"></fROM>
+<tO instance="Comune" class="Organizational unit"></tO>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 2 x1:62.5cm y1:4.5cm x2:12.5cm y2:4.5cm index:25</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Representation" type="ENUMERATION">with arrow</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16806" class="Is subordinated">
+<fROM instance="Ufficio Programmazione Urbanistica" class="Organizational unit"></fROM>
+<tO instance="Area Tecnica Territorio e Ambiente" class="Organizational unit"></tO>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 2 x1:7cm y1:10cm x2:12.5cm y2:10cm index:11</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Representation" type="ENUMERATION">with arrow</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16807" class="Is subordinated">
+<fROM instance="Sportello Unico Edilizia" class="Organizational unit"></fROM>
+<tO instance="Area Tecnica Territorio e Ambiente" class="Organizational unit"></tO>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 2 x1:10cm y1:10cm x2:12.5cm y2:10cm index:17</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Representation" type="ENUMERATION">with arrow</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16808" class="Is subordinated">
+<fROM instance="Ufficio Gestione Ambiente" class="Organizational unit"></fROM>
+<tO instance="Area Tecnica Territorio e Ambiente" class="Organizational unit"></tO>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 1 x1:12.5cm y1:10.5cm index:18</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Representation" type="ENUMERATION">with arrow</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16809" class="Is subordinated">
+<fROM instance="Ufficio Strade Mobilità e Territorio" class="Organizational unit"></fROM>
+<tO instance="Area Tecnica Territorio e Ambiente" class="Organizational unit"></tO>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 2 x1:16cm y1:10cm x2:12.5cm y2:10cm index:19</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Representation" type="ENUMERATION">with arrow</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16810" class="Is subordinated">
+<fROM instance="Ufficio Porto" class="Organizational unit"></fROM>
+<tO instance="Area Tecnica Territorio e Ambiente" class="Organizational unit"></tO>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 2 x1:19cm y1:10cm x2:12.5cm y2:10cm index:20</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Representation" type="ENUMERATION">with arrow</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16811" class="Is subordinated">
+<fROM instance="Sviluppo Urbano Sostenibile" class="Organizational unit"></fROM>
+<tO instance="Area Tecnica Territorio e Ambiente" class="Organizational unit"></tO>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 2 x1:22cm y1:10cm x2:12.5cm y2:10cm index:21</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Representation" type="ENUMERATION">with arrow</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16812" class="belongs to">
+<fROM instance="Responsabile Ufficio Programmazione Urbanistica" class="Role"></fROM>
+<tO instance="Ufficio Programmazione Urbanistica" class="Organizational unit"></tO>
+<aTTRIBUTE name="Connector number" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 0 index:28</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16813" class="Has role">
+<fROM instance="Serenalli Roberto" class="Performer"></fROM>
+<tO instance="Responsabile Ufficio Programmazione Urbanistica" class="Role"></tO>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 0 index:29</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">0</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16814" class="belongs to">
+<fROM instance="Responsabile Sportello Unico Edilizia" class="Role"></fROM>
+<tO instance="Sportello Unico Edilizia" class="Organizational unit"></tO>
+<aTTRIBUTE name="Connector number" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 0 index:40</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16815" class="belongs to">
+<fROM instance="Responsabile Ufficio Gestione Ambiente" class="Role"></fROM>
+<tO instance="Ufficio Gestione Ambiente" class="Organizational unit"></tO>
+<aTTRIBUTE name="Connector number" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 1 x1:13cm y1:14.5cm index:41</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16816" class="belongs to">
+<fROM instance="Responsabile Ufficio Strade Mobilità e Territorio" class="Role"></fROM>
+<tO instance="Ufficio Strade Mobilità e Territorio" class="Organizational unit"></tO>
+<aTTRIBUTE name="Connector number" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 0 index:42</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16817" class="belongs to">
+<fROM instance="Responsabile Ufficio Porto" class="Role"></fROM>
+<tO instance="Ufficio Porto" class="Organizational unit"></tO>
+<aTTRIBUTE name="Connector number" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 0 index:43</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16818" class="belongs to">
+<fROM instance="Responsabile Sviluppo Urbano Sostenibile" class="Role"></fROM>
+<tO instance="Sviluppo Urbano Sostenibile" class="Organizational unit"></tO>
+<aTTRIBUTE name="Connector number" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 0 index:44</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16819" class="Has role">
+<fROM instance="Mario Partenico" class="Performer"></fROM>
+<tO instance="Responsabile Sportello Unico Edilizia" class="Role"></tO>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 0 index:45</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">0</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16820" class="Has role">
+<fROM instance="Sara Giorgetti" class="Performer"></fROM>
+<tO instance="Responsabile Ufficio Gestione Ambiente" class="Role"></tO>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 0 index:46</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">0</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16821" class="Has role">
+<fROM instance="Maurizio Piccini" class="Performer"></fROM>
+<tO instance="Responsabile Ufficio Strade Mobilità e Territorio" class="Role"></tO>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 0 index:47</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">0</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16822" class="Has role">
+<fROM instance="Silvano Simonetti" class="Performer"></fROM>
+<tO instance="Responsabile Ufficio Porto" class="Role"></tO>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 0 index:48</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">0</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16823" class="Has role">
+<fROM instance="Stefano Giacai" class="Performer"></fROM>
+<tO instance="Responsabile Sviluppo Urbano Sostenibile" class="Role"></tO>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 0 index:49</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">0</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16824" class="belongs to">
+<fROM instance="Dirigente" class="Role"></fROM>
+<tO instance="Area Turismo Promozione e Sviluppo Econmico" class="Organizational unit"></tO>
+<aTTRIBUTE name="Connector number" type="INTEGER">25</aTTRIBUTE>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 2 x1:25.5cm y1:10cm x2:39.5cm y2:10cm index:52</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16825" class="Has role">
+<fROM instance="Paolo Mattei" class="Performer"></fROM>
+<tO instance="Dirigente" class="Role"></tO>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 0 index:53</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">26</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16826" class="Is subordinated">
+<fROM instance="SUAP Office" class="Organizational unit"></fROM>
+<tO instance="Area Turismo Promozione e Sviluppo Econmico" class="Organizational unit"></tO>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 2 x1:34.5cm y1:10cm x2:39.5cm y2:10cm index:61</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">27</aTTRIBUTE>
+<aTTRIBUTE name="Representation" type="ENUMERATION">with arrow</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16827" class="belongs to">
+<fROM instance="Geometra" class="Role"></fROM>
+<tO instance="SUAP Office" class="Organizational unit"></tO>
+<aTTRIBUTE name="Connector number" type="INTEGER">28</aTTRIBUTE>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 0 index:59</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16828" class="belongs to">
+<fROM instance="Responsabile Ufficio SUAP" class="Role"></fROM>
+<tO instance="SUAP Office" class="Organizational unit"></tO>
+<aTTRIBUTE name="Connector number" type="INTEGER">29</aTTRIBUTE>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 2 x1:29cm y1:14cm x2:34.5cm y2:14cm index:58</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16829" class="belongs to">
+<fROM instance="Amministrazione" class="Role"></fROM>
+<tO instance="SUAP Office" class="Organizational unit"></tO>
+<aTTRIBUTE name="Connector number" type="INTEGER">30</aTTRIBUTE>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 2 x1:42.5cm y1:14cm x2:34.5cm y2:14cm index:60</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16830" class="Has role">
+<fROM instance="Francesca Freschi" class="Performer"></fROM>
+<tO instance="Responsabile Ufficio SUAP" class="Role"></tO>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 0 index:75</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">31</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16831" class="Is manager">
+<fROM instance="Francesca Freschi" class="Performer"></fROM>
+<tO instance="SUAP Office" class="Organizational unit"></tO>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 0 index:108</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">0</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16832" class="Has role">
+<fROM instance="Geometra1" class="Performer"></fROM>
+<tO instance="Geometra" class="Role"></tO>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 2 x1:32cm y1:18.5cm x2:34.5cm y2:18.5cm index:67</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">32</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16833" class="Has role">
+<fROM instance="Amministrativo2" class="Performer"></fROM>
+<tO instance="Amministrazione" class="Role"></tO>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 0 index:73</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">33</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16834" class="Has role">
+<fROM instance="Geometra2" class="Performer"></fROM>
+<tO instance="Geometra" class="Role"></tO>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 0 index:68</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">34</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16835" class="Has role">
+<fROM instance="Geometra3" class="Performer"></fROM>
+<tO instance="Geometra" class="Role"></tO>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 2 x1:37cm y1:18.5cm x2:34.5cm y2:18.5cm index:69</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">35</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16836" class="Has role">
+<fROM instance="Amministrativo1" class="Performer"></fROM>
+<tO instance="Amministrazione" class="Role"></tO>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 2 x1:40cm y1:18cm x2:42.5cm y2:18cm index:72</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">36</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16837" class="Has role">
+<fROM instance="Amministrativo3" class="Performer"></fROM>
+<tO instance="Amministrazione" class="Role"></tO>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 2 x1:45cm y1:18cm x2:42.5cm y2:18cm index:74</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">37</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16838" class="Is subordinated">
+<fROM instance="Ufficio Attività Economiche" class="Organizational unit"></fROM>
+<tO instance="Area Turismo Promozione e Sviluppo Econmico" class="Organizational unit"></tO>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 2 x1:48.5cm y1:10cm x2:39.5cm y2:10cm index:78</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Representation" type="ENUMERATION">with arrow</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16839" class="Is subordinated">
+<fROM instance="Ufficio Sviluppo Economico" class="Organizational unit"></fROM>
+<tO instance="Area Turismo Promozione e Sviluppo Econmico" class="Organizational unit"></tO>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 2 x1:52cm y1:10cm x2:39.5cm y2:10cm index:79</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Representation" type="ENUMERATION">with arrow</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16840" class="belongs to">
+<fROM instance="Responsabile Ufficio Tributi Economato" class="Role"></fROM>
+<tO instance="Ufficio Attività Economiche" class="Organizational unit"></tO>
+<aTTRIBUTE name="Connector number" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 0 index:81</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16841" class="Has role">
+<fROM instance="Perini Rosanna" class="Performer"></fROM>
+<tO instance="Responsabile Ufficio Tributi Economato" class="Role"></tO>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 0 index:83</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">0</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16842" class="belongs to">
+<fROM instance="Responsabile Ufficio Sviluppo Economico" class="Role"></fROM>
+<tO instance="Ufficio Sviluppo Economico" class="Organizational unit"></tO>
+<aTTRIBUTE name="Connector number" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 0 index:87</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16843" class="Has role">
+<fROM instance="Laura Sorellini" class="Performer"></fROM>
+<tO instance="Responsabile Ufficio Sviluppo Economico" class="Role"></tO>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 0 index:86</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">0</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16844" class="Is subordinated">
+<fROM instance="Ufficio Tributi e Canoni" class="Organizational unit"></fROM>
+<tO instance="Area Organizzativa e Risorse Finanziarie" class="Organizational unit"></tO>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 2 x1:58.5cm y1:10cm x2:57cm y2:10cm index:93</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Representation" type="ENUMERATION">with arrow</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16845" class="belongs to">
+<fROM instance="Responsabile Ufficio Tributi e Canoni" class="Role"></fROM>
+<tO instance="Ufficio Tributi e Canoni" class="Organizational unit"></tO>
+<aTTRIBUTE name="Connector number" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 0 index:91</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16846" class="Has role">
+<fROM instance="Gabriele Paoletti" class="Performer"></fROM>
+<tO instance="Responsabile Ufficio Tributi e Canoni" class="Role"></tO>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 0 index:92</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">0</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16847" class="belongs to">
+<fROM instance="Responsabile Area Organizzativa e Risorse Finanziarie" class="Role"></fROM>
+<tO instance="Area Organizzativa e Risorse Finanziarie" class="Organizational unit"></tO>
+<aTTRIBUTE name="Connector number" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 2 x1:55.5cm y1:10cm x2:57cm y2:10cm index:97</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16848" class="Has role">
+<fROM instance="Fiorenzi Laura" class="Performer"></fROM>
+<tO instance="Responsabile Area Organizzativa e Risorse Finanziarie" class="Role"></tO>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 0 index:96</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">0</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16849" class="belongs to">
+<fROM instance="Responsabile Area Persona" class="Role"></fROM>
+<tO instance="Area Persona" class="Organizational unit"></tO>
+<aTTRIBUTE name="Connector number" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 2 x1:61.5cm y1:10cm x2:62.5cm y2:10cm index:99</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16850" class="Is subordinated">
+<fROM instance="Ufficio Politiche Sociali e Integrazioni Socio Sanitarie" class="Organizational unit"></fROM>
+<tO instance="Area Persona" class="Organizational unit"></tO>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 2 x1:65cm y1:10cm x2:62.5cm y2:10cm index:101</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Representation" type="ENUMERATION">with arrow</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16851" class="Has role">
+<fROM instance="Maurizio Mandolini" class="Performer"></fROM>
+<tO instance="Responsabile Area Persona" class="Role"></tO>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 0 index:103</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">0</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16852" class="belongs to">
+<fROM instance="Responsabile Ufficio Politiche Sociali e Integrazioni Socio Sanitarie" class="Role"></fROM>
+<tO instance="Ufficio Politiche Sociali e Integrazioni Socio Sanitarie" class="Organizational unit"></tO>
+<aTTRIBUTE name="Connector number" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 0 index:105</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16853" class="Has role">
+<fROM instance="Giuseppina Campolini" class="Performer"></fROM>
+<tO instance="Responsabile Ufficio Politiche Sociali e Integrazioni Socio Sanitarie" class="Role"></tO>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 0 index:107</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">0</aTTRIBUTE>
+</cONNECTOR>
+</mODEL>
+<mODEL id="mod.16579" name="Org Model Monti Azzurri" version="" modeltype="Organizational structure" libtype="we" applib="LearnPAd Prototype Static Library 0.21">
+<mODELATTRIBUTES>
+<aTTRIBUTE name="Contact person" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Keywords" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Copyright info" type="STRING">Edit the model attributes to display your copyright info</aTTRIBUTE>
+<aTTRIBUTE name="Copyright info position" type="ENUMERATION">Bottom right</aTTRIBUTE>
+<aTTRIBUTE name="Model type" type="ENUMERATION">Current model</aTTRIBUTE>
+<aTTRIBUTE name="State" type="ENUMERATION">In process</aTTRIBUTE>
+<aTTRIBUTE name="Reviewed on" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Reviewed by" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Author" type="STRING">barbara</aTTRIBUTE>
+<aTTRIBUTE name="Creation date" type="STRING">13.08.2015, 15:04</aTTRIBUTE>
+<aTTRIBUTE name="Last user" type="STRING">congyu</aTTRIBUTE>
+<aTTRIBUTE name="Date last changed" type="STRING">03.09.2015, 15:24:47</aTTRIBUTE>
+<aTTRIBUTE name="Number of objects and relations" type="INTEGER">28</aTTRIBUTE>
+<aTTRIBUTE name="Context of version" type="STRING"></aTTRIBUTE>
+<rECORD name="Change history"></rECORD>
+<aTTRIBUTE name="Position" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-01] Internal error!  \&quot;fontcolor\&quot; (WEModel)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<rECORD name="Technical Attributes"></rECORD>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Keine Modellbezeichnung vergeben</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Pool Term" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="ParticipantType" type="ENUMERATION">Role</aTTRIBUTE>
+<aTTRIBUTE name="Role" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Entity" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="BoundaryVisible" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="BPD Model Attributes" type="STRING">NOTEBOOK
+
+CHAPTER &quot;Business Process Diagram Attributes&quot;
+ATTR &quot;Name&quot; write-protected
+ATTR &quot;Contact person&quot;
+ATTR &quot;Author&quot; write-protected
+ATTR &quot;Language (BPMN)&quot;
+ATTR &quot;ExpressionLanguage&quot;
+ATTR &quot;QueryLanguage&quot;
+ATTR &quot;Creation date&quot; write-protected
+ATTR &quot;Date last changed&quot; write-protected
+ATTR &quot;Documentation (Model)&quot;
+ATTR &quot;State&quot;
+
+GROUP &quot;Copyright&quot;
+ATTR &quot;Copyright info&quot; 
+ATTR &quot;Copyright info position&quot; 
+ENDGROUP
+
+CHAPTER &quot;Process Attributes&quot;
+ATTR &quot;Name&quot; write-protected
+ATTR &quot;Process Term&quot;
+ATTR &quot;ProcessType&quot;
+ATTR &quot;Status&quot;
+ATTR &quot;Assignments&quot; lines:5
+ATTR &quot;Properties (BPMN)&quot; lines:5
+ATTR &quot;AdHoc&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+GROUP &quot;AdHoc = True&quot;
+ATTR &quot;AdHocOrdering&quot;
+ATTR &quot;AdHocCompletionCondition&quot;
+ENDGROUP
+ATTR &quot;SuppressJoinFailure&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ATTR &quot;EnableInstanceCompensation&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ATTR &quot;Categories (Process)&quot;
+ATTR &quot;Documentation (Process)&quot;
+
+CHAPTER &quot;Pool Attributes&quot;
+GROUP &quot;Common Graphical Object Attributes&quot;
+ATTR &quot;Name&quot; write-protected
+ATTR &quot;Categories (Pool)&quot;
+ATTR &quot;Documentation (Pool)&quot;
+ENDGROUP
+GROUP &quot;Common Swimlane Attributes&quot;
+ATTR &quot;Pool Term&quot;
+ENDGROUP
+GROUP &quot;Pool Attributes&quot;
+ATTR &quot;ParticipantType&quot;
+ATTR &quot;Role&quot;
+ATTR &quot;Entity&quot;
+ATTR &quot;BoundaryVisible&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot; write-protected
+ENDGROUP</aTTRIBUTE>
+<aTTRIBUTE name="Language" type="ENUMERATION">System</aTTRIBUTE>
+<aTTRIBUTE name="ExpressionLanguage" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="QueryLanguage" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Process Term" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="BPD Term" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="ProcessType" type="ENUMERATION">None</aTTRIBUTE>
+<aTTRIBUTE name="Status" type="ENUMERATION">None</aTTRIBUTE>
+<rECORD name="Assignments"></rECORD>
+<aTTRIBUTE name="AdHoc" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="AdHocOrdering" type="ENUMERATION">None</aTTRIBUTE>
+<aTTRIBUTE name="AdHocCompletionCondition" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="EnableInstanceCompensation" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Categories (Process)" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation (Process)" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation (Pool)" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Categories (Pool)" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="SuppressJoinFailure" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="RACI/DEMI visualisation" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Modelling direction" type="ENUMERATION">vertical</aTTRIBUTE>
+<aTTRIBUTE name="IT systems" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Responsible role" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Input/Output" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Products" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Use cases" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Products color" type="STRING">whitesmoke</aTTRIBUTE>
+<aTTRIBUTE name="RACI/DEMI color" type="STRING">whitesmoke</aTTRIBUTE>
+<aTTRIBUTE name="Responsible role color" type="STRING">whitesmoke</aTTRIBUTE>
+<aTTRIBUTE name="Input/Output color" type="STRING">whitesmoke</aTTRIBUTE>
+<aTTRIBUTE name="Use cases color" type="STRING">whitesmoke</aTTRIBUTE>
+<aTTRIBUTE name="IT systems color" type="STRING">whitesmoke</aTTRIBUTE>
+<aTTRIBUTE name="_ToggleModelInfo_" type="PROGRAMCALL">ITEM &quot;_ToggleModelInfo_&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Display modelling information" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Documentation (Model)" type="STRING"></aTTRIBUTE>
+<rECORD name="Properties (BPMN)"></rECORD>
+<aTTRIBUTE name="CreationDate" type="EXPRESSION">EXPR val:&quot;13.08.2015, 15:04&quot;</aTTRIBUTE>
+<aTTRIBUTE name="ModificationDate" type="EXPRESSION">EXPR val:&quot;03.09.2015, 08:23:29&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Language (BPMN)" type="STRING">English</aTTRIBUTE>
+<aTTRIBUTE name="BPMN20 Model Attributes" type="LONGSTRING">NOTEBOOK
+# TODO AVAL sMfbRegistration:&quot;_MFB-Registration_&quot;
+CHAPTER &quot;Description&quot;
+ATTR &quot;Contact person&quot;
+ATTR &quot;Keywords&quot; lines:2
+ATTR &quot;Description&quot; lines:3
+ATTR &quot;Comment&quot; lines:3
+
+GROUP &quot;Copyright&quot;
+ATTR &quot;Copyright info&quot; 
+ATTR &quot;Copyright info position&quot; 
+ENDGROUP
+ATTR &quot;Name&quot; write-protected
+ATTR &quot;Id&quot; write-protected
+
+
+
+#---------------------------------------------
+CHAPTER &quot;Process properties&quot;
+#---------------------------------------------
+GROUP &quot;Process attributes&quot;
+ATTR &quot;Process type&quot; #None, Private, Public 
+ATTR &quot;Executable&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ATTR &quot;Closed&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ENDGROUP
+
+GROUP &quot;Process relevance&quot;
+ATTR &quot;Auditing&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ATTR &quot;Monitoring&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ENDGROUP
+
+CHAPTER &quot;User attributes&quot;
+ATTR &quot;Model type&quot;
+ATTR &quot;State&quot;
+ATTR &quot;Reviewed on&quot;
+ATTR &quot;Reviewed by&quot;
+
+CHAPTER &quot;System attributes&quot;
+ATTR &quot;Author&quot; write-protected
+ATTR &quot;Creation date&quot; write-protected
+ATTR &quot;Last user&quot; write-protected
+# ATTR &quot;Date last changed from&quot; write-protected
+ATTR &quot;Date last changed&quot; write-protected
+ATTR &quot;Number of objects and relations&quot; write-protected
+ATTR &quot;Context of version&quot; write-protected
+
+CHAPTER &quot;People-like view&quot;
+ATTR &quot;Action&quot;
+ATTR &quot;People-like view&quot;
+
+CHAPTER &quot;BAR Display&quot;
+ATTR &quot;BAR Display active&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot;
+AVAL s_Aktiv: &quot;BAR Display active&quot;
+ATTR &quot;Modelling direction&quot; ctrltype: radio enabled: (s_Aktiv = &quot;Yes&quot;)
+ATTR &quot;Modelling_size&quot;
+
+GROUP &quot;Responsible for execution&quot;
+ATTR &quot;Responsible for execution_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_Responsible_for_execution_display: &quot;Responsible for execution_display&quot;
+ATTR &quot;Responsible for execution_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_Responsible_for_execution_display = &quot;Yes&quot;))
+ATTR &quot;Responsible for execution_size&quot;
+ENDGROUP
+
+GROUP &quot;Accountable for approving results&quot;
+ATTR &quot;Accountable for approving results_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_Accountableforapprovingresults_display: &quot;Actor_display&quot;
+ATTR &quot;Accountable for approving results_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_Accountableforapprovingresults_display = &quot;Yes&quot;))
+ATTR &quot;Accountable for approving results_size&quot;
+ENDGROUP
+
+GROUP &quot;Cooperation/participation&quot;
+ATTR &quot;Cooperation/participation_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_Cooperationparticipation_display: &quot;Cooperation/participation_display&quot;
+ATTR &quot;Cooperation/participation_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_Cooperationparticipation_display = &quot;Yes&quot;))
+ATTR &quot;Cooperation/participation_size&quot;
+ENDGROUP
+
+GROUP &quot;To inform&quot;
+ATTR &quot;To inform_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_Toinform_display: &quot;To inform_display&quot;
+ATTR &quot;To inform_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_Toinform_display = &quot;Yes&quot;))
+ATTR &quot;To inform_size&quot;
+ENDGROUP
+
+GROUP &quot;Knowledge Product&quot;
+ATTR &quot;Knowledge Product_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_KnowledgeProduct_display: &quot;Knowledge Product_display&quot;
+ATTR &quot;Knowledge Product_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_KnowledgeProduct_display = &quot;Yes&quot;))
+ATTR &quot;Knowledge Product_size&quot;
+ENDGROUP
+
+GROUP &quot;Documents and Resources&quot;
+ATTR &quot;Documents and Resources_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_DocumentsandResources_display: &quot;Documents and Resources_display&quot;
+ATTR &quot;Documents and Resources_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_DocumentsandResources_display = &quot;Yes&quot;))
+ATTR &quot;Documents and Resources_size&quot;
+ENDGROUP
+
+GROUP &quot;Incoming Data Object&quot;
+ATTR &quot;Incoming Data Object_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_IncomingDataObject_display: &quot;Incoming Data Object_display&quot;
+ATTR &quot;Incoming Data Object_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_IncomingDataObject_display = &quot;Yes&quot;))
+ATTR &quot;Incoming Data Object_size&quot;
+ENDGROUP
+
+GROUP &quot;Outgoing Data Object&quot;
+ATTR &quot;Outgoing Data Object_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_OutgoingDataObject_display: &quot;Outgoing Data Object_display&quot;
+ATTR &quot;Outgoing Data Object_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_OutgoingDataObject_display = &quot;Yes&quot;))
+ATTR &quot;Outgoing Data Object_size&quot;
+ENDGROUP
+
+GROUP &quot;Description&quot;
+ATTR &quot;Description_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_Description_display: &quot;Description_display&quot;
+ATTR &quot;Description_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_Description_display = &quot;Yes&quot;))
+ATTR &quot;Description_size&quot;
+ENDGROUP
+
+CHAPTER &quot;Comment View&quot;
+ATTR &quot;Comment Mode&quot; ctrltype: check checked-value: &quot;No&quot; unchecked-value: &quot;Yes&quot;
+AVAL s_Aktiv: &quot;Comment Mode&quot;
+ATTR &quot;CommentAreaSize&quot;
+ATTR &quot;CommentModellingAreaSize&quot;
+ATTR &quot;CommentModellingDirection&quot;
+
+
+
+
+CHAPTER &quot;Change history&quot;
+ATTR &quot;Change history&quot; lines:30
+
+</aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;90409&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Auditing" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Monitoring" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Process type" type="ENUMERATION">None</aTTRIBUTE>
+<aTTRIBUTE name="Executable" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Closed" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="_GoToAceHp_" type="PROGRAMCALL">ITEM &quot;_GoToAceHp_&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="__GfxThumb__" type="LONGSTRING">iVBORw0KGgoAAAANSUhEUgAAAJcAAAEACAIAAAAx6XNhAAAACXBIWXMAAAsTAAALEwEAmpwYAAAOx0lEQVR4nO2dX2xb1RnAP9OKipc9oQ4KKXRLWtYFDbXQ4tMWUB/YSkfVScMFbZpRFU7RxJZqIxtTuw02HiaFbNdDgwUJqhamLRajSaZeTTCGBk1LJpEVYkyT6ykLbdUWkXUPTEvNPT57ONeOY1/b97+dz9/vobJv7vnO5/u755x763N8Y1LKixcvjo+PAxEC8/PziUQi7Fpis7Ozp06duu3WW//y+uszMzMAsGzZsmXLlq1cufKObXdcueJKAFh97bUOw314/jwA5HK57du2hZGuiu8qpUYBLxQDXhNIQCvsBSvPU/84FYXIkZGR01NTL7300vtVHDly5PTUlMznZT5rZLNavEfPZ7V4nI9mZX6UA0A8ziDOegaMfFbrGTDyeZnPj4+Py3xWiwMbGNVHBzioUsAGiqUAAOJaNl/cbYBDnMWtLUY2q8UB4ipmD4/H+eioPpqV+ayRzct8/vTUlCoIEGdx4KOjHMpSgh49ryKrxPLFnYGPWllpixMuBlQ5qBc9usqkp4fHe/hAD7e2FCPHi7X0WH+yYlrb8zKfn5qampqaGhkZGRoakiETGxkZueGGG2ZnZy9durRixYqS3cuXL69cuXLVqlVfWr/e1WnxQS73hc7OQM4wW97NZt2mFHHAUlgAmJ2djaAtLgeA+fn51atXL1++XAgRi8WuuOIKALjqqqs6OjrmPp4bf2di88YNDsONT0wAwJkLFzquCbKDqog/PjGxeYPTlCIOqHh7YiLAaA2JSSlHR0ejrLLdiKgt7tq1K51Oh1oNESoxKWWzcyD8srzZCRABQBYxQBYxQBYxQBYxQBYxQBYxQBYxQBYxQBYxQBYxQBYxQBYxsMQsZjKZm2++2UNB3F/dLDGLhC1Lz2I+n5dSFgoFNXFIvSj/t/rtpUuXmp11uCw9i24VFgqFZqccOkvDYiwWGxoaUrNX3CosHxHL42AimBkbsVjMfxAnDA0N3Xvvva4UFgqFTz75xNs1kavEmnhyBNAW1QnuP04d9uzZU6rCrUJ1mkop0+l0eZxg0ws8pisC61FDPRMTiUQ6nU4kEplMxq3C0riYSCRKcYJND4/FUClv7m4VVgwZ+AZFaLpF5wPqnj17VH/Y0dHhSiHu+31FMy06H1Btx0WHCulOIwqcdHHl4+LZs2cjyGpp0XyLDlGyu7u7m51IK7JkLJaRS23pSie07v3pDIPE4bHezlwuB8eSXftBM8Z2HtvXn81k4ODB3dC1Ywfkcp1hLsRrDaRvAMDbQkvPBVuNpn+QpdgWiUrIIgbIIgbIIgbIIgbIIgbIYgBIKZv7wwhk0SmZTKbOX9evX19rhwj+v4ksusDDhIHJyckwMqmALLqgZaffkUUXuFUY2ZdiZNEFfqbfhQpZdIFbhdQWWxG3CqkttiKep9+FDVl0gVuF1BZbEbcKyWIr4lYh9aitSMtOvyOLTmnl6Xdk0TPlU/G6D44N7oBcakv/2rHBHZGnQhY909k7JnsBoLe3bMtgU1Ihixggixggi96xXV/elEXnZNEjtmv2IlsZXwFZ9IiUstqZ7cYIIIsYIIsYIIsYIIsYIIuV+L88UT8kUWeHwG9FyOIi/P8Ck2w0TzyMH8chizb4bCj1i5NFwh6yiAGyuIiGo1prVtHuFqsXOtVZ/VSi4ff+ES+waneL4S2DinKBVbtbnJycXLdune0ktlqz3Bwug4pygVW7W4Qa8/b9T9p3q9DPtEeyaDNvP5BJ+1EusCKL9dqin0n7bhVSW/SFK4XOj7VbhdQWfeFKofNjHeUCK7LY+HAH0hYD7KurIYsNDncgbdFJFWTRF64UemiLDhVSj+qLc+fOhRE2ygVW7W4xpJVQUS+wkr6BJf6L0zovHQymGVJKQ2PANF3XDSkNXeeMaYbUOXDdaUhDYwDAuFXW0Bhw3dAY16Wh6xoHrlu1qCp0T7UsQBYx0O49Kg7IIgr8N2dY4j2qOg4VmVRsCTtVn/HbvS2q2adhPz/SCWpunLfpd+1uURZXOVUfvvLDWme3VqDdLdaZRhxlA5XFR7WCpxOlrS2WFNY6cFG2vEQi4XnCcVtbVDhUFUGn6rmK9rUYwUOxI6NNLTbsS21p2ebYphYVrXnB6YF2tIipL1W0nUVvfWmJaDrV0kKOw+9cFELs3bSqfpG2s6ho8b40kUj87t2PTVP89fhJAJi/fIspzO/eVfPBvO1lcan0pcl9Xz7y3KvFdw+c0+A6gOS7mcO9u233927RYWNvOtV5+myIYXeqydTw9i9+9l/auW9sEqYpzBM/+sN/v9C9UZhCJFPDtiK9WKxo7Kk3DPhowlWEocx/TGF+SzsKkH/u5BnTFN/edqOHTFzlaQpTOlg7GE1u9RFSvrn/ujetd3v2/lmYQghT1No/Jl1OoEumhtWLLZs2mqYYnzil3tZq7HUi3BnfZAox9vd33EYIL0+HuYX3k33J1PCd8U3m8R+8WHjyvlvNzFNdk7e/v2uDEKYwhWkKcebc+eqP4K4tJlPD22OvPNj7IgAcAQC4/6HXHu8S9Rp7dYS7lx/95iNHihEeePiNn601XUQIL89kavjuu7aaf/veg70vHrG2WQUrSoXaqZpCmIVCQZjCFF3f+e2pr/z09MiBNcI0hTBrNEfXPaqQctvAh/ffJkxhihMH02+LNRvqNXa7LOUd5Z3+CfG5jcIULiKEl6dpCtuCweZWh8O9u5Op4Y1CSiFMIUzBtvY886vfvHngoc2mKc5f/MjvuFhs7C+/9f3Vb1nb7nvwmNXYO667tmFjSqaGt2+Ni+N/tO3016y+PpDm6C1PKzchTCGrC1bnFmpzFBsf/5qwDstn7nn+gBCmKUTtE91dW1SNnf3C+PpGkfnlTZO3//jzxf66VmOvzE8IU8it/TPFTv8nnWKh03eVTOB5CnX61ygYVG4NUc1RvV6z+no1Fpb+ZFvEhcWKxt75yDPv7Xzig1ceWyNEncZeHWFzjU7fdtz2gLc8rdw23GLaFQwqN+cfQb1QOhtW7X5cFFIWVGOPx/c++/Szx3+4d1Odxl6NWaPTd5tJGHmawrQtaLtzBP8b5/DU8X6n4bCx14nQteZGU5gzH551GyG8PN3mFtwtRy61pWv/Ca7Lvul9/dkM7B7bPRx7MsO6D471Te/rX9vXN51MwuGD2a7h3bLykR2uLZZw2NhDjRBeLQ5LNeW33m3S8GyRULSEyFoTVa01KIxruiGlzoFphqExxnVDSkPj1iISpi2sHQFgXNfVmhLDqA65eH8OAFyXOgfGahZxQe1FM2rdjM4YY6DWu1TUpJJXWXHOFmWlca4bhsaYZtgvhYHAJhwvHEPD0DnjnKn61GG3jpvtUaK26JdWaIvt9c1UGMgWmHBMFlsKdaXKuJ6Ae9IZ3n2wrw8MY3p4eufgTsh1dtb6nthzLw6+xwP/EYKqpTimWmO/ZqhtjC+MqQ2WiEbzWWrhsS36/4n0aJ4B47CWHYNSlp65NzZW3Fa6K+scG9sBAGVbWguPFqXvR/H4j9A6tQRBLrUlmQaAbtWLHhu+J23d8i96Vmdfl22/6qch++9DoumFPNQC7ntID0WCwtfVjf+rsmiu65r+fyth492i//ukaO60WuF+LmzoTsMe6f432mUIN44OT0HvFj18zsAjhFrLUmq+TRmNWx/wdKnirVR9nASku/4gS/kp6CcajYv2yEh6+6CgcbEmrbCoymnyQbV9ZICPjtFPWY81eiwG4DPX0mkU9m86eaulRSw6TJ7GRXukj95eRv6NI1msiWcH0a+SbGCxzhcCKlHbHeTiWSC1gpQ+avUO0v08kmBrcfX/drZV1386scNDBA6Ps5N+2S3+g3geQoKqBdyMbf6r9hChPEjj41X/AwPAmVdTADBz9Ilc+rFae9YJAgBnXvu12uGfLx8wfv9o/eMbap7luLXYsGoA8HaIZJlm2/wDsFj/LGsYpP5Z5pxA8qwookSq/Wu9hmKn57NqP/kHYHHm6BNqn9OHHvZmcWbk56XkPnj+oZAsOsmzglJzHBoasn3t0GKp6kAsVucfwDWq+PR/6kXh03lvEcoLeg7SEA95lq5uyi9zyl9LZzckpaoDoTr/xrOK1dVRrd0cXvjVCeLkKtcJgeTpjbAPUcMgfttieSxv85Qq8g5pspP/PAOp2nPt9fOnu/6oee/p+wKPSes0UFDnCq0MQ2OMMWCatSRKY2pJkVpL5eK5OjoHgIWy3FqQ5eWxPIvTg/IVWxpjjDHGNWPhr2q1lF62PErzt0jLvt7ia1k6aAursbi1aKu4Q2Wc0mFh1tKtUpCKY155uKgtYoDGRQyQRRQ4HQA452qsKS4tZowxziuX5dYcP0rDqlrpqyJAcTmxwnahL9EYGhcxQD0qBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiCiRhYWgMAIBphnqr67rGGGNcl4bG1HZDYxaaoYowruu6rmuaZhjWX7kqyFUgFUcF4brUOeOcAUBpSykm16WhabqUhsY5X6iaMY1zsN7quiGlzoExtSfjUsqYlLLJ5xHhG+pRUdC8HoyQUs5prB/gEGP9XJ/mcIjrc1JOc+gH+JNu7XCI8ZPGws79XJ/TWD/TpjV+0pBzknpUHFCPigGyiAGy2FL8O7Xlhf0nAAC4vrevC44lX9h/4iZdrhuOjWX41d1wdd/gWsjN9XeNgb5rcMfcvtjUoPwqjYutRSz2lNsiUj5KFjHwf1Pz/biDycooAAAAAElFTkSuQmCC</aTTRIBUTE>
+<aTTRIBUTE name="NT Model Attributes" type="LONGSTRING">NOTEBOOK
+CHAPTER &quot;Description&quot;
+#ATTR &quot;Shared&quot;
+ATTR &quot;Model state&quot; enabled:(cond(search (sMfbRegistration, &quot;MFB_VERS&quot;, 0) = -1, 1, 0))
+ATTR &quot;Description&quot;
+ATTR &quot;Show State&quot; ctrltype:check unchecked-value:&quot;No&quot; checked-value:&quot;Yes&quot; 
+ATTR &quot;Last user&quot; write-protected
+ATTR &quot;Date last changed&quot; write-protected
+#CHAPTER &quot;Suggestion for improvement&quot;
+#ATTR &quot;Suggestion for improvement&quot;
+</aTTRIBUTE>
+<aTTRIBUTE name="Model state" type="ENUMERATION">Draft</aTTRIBUTE>
+<aTTRIBUTE name="People-like view" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Action" type="ENUMERATION">Fill in</aTTRIBUTE>
+<aTTRIBUTE name="Keywords" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Description" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Model type" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Show State" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="BAR Display active" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Actor_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="Actor_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Actor_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="Description_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="Description_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Description_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="ModelingAreaSize" type="ENUMERATION">20</aTTRIBUTE>
+<aTTRIBUTE name="Modelling_size" type="ENUMERATION">3</aTTRIBUTE>
+<aTTRIBUTE name="DrawingAreaWidth" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="DrawingAreaHeight" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Reference overview settings" type="LONGSTRING">Responsible for execution|Responsible for execution
+Accountable for approving results|Accountable for approving results
+Cooperation/participation|Cooperation/participation
+To inform|To inform
+Modelling|Modelling
+Knowledge Product|Knowledge Product
+Documents and Resources|Documents and Resources
+#Data Object|Data Object
+Incoming Data Object|Incoming Data Object
+Outgoing Data Object|Outgoing Data Object
+Description|Description</aTTRIBUTE>
+<aTTRIBUTE name="Data Object_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="Data Object_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Data Object_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="Knowledge Product_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="Knowledge Product_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Knowledge Product_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="Documents and Resources_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Documents and Resources_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="Documents and Resources_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="Responsible for execution_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="Responsible for execution_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Responsible for execution_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="Accountable for approving results_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="Accountable for approving results_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Accountable for approving results_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="Cooperation/participation_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="Cooperation/participation_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Cooperation/participation_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="To inform_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="To inform_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="To inform_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="Incoming Data Object_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="Incoming Data Object_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Incoming Data Object_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="Outgoing Data Object_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="Outgoing Data Object_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Outgoing Data Object_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="id_bpmndi_diagram" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="id_bpmndi_plane" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="id_bpmndi_collaboration" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="CommentModellingAreaSize" type="ENUMERATION">3</aTTRIBUTE>
+<aTTRIBUTE name="CommentTypeSize" type="ENUMERATION">8</aTTRIBUTE>
+<aTTRIBUTE name="CommentAreaSize" type="ENUMERATION">2</aTTRIBUTE>
+<aTTRIBUTE name="Comment Mode" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="CommentxCoorTextBox" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="CommentyCoorTextBox" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="CommentModellingDirection" type="ENUMERATION">vertical</aTTRIBUTE>
+</mODELATTRIBUTES>
+<iNSTANCE id="obj.16580" class="Organizational unit" name="Agriculture Office">
+<aTTRIBUTE name="Position" type="STRING">NODE x:16.5cm y:10.5cm index:1</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Model reference"></iNTERREF>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Organisationseinheit</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Submodelname" type="EXPRESSION">EXPR val:&quot;Bezeichnung&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Type" type="ENUMERATION">Standard</aTTRIBUTE>
+<aTTRIBUTE name="Functional unit" type="ENUMERATION">no</aTTRIBUTE>
+<aTTRIBUTE name="Manager" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Function" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Level" type="INTEGER">0</aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16583" class="Organizational unit" name="SUAP Office">
+<aTTRIBUTE name="Position" type="STRING">NODE x:12.5cm y:10.5cm index:2</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Model reference"></iNTERREF>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Organisationseinheit</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Submodelname" type="EXPRESSION">EXPR val:&quot;Bezeichnung&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Type" type="ENUMERATION">Standard</aTTRIBUTE>
+<aTTRIBUTE name="Functional unit" type="ENUMERATION">no</aTTRIBUTE>
+<aTTRIBUTE name="Manager" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Function" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Level" type="INTEGER">0</aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16586" class="Role" name="SUAP Officer">
+<aTTRIBUTE name="Position" type="STRING">NODE x:10cm y:14.5cm index:3</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Rolle</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16589" class="Performer" name="Barnaby Barnes">
+<aTTRIBUTE name="Position" type="STRING">NODE x:10cm y:18.5cm index:4</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Hourly wages" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Calendar" type="LONGSTRING">B@Working day@b@32400-43200@T@45000-59400@T@Free day@c@@@$cbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbcbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbcbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbcccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbccbbccb</aTTRIBUTE>
+<aTTRIBUTE name="Availability" type="EXPRESSION">EXPR expr:(round(paval(&quot;Presence&quot;,&quot;Hours per day&quot;)*paval(&quot;Presence&quot;,&quot;Days per week&quot;)/40*100)) val:100</aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Time dependent costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Info on results" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Workload" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Capacity" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Personnel costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Bearbeiter</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<rECORD name="Further education"></rECORD>
+<aTTRIBUTE name="Presence" type="ATTRPROFREF"></aTTRIBUTE>
+<aTTRIBUTE name="E-Mail" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16592" class="Organizational unit" name="Monti Azzurri">
+<aTTRIBUTE name="Position" type="STRING">NODE x:9cm y:3.5cm index:7</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Model reference"></iNTERREF>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Organisationseinheit</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Submodelname" type="EXPRESSION">EXPR val:&quot;Bezeichnung&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Type" type="ENUMERATION">Standard</aTTRIBUTE>
+<aTTRIBUTE name="Functional unit" type="ENUMERATION">no</aTTRIBUTE>
+<aTTRIBUTE name="Manager" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Function" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Level" type="INTEGER">0</aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16595" class="Role" name="Secretary General">
+<aTTRIBUTE name="Position" type="STRING">NODE x:2.5cm y:14.5cm index:11</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Rolle</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16598" class="Role" name="President">
+<aTTRIBUTE name="Position" type="STRING">NODE x:5.5cm y:14.5cm index:12</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Rolle</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16601" class="Organizational unit" name="Area 3">
+<aTTRIBUTE name="Position" type="STRING">NODE x:14.5cm y:6.5cm index:13</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Model reference"></iNTERREF>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Organisationseinheit</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Submodelname" type="EXPRESSION">EXPR val:&quot;Bezeichnung&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Type" type="ENUMERATION">Standard</aTTRIBUTE>
+<aTTRIBUTE name="Functional unit" type="ENUMERATION">no</aTTRIBUTE>
+<aTTRIBUTE name="Manager" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Function" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Level" type="INTEGER">0</aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16604" class="Role" name="Responsible Agriculture, Forestry, Environment">
+<aTTRIBUTE name="Position" type="STRING">NODE x:18.5cm y:14cm index:17</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Rolle</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16607" class="Performer" name="Emanuele Laurenzi ">
+<aTTRIBUTE name="Position" type="STRING">NODE x:2.5cm y:18.5cm index:21</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Hourly wages" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Calendar" type="LONGSTRING">B@Working day@b@32400-43200@T@45000-59400@T@Free day@c@@@$cbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbcbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbcbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbcccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbccbbccb</aTTRIBUTE>
+<aTTRIBUTE name="Availability" type="EXPRESSION">EXPR expr:(round(paval(&quot;Presence&quot;,&quot;Hours per day&quot;)*paval(&quot;Presence&quot;,&quot;Days per week&quot;)/40*100)) val:100</aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Time dependent costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Info on results" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Workload" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Capacity" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Personnel costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Bearbeiter</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<rECORD name="Further education"></rECORD>
+<aTTRIBUTE name="Presence" type="ATTRPROFREF"></aTTRIBUTE>
+<aTTRIBUTE name="E-Mail" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16610" class="Performer" name="Sandro Emmenegger">
+<aTTRIBUTE name="Position" type="STRING">NODE x:5.5cm y:18.5cm index:24</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Hourly wages" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Calendar" type="LONGSTRING">B@Working day@b@32400-43200@T@45000-59400@T@Free day@c@@@$cbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbcbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbcbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbcccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbccbbccb</aTTRIBUTE>
+<aTTRIBUTE name="Availability" type="EXPRESSION">EXPR expr:(round(paval(&quot;Presence&quot;,&quot;Hours per day&quot;)*paval(&quot;Presence&quot;,&quot;Days per week&quot;)/40*100)) val:100</aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Time dependent costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Info on results" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Workload" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Capacity" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Personnel costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Bearbeiter</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<rECORD name="Further education"></rECORD>
+<aTTRIBUTE name="Presence" type="ATTRPROFREF"></aTTRIBUTE>
+<aTTRIBUTE name="E-Mail" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16613" class="Performer" name="Congyu Zhang">
+<aTTRIBUTE name="Position" type="STRING">NODE x:18.5cm y:18.5cm index:27</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Hourly wages" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Calendar" type="LONGSTRING">B@Working day@b@32400-43200@T@45000-59400@T@Free day@c@@@$cbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbcbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbcbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbcccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbccbbccb</aTTRIBUTE>
+<aTTRIBUTE name="Availability" type="EXPRESSION">EXPR expr:(round(paval(&quot;Presence&quot;,&quot;Hours per day&quot;)*paval(&quot;Presence&quot;,&quot;Days per week&quot;)/40*100)) val:100</aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Time dependent costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Info on results" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Workload" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Capacity" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Personnel costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Bearbeiter</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<rECORD name="Further education"></rECORD>
+<aTTRIBUTE name="Presence" type="ATTRPROFREF"></aTTRIBUTE>
+<aTTRIBUTE name="E-Mail" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16616" class="Role" name="Responsible SUAP office">
+<aTTRIBUTE name="Position" type="STRING">NODE x:12.5cm y:14.5cm index:29</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Rolle</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16619" class="Performer" name="Barbara Thössen">
+<aTTRIBUTE name="Position" type="STRING">NODE x:15.5cm y:18.5cm index:31</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Hourly wages" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Calendar" type="LONGSTRING">B@Working day@b@32400-43200@T@45000-59400@T@Free day@c@@@$cbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbcbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbcbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbcccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbccbbccb</aTTRIBUTE>
+<aTTRIBUTE name="Availability" type="EXPRESSION">EXPR expr:(round(paval(&quot;Presence&quot;,&quot;Hours per day&quot;)*paval(&quot;Presence&quot;,&quot;Days per week&quot;)/40*100)) val:100</aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Time dependent costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Info on results" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Workload" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Capacity" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Personnel costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Bearbeiter</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<rECORD name="Further education"></rECORD>
+<aTTRIBUTE name="Presence" type="ATTRPROFREF"></aTTRIBUTE>
+<aTTRIBUTE name="E-Mail" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<cONNECTOR id="con.16622" class="Is subordinated">
+<fROM instance="Agriculture Office" class="Organizational unit"></fROM>
+<tO instance="Area 3" class="Organizational unit"></tO>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 2 x1:16.5cm y1:9cm x2:15cm y2:9cm index:39</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Representation" type="ENUMERATION">with arrow</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16623" class="Is subordinated">
+<fROM instance="SUAP Office" class="Organizational unit"></fROM>
+<tO instance="Area 3" class="Organizational unit"></tO>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 2 x1:12cm y1:9cm x2:14cm y2:9cm index:9</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">4</aTTRIBUTE>
+<aTTRIBUTE name="Representation" type="ENUMERATION">with arrow</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16624" class="belongs to">
+<fROM instance="SUAP Officer" class="Role"></fROM>
+<tO instance="SUAP Office" class="Organizational unit"></tO>
+<aTTRIBUTE name="Connector number" type="INTEGER">2</aTTRIBUTE>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 0 index:6</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16625" class="Has role">
+<fROM instance="Barnaby Barnes" class="Performer"></fROM>
+<tO instance="SUAP Officer" class="Role"></tO>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 0 index:5</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">1</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16626" class="belongs to">
+<fROM instance="Secretary General" class="Role"></fROM>
+<tO instance="Monti Azzurri" class="Organizational unit"></tO>
+<aTTRIBUTE name="Connector number" type="INTEGER">8</aTTRIBUTE>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 1 x1:3cm y1:3.5cm index:20</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16627" class="belongs to">
+<fROM instance="President" class="Role"></fROM>
+<tO instance="Monti Azzurri" class="Organizational unit"></tO>
+<aTTRIBUTE name="Connector number" type="INTEGER">10</aTTRIBUTE>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 1 x1:5.5cm y1:4cm index:23</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16628" class="Is subordinated">
+<fROM instance="Area 3" class="Organizational unit"></fROM>
+<tO instance="Monti Azzurri" class="Organizational unit"></tO>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 1 x1:14.5cm y1:3.5cm index:8</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">3</aTTRIBUTE>
+<aTTRIBUTE name="Representation" type="ENUMERATION">with arrow</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16629" class="belongs to">
+<fROM instance="Responsible Agriculture, Forestry, Environment" class="Role"></fROM>
+<tO instance="Agriculture Office" class="Organizational unit"></tO>
+<aTTRIBUTE name="Connector number" type="INTEGER">14</aTTRIBUTE>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 0 index:26</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16630" class="Has role">
+<fROM instance="Emanuele Laurenzi " class="Performer"></fROM>
+<tO instance="Secretary General" class="Role"></tO>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 0 index:22</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">9</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16631" class="Has role">
+<fROM instance="Sandro Emmenegger" class="Performer"></fROM>
+<tO instance="President" class="Role"></tO>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 0 index:25</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">11</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16632" class="Has role">
+<fROM instance="Congyu Zhang" class="Performer"></fROM>
+<tO instance="Responsible Agriculture, Forestry, Environment" class="Role"></tO>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 0 index:28</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">15</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16633" class="belongs to">
+<fROM instance="Responsible SUAP office" class="Role"></fROM>
+<tO instance="SUAP Office" class="Organizational unit"></tO>
+<aTTRIBUTE name="Connector number" type="INTEGER">16</aTTRIBUTE>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 0 index:30</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16634" class="Has role">
+<fROM instance="Barbara Thössen" class="Performer"></fROM>
+<tO instance="Responsible SUAP office" class="Role"></tO>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 1 x1:12.5cm y1:18.5cm index:32</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">17</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16635" class="Is manager">
+<fROM instance="Barbara Thössen" class="Performer"></fROM>
+<tO instance="SUAP Office" class="Organizational unit"></tO>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 0 index:37</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">19</aTTRIBUTE>
+</cONNECTOR>
+</mODEL>
+<mODEL id="mod.16520" name="Document and Knowledge model TitoloUnico" version="" modeltype="Document and Knowledge model" libtype="bp" applib="LearnPAd Prototype Dynamic Library 0.21">
+<mODELATTRIBUTES>
+<aTTRIBUTE name="Contact person" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Keywords" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Copyright info" type="STRING">Edit the model attributes to display your copyright info</aTTRIBUTE>
+<aTTRIBUTE name="Copyright info position" type="ENUMERATION">Bottom right</aTTRIBUTE>
+<aTTRIBUTE name="Model type" type="ENUMERATION">Current model</aTTRIBUTE>
+<aTTRIBUTE name="State" type="ENUMERATION">In process</aTTRIBUTE>
+<aTTRIBUTE name="Reviewed on" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Reviewed by" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Author" type="STRING">barbara</aTTRIBUTE>
+<aTTRIBUTE name="Creation date" type="STRING">13.08.2015, 13:16</aTTRIBUTE>
+<aTTRIBUTE name="Last user" type="STRING">congyu</aTTRIBUTE>
+<aTTRIBUTE name="Date last changed" type="STRING">08.09.2015, 01:54:25</aTTRIBUTE>
+<aTTRIBUTE name="Number of objects and relations" type="INTEGER">19</aTTRIBUTE>
+<aTTRIBUTE name="Context of version" type="STRING"></aTTRIBUTE>
+<rECORD name="Change history"></rECORD>
+<aTTRIBUTE name="Position" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-01] Internal error!  \&quot;fontcolor\&quot; (BPModel)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<rECORD name="Technical Attributes"></rECORD>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Keine Modellbezeichnung vergeben</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Pool Term" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="ParticipantType" type="ENUMERATION">Role</aTTRIBUTE>
+<aTTRIBUTE name="Role" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Entity" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="BoundaryVisible" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="BPD Model Attributes" type="STRING">NOTEBOOK
+
+CHAPTER &quot;Business Process Diagram Attributes&quot;
+ATTR &quot;Name&quot; write-protected
+ATTR &quot;Contact person&quot;
+ATTR &quot;Author&quot; write-protected
+ATTR &quot;Language (BPMN)&quot;
+ATTR &quot;ExpressionLanguage&quot;
+ATTR &quot;QueryLanguage&quot;
+ATTR &quot;Creation date&quot; write-protected
+ATTR &quot;Date last changed&quot; write-protected
+ATTR &quot;Documentation (Model)&quot;
+ATTR &quot;State&quot;
+
+GROUP &quot;Copyright&quot;
+ATTR &quot;Copyright info&quot; 
+ATTR &quot;Copyright info position&quot; 
+ENDGROUP
+
+CHAPTER &quot;Process Attributes&quot;
+ATTR &quot;Name&quot; write-protected
+ATTR &quot;Process Term&quot;
+ATTR &quot;ProcessType&quot;
+ATTR &quot;Status&quot;
+ATTR &quot;Assignments&quot; lines:5
+ATTR &quot;Properties (BPMN)&quot; lines:5
+ATTR &quot;AdHoc&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+GROUP &quot;AdHoc = True&quot;
+ATTR &quot;AdHocOrdering&quot;
+ATTR &quot;AdHocCompletionCondition&quot;
+ENDGROUP
+ATTR &quot;SuppressJoinFailure&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ATTR &quot;EnableInstanceCompensation&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ATTR &quot;Categories (Process)&quot;
+ATTR &quot;Documentation (Process)&quot;
+
+CHAPTER &quot;Pool Attributes&quot;
+GROUP &quot;Common Graphical Object Attributes&quot;
+ATTR &quot;Name&quot; write-protected
+ATTR &quot;Categories (Pool)&quot;
+ATTR &quot;Documentation (Pool)&quot;
+ENDGROUP
+GROUP &quot;Common Swimlane Attributes&quot;
+ATTR &quot;Pool Term&quot;
+ENDGROUP
+GROUP &quot;Pool Attributes&quot;
+ATTR &quot;ParticipantType&quot;
+ATTR &quot;Role&quot;
+ATTR &quot;Entity&quot;
+ATTR &quot;BoundaryVisible&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot; write-protected
+ENDGROUP</aTTRIBUTE>
+<aTTRIBUTE name="Language" type="ENUMERATION">System</aTTRIBUTE>
+<aTTRIBUTE name="ExpressionLanguage" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="QueryLanguage" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Process Term" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="BPD Term" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="ProcessType" type="ENUMERATION">None</aTTRIBUTE>
+<aTTRIBUTE name="Status" type="ENUMERATION">None</aTTRIBUTE>
+<rECORD name="Assignments"></rECORD>
+<aTTRIBUTE name="AdHoc" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="AdHocOrdering" type="ENUMERATION">None</aTTRIBUTE>
+<aTTRIBUTE name="AdHocCompletionCondition" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="EnableInstanceCompensation" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Categories (Process)" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation (Process)" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation (Pool)" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Categories (Pool)" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="SuppressJoinFailure" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="RACI/DEMI visualisation" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Modelling direction" type="ENUMERATION">vertical</aTTRIBUTE>
+<aTTRIBUTE name="IT systems" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Responsible role" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Input/Output" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Products" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Use cases" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Products color" type="STRING">whitesmoke</aTTRIBUTE>
+<aTTRIBUTE name="RACI/DEMI color" type="STRING">whitesmoke</aTTRIBUTE>
+<aTTRIBUTE name="Responsible role color" type="STRING">whitesmoke</aTTRIBUTE>
+<aTTRIBUTE name="Input/Output color" type="STRING">whitesmoke</aTTRIBUTE>
+<aTTRIBUTE name="Use cases color" type="STRING">whitesmoke</aTTRIBUTE>
+<aTTRIBUTE name="IT systems color" type="STRING">whitesmoke</aTTRIBUTE>
+<aTTRIBUTE name="_ToggleModelInfo_" type="PROGRAMCALL">ITEM &quot;_ToggleModelInfo_&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Display modelling information" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Documentation (Model)" type="STRING"></aTTRIBUTE>
+<rECORD name="Properties (BPMN)"></rECORD>
+<aTTRIBUTE name="CreationDate" type="EXPRESSION">EXPR val:&quot;13.08.2015, 13:16&quot;</aTTRIBUTE>
+<aTTRIBUTE name="ModificationDate" type="EXPRESSION">EXPR val:&quot;08.09.2015, 01:54:18&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Language (BPMN)" type="STRING">English</aTTRIBUTE>
+<aTTRIBUTE name="BPMN20 Model Attributes" type="LONGSTRING">NOTEBOOK
+# TODO AVAL sMfbRegistration:&quot;_MFB-Registration_&quot;
+CHAPTER &quot;Description&quot;
+ATTR &quot;Contact person&quot;
+ATTR &quot;Keywords&quot; lines:2
+ATTR &quot;Description&quot; lines:3
+ATTR &quot;Comment&quot; lines:3
+
+GROUP &quot;Copyright&quot;
+ATTR &quot;Copyright info&quot; 
+ATTR &quot;Copyright info position&quot; 
+ENDGROUP
+ATTR &quot;Name&quot; write-protected
+ATTR &quot;Id&quot; write-protected
+
+
+
+#---------------------------------------------
+CHAPTER &quot;Process properties&quot;
+#---------------------------------------------
+GROUP &quot;Process attributes&quot;
+ATTR &quot;Process type&quot; #None, Private, Public 
+ATTR &quot;Executable&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ATTR &quot;Closed&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ENDGROUP
+
+GROUP &quot;Process relevance&quot;
+ATTR &quot;Auditing&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ATTR &quot;Monitoring&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ENDGROUP
+
+CHAPTER &quot;User attributes&quot;
+ATTR &quot;Model type&quot;
+ATTR &quot;State&quot;
+ATTR &quot;Reviewed on&quot;
+ATTR &quot;Reviewed by&quot;
+
+CHAPTER &quot;System attributes&quot;
+ATTR &quot;Author&quot; write-protected
+ATTR &quot;Creation date&quot; write-protected
+ATTR &quot;Last user&quot; write-protected
+# ATTR &quot;Date last changed from&quot; write-protected
+ATTR &quot;Date last changed&quot; write-protected
+ATTR &quot;Number of objects and relations&quot; write-protected
+ATTR &quot;Context of version&quot; write-protected
+
+CHAPTER &quot;People-like view&quot;
+ATTR &quot;Action&quot;
+ATTR &quot;People-like view&quot;
+
+CHAPTER &quot;BAR Display&quot;
+ATTR &quot;BAR Display active&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot;
+AVAL s_Aktiv: &quot;BAR Display active&quot;
+ATTR &quot;Modelling direction&quot; ctrltype: radio enabled: (s_Aktiv = &quot;Yes&quot;)
+ATTR &quot;Modelling_size&quot;
+
+GROUP &quot;Responsible for execution&quot;
+ATTR &quot;Responsible for execution_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_Responsible_for_execution_display: &quot;Responsible for execution_display&quot;
+ATTR &quot;Responsible for execution_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_Responsible_for_execution_display = &quot;Yes&quot;))
+ATTR &quot;Responsible for execution_size&quot;
+ENDGROUP
+
+GROUP &quot;Accountable for approving results&quot;
+ATTR &quot;Accountable for approving results_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_Accountableforapprovingresults_display: &quot;Actor_display&quot;
+ATTR &quot;Accountable for approving results_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_Accountableforapprovingresults_display = &quot;Yes&quot;))
+ATTR &quot;Accountable for approving results_size&quot;
+ENDGROUP
+
+GROUP &quot;Cooperation/participation&quot;
+ATTR &quot;Cooperation/participation_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_Cooperationparticipation_display: &quot;Cooperation/participation_display&quot;
+ATTR &quot;Cooperation/participation_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_Cooperationparticipation_display = &quot;Yes&quot;))
+ATTR &quot;Cooperation/participation_size&quot;
+ENDGROUP
+
+GROUP &quot;To inform&quot;
+ATTR &quot;To inform_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_Toinform_display: &quot;To inform_display&quot;
+ATTR &quot;To inform_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_Toinform_display = &quot;Yes&quot;))
+ATTR &quot;To inform_size&quot;
+ENDGROUP
+
+GROUP &quot;Knowledge Product&quot;
+ATTR &quot;Knowledge Product_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_KnowledgeProduct_display: &quot;Knowledge Product_display&quot;
+ATTR &quot;Knowledge Product_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_KnowledgeProduct_display = &quot;Yes&quot;))
+ATTR &quot;Knowledge Product_size&quot;
+ENDGROUP
+
+GROUP &quot;Documents and Resources&quot;
+ATTR &quot;Documents and Resources_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_DocumentsandResources_display: &quot;Documents and Resources_display&quot;
+ATTR &quot;Documents and Resources_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_DocumentsandResources_display = &quot;Yes&quot;))
+ATTR &quot;Documents and Resources_size&quot;
+ENDGROUP
+
+GROUP &quot;Incoming Data Object&quot;
+ATTR &quot;Incoming Data Object_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_IncomingDataObject_display: &quot;Incoming Data Object_display&quot;
+ATTR &quot;Incoming Data Object_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_IncomingDataObject_display = &quot;Yes&quot;))
+ATTR &quot;Incoming Data Object_size&quot;
+ENDGROUP
+
+GROUP &quot;Outgoing Data Object&quot;
+ATTR &quot;Outgoing Data Object_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_OutgoingDataObject_display: &quot;Outgoing Data Object_display&quot;
+ATTR &quot;Outgoing Data Object_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_OutgoingDataObject_display = &quot;Yes&quot;))
+ATTR &quot;Outgoing Data Object_size&quot;
+ENDGROUP
+
+GROUP &quot;Description&quot;
+ATTR &quot;Description_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_Description_display: &quot;Description_display&quot;
+ATTR &quot;Description_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_Description_display = &quot;Yes&quot;))
+ATTR &quot;Description_size&quot;
+ENDGROUP
+
+CHAPTER &quot;Comment View&quot;
+ATTR &quot;Comment Mode&quot; ctrltype: check checked-value: &quot;No&quot; unchecked-value: &quot;Yes&quot;
+AVAL s_Aktiv: &quot;Comment Mode&quot;
+ATTR &quot;CommentAreaSize&quot;
+ATTR &quot;CommentModellingAreaSize&quot;
+ATTR &quot;CommentModellingDirection&quot;
+
+
+
+
+CHAPTER &quot;Change history&quot;
+ATTR &quot;Change history&quot; lines:30
+
+</aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;87801&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Auditing" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Monitoring" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Process type" type="ENUMERATION">None</aTTRIBUTE>
+<aTTRIBUTE name="Executable" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Closed" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="_GoToAceHp_" type="PROGRAMCALL">ITEM &quot;_GoToAceHp_&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="__GfxThumb__" type="LONGSTRING">iVBORw0KGgoAAAANSUhEUgAAALMAAAEACAIAAAB3X9DLAAAACXBIWXMAAAsTAAALEwEAmpwYAAASuElEQVR4nO3dT4gj150H8G87c8lACOwmGHbX2IeuiqeiyxqSHb3e4LDk4JagqcNQVx0sXkMgtJhELMPWUWCItsPTJaBinKSPKeaglldPPuSPF6ernYsJoVzJvldjMh4IeJzJxdgzNCG1h+pu93heq1t/Wy39PoemWirV70n11aunUqlqJcuyBw8evPPOOyDL4fHjx57nnTnbyv379999992XXnrpypUrv/3tb5+4b2UFwDe/+c2//e1vAP7l2WeHasGv3n7btm0ASqn/+Na3hnrs/PjV229/zbYB/POQT//8y7e/ZgNQ/zfFV+l4XQB49913zxWO3d3du3ffv3v3/V/+8pf3TH7961/fvXs3OzjIDg6yZFtWi7ybiGJRJIkoVsV2lVerIjnQ21WRHMhqkRWLIjnI59/f39/f388OElEEUBXbx3MmsrvNgBOPTWS1yLtdXtwWVfBu/u9BfqPsbvNiVVSLvHugt4tsO9Hdbb6dHBcFwI7+zQ4SUSzy6mHD8gYfFe2KIlDdzquLJJFP3sW2u/kt+WOPn0V2cHD4LIrbcrsqkq7sJrrbFdXq8etwVKsrisV8BtlNsoMDvZ2/YgCKrAgAbLvKq9uya3iV2HbejOToRftsOr8LgEgOZBW8e3B0eyKrRZEcZElXVsGK1ePpo4cfVrn7/t2779/d3d39+c9/np3lCoDHjx8B+N3vfpf3DZ/zpS996dGjx/l0Cktdu+Eixa1bSFPc2lCvbQT7YNc2cOd2Yt3Ee/vRPgopsAoAV69e/WxBRSR3bsfYwJ3bITa8O9+Pitv+BpCmvfyx1264gLoB3EF8LXWu3XDxpnpvP74G584fcAMJbrh4s3dnP9p3KtWqt2H1XjssiuK2b6W9124n1o+xCvvWLRvdxsbt+NqG995+fO2whI3VrdeT8ir0m/0IQD/1LfTu3A5x0//DRm0f4haAtHfndrAPdu3m1vdWTz4L+1aSvYLWy98PcdP/w6sVfL3w3m2kN91bG+q1jbwl8TU42A/7qz5+hPUfA6m2Xnf1jzoAije8r+9H+0XcuR3sAxvfW8dTr9KxtH9iOrW/joK1CoBVt22k6j3E1948nmP95i0AWF1V7yEC/BR45ZX1m9vs9vePl3H16tXHjx6d0U+csLK7u/vcc88BuHLlyu9///un5/jGN77xySef/GuhcLLVrZdfxev/u7V6xtLTe/cArD7//PkbNJr+d19WN89uz2jSe/eGfwpp67v98o+/d54WzeZVSu/d+/jjjwHcv3//PFuTld3d3WePtqDPP//8gwcPnnnmmS984QvPPPMMgC9/+cv3PvggyzIA1196aaim/Pmjj+7fvw/gueee+6evfnWEJzMPjp/Fvw359Idd/lRfpT9/9NEH9+/n0w8+/PBcyciyrNvtTqlBZD6dJxlXAGxsbIRhOJMmkUtjJd9SEPI5Vy66AWROLXwy0taaVYOQXqLKdVQqSaHg1I8n3KSiXC9R5brdrDTigrfj2toCtGqUauAccDyg7NSsUMidsmpWwtjb2ZvSh6C5svhbk/7mSilgjEXwpG8DUEAZ6DVKtYLUjuohrCW+dlQzrAUQ2kcT5To01tfR72vVKIWe9KBs21aNUi0Cl1l7/aKf1fQtfjJM0tZaBea3ftra7JXby9ApnOG8yci/Q8lnpunFmD5jjQ+eaWVlOTuVxXdmRGjFE7NBn02ow1hmC/+plZxq8Dt/UDIGdRh/WhmlLS8M3wONVmi0WuSEMfqMZ38x3PwffmdGhcaptUwGDxXGGGdkn47cpuHMrBA5YYw+IxviAKGxzKzQkpnOOAPUZyw46jOWF40zyCjG6DP+PqsVNrNCS2Z64wzamiyyccYZtDW53KY3zqA+Y5FRn7G8aJxBRjHNPuPTo99dXh3vsMnzFxq/1jK5iHHGo7eAE992jvx96bCFxq9Fjgxa94OSka+AL37787c/vapOPmTkb+GHKjRyrSUz+J0/3lFbJ1fb4FU1ppkVWibTTEYuX20zWFUzK0RG35qQRTfucaBpa61p79XVZq/cLvc2m7brQnU6cOIEHsIwLvg77fXxf9eTttasWsSFAKZbaIlMbX8GAKTa3nHVZjMMYri27TgKKqwFBSF9VzVKUQQoYBIfJG1fa9WshEHBrk+1EDl05pm8zk8LzqWe4AIvvNAyo3EGOcWA1Jx+rxYMYEIKLrQWjHHOACZ0pgUXWjJAaC054zLTgjGh5Yhv8acLPTEhOeNyguWWy+C1P9o4Y9UuAEHYQAS4vu/b6ACurfu9MEhsNwIKGnA8F/1eGEVRBXpvpNw+XUhBA74Xlmpw63A8FyqYWDlywoTyl79XT7mLn3LP5GtNo9ySonEGOcWA1Jju1YIBXEoOLg9HGFxmkgNgQksp8228FgzAE/Nowdmg97pRXk5IqTMphWBcHo489FEJMMYYF1LnfcVh+4YqsqwGr/2RxhlxpwPEjnZ9H0rZ6KsYQBT2LB9NlNtAejij+myeXhhEEQr68MTTQ4ihYJViLvwdVzWVr7P1VQB2AYi42KmXobXWvTAI4SKMwH3arzG+yW4v6FRGi4PGGcSMzp+xvKb6vQlZWLS9IGZnHAcK6jkW1JmDyLP7jONFzMMpLGl6stOD1jt1CcSIPpsQM0oGMaNkEDNKBjGjZBAzSgYxo2QQM0oGOcVohwNdNodHk+fHfUmO/IhzJqSUUh4dlsaEPDxODCw/Qv34aHgAy3Zw6bL0GaphdaCdMEjsOmLEjgLjvg0AyvFc9OFKHxYKQMQYi8JeD1FU0CnCIIQDIBnhaLTLjPaOH+pvrqn6iWvupa2W3tpa4sMGKRnE7Lxbk3n4YpCmJzt9xhofPBMdCrqoJnB8BllUox8HSh3GMhv1U+tUr7A32avq0TX6TjH4bT/GseNTvcLeZK+qR9foG968nnd8sgunM5ebTG2cMdXTgU924XTm8uFRn7G8pjbOoD5joVGfsbymNs6Y6oXvJrtwukbf8Ob1eq20NZm+6Y0zaGuyyKjPWF7T259BfcYioz5jeV3cOGOcK+xN9qp6dI2+4U2nzxj/CntDLfzTvuFCa6MtDUt0jb6ZH5/x6K3Pf3+d/zuRV3yyC396aWMucIGMcdbHp6+KOMFr30124VNt6oIa+6itk++tib/Qk134VJu6cOh4vuVFx4GSUQz72SRtrVm1gtROJ7/YYq9ct3UPyl7fslqbvbKbWKWAS+12Kh13z+2slAIwIX0b6DRKQcSE3ht0XvK034eFXg9lu1PpuDt11WwmcOrtLbRaldpRaSe0woL0XVjW8QzmpaatNasGIb1Eleu21gBUo5MUYqe+l7cflabtu0p1UHaTinK9RNnu1vrif3adwv6MuNOMgxguwiCE64W1xM/WkdpOUunEDIiVdhzPza9hwMTRz0cLnHuuPbi1q5Zaq8D3ba3iKHZ0LwyCCMypb22VgVpeGrYuoOZYFvThDNxtn/Kj0yeuquSFpdCTvu+iESQ6RRgkdt31nU6pEbMIcD0PKgwSvz24lctg6tuLk78X/fxvR8mFOuvbj9MNvvfI4bVmtOBCCwbGpZRSa8E5H/myVU9cWE/yz6Y5wOXxxfQGlMhPbsDz0x/kDwFwdDYEwT+bllNo/+UweP1O6CwJQ3fygz25CXCEcKDCILHdGCgcnddgcAnbSSod+G6qYsSOdpwCQxSrvutKH6rBuH94ZgSoybf/csjo14sn0dbtnJYuGeTYlMYZ4w8FTl/yoCGCzgvni9Unqg8sMr3WXmKD1/7I44wJDAVOM3CIoHuNCFy6roJOe/nZlRzO4sEVptjayytbmHEGDQtm6TIlg0wWfW9CRrEsZ30kT1uccQaZpTP6DNqgLKozT/J3rivsHS+Cphdm+uz1Tl0CMaIRKDGjZBAzSgYxo2QQM0oGMaNkEDNKBjGjZBAzSgYxo2QQM0oGMaNkEDNKBjGjZBAzSgYxo2QQM0oGMaNkEDNKBjGjZBAzSgYxo2QQM0oGMaNkEDNKBjGjZBAzSgYxo2QQM0oGMaNkEDNKBjGjZBAzSgYxo2QQM0oGMaNkEDNKBjGjZBAzSgYxo2QQM0oGMaNkEDNKBjGjZBAzSgYxo2QQM0oGMaNkEDNKBjGjZBAzSgYxo2QQM0oGMaNkEDNKBjGjZBAzSgYxo2QQM0oGMaNkEDNKBjGjZBAzSgYxo2QQM0oGMaNkEDNKBjGjZBAzSgYxo2QQM0oGMaNkEDNKBjGjZBAzSgYxo2QQM0oGMaNkEDNKBjGjZBAzSgYxo2QQM0oGMaNkEDNKBjGjZBAzSgYxo2QQM0oGMaNkEDNKBjGjZBAzSgYxo2QQM0oGMaNkEDNKBjFbpGSkrTWrVhDStQELnYqq+4lVgszqarNXbtvNNVXfs5trqr6DilWLuBBAuY5KBTu+rS0A6FilgHHpo6Hqe+XemlWLwA+XULe1BqAajaRQAODU63az0nH9oFQSOttavdinP2GLlAwAQJx04lrsSS+OEo2YcR/9Xhgkdh1xlOgUcZRouL7WqlkJg4LtxlFU0Ot2Z03VdxADKLiA8uzjFR2rfi8MQrheWAo96fu+jU6jFMCtw/FcqABINLBYyVjJsuyi20Dm0Xn7jJWVFQB5jGh6MabPWOODZ1pZoU5lMZ0ZEVrxxGzQ1oQ6jGW2cJ9NyLkNfucPSgZ1GMuMthfEjMYZxIzGGctrOuOMP62M0pYXhu+BRis0y1ojFLoMxugznv3FcPN/+J0ZFZplrZELzYHBQ4UxxhnZpyO3aTgzKzTjWvNtjD4jezS5ZsxHoRnXumhT259BfcZCoz7j4mpdNBpnzGut+TZGn/H3Wb2IMys041oXbXrjDNqaLLJxxhm0NbncpjfOoD5jkVGfcXG1LhqNM+a11nyjPuPial20CxpnPHrriX+/+O1BMw82VKFZ1hqn0NybwvEZ+cv3ue+mR/4yfdhCs6w1jUIzNPidP8ZRW39aMbxpHr01+eMVZlZoxrUu2tSSAdObZkqv4MwKzbjWHBuYGjoOdInRcaDL66xPGEPTggFcCAYwobXUgnGZZVpIzrjMJAeYEBxc6vwWLTjnXOjhSz1ZUXLGpZZSCsY5Z1zKvA15LcEAcCFHL/NZISk4E1IwJrQWecvzumBCSqnHfkZzYfDaH7XPiIECECQ92La946pW37KV47noq/yuGLGjHcdz0e+FQRCBu+1RzzCxurWjy6voteBCA7B9F40gdOD6OltHa60WO9r1JSuVbKs94jM6UUj3teMpFUZRodeLgxD1ra1VdKxaBOED0PkzYk596zKfTiUb/GP3AXdftnFG2trslduXeV3Nk0VKBhnOwvyuNW2tWbUIABM6PwGXdgFLVSohCv5ee30CBZr2jgsNqE4jcQpxGBe8nToqlcT3nUapFoFLiUbH8evlydWdT5fos8mqXQAixqVvaxUy7kMD6IVRFHEf6djnyUq1veOqZicMYk96HgAgCMKe6/u+DSgAQKzgeY4NPbm6F2bBxhlpa62CnT0aTUzbpUvGHMnPMiml01C2byvVCEMUCoUgdvSe3dxE21VrKikkbruNzU2022itNWoFP3PRX19fR39zpRQzVih4cVCLuMxc9AGlGonto9GIC/5eez1trTVtH5384cr2bViqYYUQ/p6N/jo6m2jXrVRrbVmW1jq/xUW/0yg5frZ1WHpzpRELf69spVprqEajhgiR5Gg40gs7ie+6qtGB74Sl0NN7W6uXaJwxG/loJj9VaLvcy08D2muUagXOnfrRLU2rFPv/hQjcU40aPAnYtu/7AOC60K1GEHuuCy9xEhdp/m8rrEURoPqubQFpqxGAC9+1oRAgilXfOTyrpK0apShCAQBg+65qlPKHw5MAemEECKAPoNUIYq8ONBXalt5UqKtGEHuuE5YCCL2ettby0gEiDqTQTYW6jULEgCiCK30AvmsDgOfYKoyAfEs6zV0pl5EWDGCcMzBxuGsr358mpZBSCwYutRCcMXFxjZTiiV16UnCpD/8OfsjxPFowNnhP3RlbEyxpz7H4zh4qnJnP43lOzk/Tczb9gmBNsH3gVeC6lA+1VMCrwAuCvSHEGwCA/+RSCfZT4DrwgpQPsyzT4qdcPhSsCfyUsSbQZOINzvez8+wdP9mOp2+k6fmY/mu/j2wdrbUXQ++H6HQr+ApnL8L/oY2HqrHL5UOn8ZNQwcFfmOj5iGD9A/BXbW+4KuoAYC96hd9E0VcQ/jGI0G5fp08fS+ivrU1Vbl8f/MGfkkHMLtE+UDJTlIxFpfv9f7QQNRWr2/nfh9qy0PzvjvsDt/OzRgxvZ8PWCsh3/V9fX0fa+p9emYXWT/ayH1AyFpWFzs8qeNFDt5Ic/t2pP+zlx83Ef4kioPfQC3+T+LbT+E3iX19P3+mFfwzxlQL/d9A4g5zm/wEEQfSzEnzQdwAAAABJRU5ErkJggg==</aTTRIBUTE>
+<aTTRIBUTE name="NT Model Attributes" type="LONGSTRING">NOTEBOOK
+CHAPTER &quot;Description&quot;
+#ATTR &quot;Shared&quot;
+ATTR &quot;Model state&quot; enabled:(cond(search (sMfbRegistration, &quot;MFB_VERS&quot;, 0) = -1, 1, 0))
+ATTR &quot;Description&quot;
+ATTR &quot;Show State&quot; ctrltype:check unchecked-value:&quot;No&quot; checked-value:&quot;Yes&quot; 
+ATTR &quot;Last user&quot; write-protected
+ATTR &quot;Date last changed&quot; write-protected
+#CHAPTER &quot;Suggestion for improvement&quot;
+#ATTR &quot;Suggestion for improvement&quot;
+</aTTRIBUTE>
+<aTTRIBUTE name="Model state" type="ENUMERATION">Draft</aTTRIBUTE>
+<aTTRIBUTE name="People-like view" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Action" type="ENUMERATION">Fill in</aTTRIBUTE>
+<aTTRIBUTE name="Keywords" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Description" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Model type" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Show State" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="BAR Display active" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Actor_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="Actor_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Actor_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="Description_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="Description_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Description_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="ModelingAreaSize" type="ENUMERATION">20</aTTRIBUTE>
+<aTTRIBUTE name="Modelling_size" type="ENUMERATION">3</aTTRIBUTE>
+<aTTRIBUTE name="DrawingAreaWidth" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="DrawingAreaHeight" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Reference overview settings" type="LONGSTRING">Responsible for execution|Responsible for execution
+Accountable for approving results|Accountable for approving results
+Cooperation/participation|Cooperation/participation
+To inform|To inform
+Modelling|Modelling
+Knowledge Product|Knowledge Product
+Documents and Resources|Documents and Resources
+#Data Object|Data Object
+Incoming Data Object|Incoming Data Object
+Outgoing Data Object|Outgoing Data Object
+Description|Description</aTTRIBUTE>
+<aTTRIBUTE name="Data Object_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="Data Object_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Data Object_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="Knowledge Product_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="Knowledge Product_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Knowledge Product_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="Documents and Resources_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Documents and Resources_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="Documents and Resources_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="Responsible for execution_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="Responsible for execution_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Responsible for execution_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="Accountable for approving results_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="Accountable for approving results_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Accountable for approving results_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="Cooperation/participation_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="Cooperation/participation_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Cooperation/participation_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="To inform_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="To inform_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="To inform_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="Incoming Data Object_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="Incoming Data Object_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Incoming Data Object_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="Outgoing Data Object_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="Outgoing Data Object_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Outgoing Data Object_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="id_bpmndi_diagram" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="id_bpmndi_plane" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="id_bpmndi_collaboration" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="CommentModellingAreaSize" type="ENUMERATION">3</aTTRIBUTE>
+<aTTRIBUTE name="CommentTypeSize" type="ENUMERATION">8</aTTRIBUTE>
+<aTTRIBUTE name="CommentAreaSize" type="ENUMERATION">2</aTTRIBUTE>
+<aTTRIBUTE name="Comment Mode" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="CommentxCoorTextBox" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="CommentyCoorTextBox" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="CommentModellingDirection" type="ENUMERATION">vertical</aTTRIBUTE>
+</mODELATTRIBUTES>
+<iNSTANCE id="obj.16521" class="Document" name="Acquired Competency Barnaby Barnes">
+<aTTRIBUTE name="Position" type="STRING">NODE x:3cm y:2.5cm index:1</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-02] Attribute \&quot;Fontcolor\&quot; (Group) does not exist!  \&quot;fontcolor\&quot; (Document)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<rECORD name="Technical Attributes"></rECORD>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Referenced document" type="PROGRAMCALL">ITEM &quot;&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Dokument</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Display file name" type="INTEGER">0</aTTRIBUTE>
+<rECORD name="CompetencyAndLevel">
+<rOW id="row.16524" number="1">
+<iNTERREF name="Competency">
+<iREF type="objectreference" tmodeltype="Competency model" tmodelname="Competency model TitoloUnico" tmodelver="" tclassname="Competency" tobjname="Assessing administrative &amp; procedural regularity"></iREF>
+</iNTERREF>
+<aTTRIBUTE name="ACLevel" type="STRING">3</aTTRIBUTE>
+<aTTRIBUTE name="LearningGoal" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Status" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Score" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Updated" type="DATE">2014:01:01</aTTRIBUTE>
+</rOW>
+<rOW id="row.16526" number="2">
+<iNTERREF name="Competency">
+<iREF type="objectreference" tmodeltype="Competency model" tmodelname="Competency model TitoloUnico" tmodelver="" tclassname="Competency" tobjname="Managing front-office &amp; external services"></iREF>
+</iNTERREF>
+<aTTRIBUTE name="ACLevel" type="STRING">2</aTTRIBUTE>
+<aTTRIBUTE name="LearningGoal" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Status" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Score" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Updated" type="DATE">2014:01:01</aTTRIBUTE>
+</rOW>
+<rOW id="row.16528" number="3">
+<iNTERREF name="Competency">
+<iREF type="objectreference" tmodeltype="Competency model" tmodelname="Competency model TitoloUnico" tmodelver="" tclassname="Competency" tobjname="Competent verification of congruency and pertinency"></iREF>
+</iNTERREF>
+<aTTRIBUTE name="ACLevel" type="STRING">4</aTTRIBUTE>
+<aTTRIBUTE name="LearningGoal" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Status" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Score" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Updated" type="DATE">2014:01:01</aTTRIBUTE>
+</rOW>
+<rOW id="row.16530" number="4">
+<iNTERREF name="Competency">
+<iREF type="objectreference" tmodeltype="Competency model" tmodelname="Competency model TitoloUnico" tmodelver="" tclassname="Competency" tobjname="Manage specific admin procedure"></iREF>
+</iNTERREF>
+<aTTRIBUTE name="ACLevel" type="STRING">3</aTTRIBUTE>
+<aTTRIBUTE name="LearningGoal" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Status" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Score" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Updated" type="DATE">2014:01:01</aTTRIBUTE>
+</rOW>
+</rECORD>
+<iNTERREF name="Referenced Learning Object"></iNTERREF>
+<aTTRIBUTE name="Document Type" type="ENUMERATION">Not Specified</aTTRIBUTE>
+<aTTRIBUTE name="Document Form" type="ENUMERATION">Image</aTTRIBUTE>
+<aTTRIBUTE name="Document Format" type="ENUMERATION">doc</aTTRIBUTE>
+<aTTRIBUTE name="Document Kind" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Document Lifecycle" type="STRING"></aTTRIBUTE>
+<rECORD name="Document Tags"></rECORD>
+<aTTRIBUTE name="Document Version" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16532" class="Group" name="Competency Profiles">
+<aTTRIBUTE name="Position" type="STRING">NODE x:1cm y:1.5cm w:18cm h:4.5cm index:2</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(&quot;&quot;) val:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<rECORD name="Technical Attributes"></rECORD>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Open questions" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Show name" type="ENUMERATION">outside</aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16532&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Cardinality" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Color" type="STRING">white</aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16535" class="Group" name="Learning Objects">
+<aTTRIBUTE name="Position" type="STRING">NODE x:1cm y:7.5cm w:18cm h:4.5cm index:3</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(&quot;&quot;) val:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<rECORD name="Technical Attributes"></rECORD>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Open questions" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Show name" type="ENUMERATION">outside</aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16535&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Cardinality" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Color" type="STRING">white</aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16538" class="Group" name="Business Relevant Documents">
+<aTTRIBUTE name="Position" type="STRING">NODE x:1cm y:23.5cm w:18cm h:4.5cm index:4</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(&quot;&quot;) val:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<rECORD name="Technical Attributes"></rECORD>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Open questions" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Show name" type="ENUMERATION">outside</aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16538&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Cardinality" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Color" type="STRING">white</aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16541" class="Document" name="SCIA Instance">
+<aTTRIBUTE name="Position" type="STRING">NODE x:3cm y:25cm index:5</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-02] Attribute \&quot;Fontcolor\&quot; (Group) does not exist!  \&quot;fontcolor\&quot; (Document)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<rECORD name="Technical Attributes"></rECORD>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Referenced document" type="PROGRAMCALL">ITEM &quot;&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Dokument</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Display file name" type="INTEGER">1</aTTRIBUTE>
+<rECORD name="CompetencyAndLevel"></rECORD>
+<iNTERREF name="Referenced Learning Object"></iNTERREF>
+<aTTRIBUTE name="Document Type" type="ENUMERATION">Not Specified</aTTRIBUTE>
+<aTTRIBUTE name="Document Form" type="ENUMERATION">Text</aTTRIBUTE>
+<aTTRIBUTE name="Document Format" type="ENUMERATION">doc</aTTRIBUTE>
+<aTTRIBUTE name="Document Kind" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Document Lifecycle" type="STRING"></aTTRIBUTE>
+<rECORD name="Document Tags"></rECORD>
+<aTTRIBUTE name="Document Version" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16544" class="Document" name="Third Party Opinion">
+<aTTRIBUTE name="Position" type="STRING">NODE x:7cm y:25cm index:6</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-02] Attribute \&quot;Fontcolor\&quot; (Group) does not exist!  \&quot;fontcolor\&quot; (Document)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<rECORD name="Technical Attributes"></rECORD>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING">Opinion on an inssue</aTTRIBUTE>
+<aTTRIBUTE name="Referenced document" type="PROGRAMCALL">ITEM &quot;&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Dokument</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Display file name" type="INTEGER">0</aTTRIBUTE>
+<rECORD name="CompetencyAndLevel"></rECORD>
+<iNTERREF name="Referenced Learning Object"></iNTERREF>
+<aTTRIBUTE name="Document Type" type="ENUMERATION">Not Specified</aTTRIBUTE>
+<aTTRIBUTE name="Document Form" type="ENUMERATION">Text</aTTRIBUTE>
+<aTTRIBUTE name="Document Format" type="ENUMERATION">doc</aTTRIBUTE>
+<aTTRIBUTE name="Document Kind" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Document Lifecycle" type="STRING"></aTTRIBUTE>
+<rECORD name="Document Tags"></rECORD>
+<aTTRIBUTE name="Document Version" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16547" class="Document" name="Titolo Unico Authorization Document">
+<aTTRIBUTE name="Position" type="STRING">NODE x:11cm y:25cm index:7</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-02] Attribute \&quot;Fontcolor\&quot; (Group) does not exist!  \&quot;fontcolor\&quot; (Document)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<rECORD name="Technical Attributes"></rECORD>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Referenced document" type="PROGRAMCALL">ITEM &quot;&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Dokument</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Display file name" type="INTEGER">0</aTTRIBUTE>
+<rECORD name="CompetencyAndLevel"></rECORD>
+<iNTERREF name="Referenced Learning Object"></iNTERREF>
+<aTTRIBUTE name="Document Type" type="ENUMERATION">Not Specified</aTTRIBUTE>
+<aTTRIBUTE name="Document Form" type="ENUMERATION">Text</aTTRIBUTE>
+<aTTRIBUTE name="Document Format" type="ENUMERATION">doc</aTTRIBUTE>
+<aTTRIBUTE name="Document Kind" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Document Lifecycle" type="STRING"></aTTRIBUTE>
+<rECORD name="Document Tags"></rECORD>
+<aTTRIBUTE name="Document Version" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16550" class="Document" name="Required Compentency SUAP Officer">
+<aTTRIBUTE name="Position" type="STRING">NODE x:7cm y:2.5cm index:8</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-02] Attribute \&quot;Fontcolor\&quot; (Group) does not exist!  \&quot;fontcolor\&quot; (Document)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<rECORD name="Technical Attributes"></rECORD>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Referenced document" type="PROGRAMCALL">ITEM &quot;&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Dokument</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Display file name" type="INTEGER">0</aTTRIBUTE>
+<rECORD name="CompetencyAndLevel">
+<rOW id="row.16553" number="1">
+<iNTERREF name="Competency">
+<iREF type="objectreference" tmodeltype="Competency model" tmodelname="Competency model TitoloUnico" tmodelver="" tclassname="Competency" tobjname="Assessing administrative &amp; procedural regularity"></iREF>
+</iNTERREF>
+<aTTRIBUTE name="ACLevel" type="STRING">4</aTTRIBUTE>
+<aTTRIBUTE name="LearningGoal" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Status" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Score" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Updated" type="DATE">2014:01:01</aTTRIBUTE>
+</rOW>
+<rOW id="row.16555" number="2">
+<iNTERREF name="Competency">
+<iREF type="objectreference" tmodeltype="Competency model" tmodelname="Competency model TitoloUnico" tmodelver="" tclassname="Competency" tobjname="Managing front-office &amp; external services"></iREF>
+</iNTERREF>
+<aTTRIBUTE name="ACLevel" type="STRING">4</aTTRIBUTE>
+<aTTRIBUTE name="LearningGoal" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Status" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Score" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Updated" type="DATE">2014:01:01</aTTRIBUTE>
+</rOW>
+<rOW id="row.16557" number="3">
+<iNTERREF name="Competency">
+<iREF type="objectreference" tmodeltype="Competency model" tmodelname="Competency model TitoloUnico" tmodelver="" tclassname="Competency" tobjname="Competent verification of congruency and pertinency"></iREF>
+</iNTERREF>
+<aTTRIBUTE name="ACLevel" type="STRING">4</aTTRIBUTE>
+<aTTRIBUTE name="LearningGoal" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Status" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Score" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Updated" type="DATE">2014:01:01</aTTRIBUTE>
+</rOW>
+<rOW id="row.16559" number="4">
+<iNTERREF name="Competency">
+<iREF type="objectreference" tmodeltype="Competency model" tmodelname="Competency model TitoloUnico" tmodelver="" tclassname="Competency" tobjname="Manage specific admin procedure"></iREF>
+</iNTERREF>
+<aTTRIBUTE name="ACLevel" type="STRING">4</aTTRIBUTE>
+<aTTRIBUTE name="LearningGoal" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Status" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Score" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Updated" type="DATE">2014:01:01</aTTRIBUTE>
+</rOW>
+</rECORD>
+<iNTERREF name="Referenced Learning Object"></iNTERREF>
+<aTTRIBUTE name="Document Type" type="ENUMERATION">Not Specified</aTTRIBUTE>
+<aTTRIBUTE name="Document Form" type="ENUMERATION">Image</aTTRIBUTE>
+<aTTRIBUTE name="Document Format" type="ENUMERATION">doc</aTTRIBUTE>
+<aTTRIBUTE name="Document Kind" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Document Lifecycle" type="STRING"></aTTRIBUTE>
+<rECORD name="Document Tags"></rECORD>
+<aTTRIBUTE name="Document Version" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16561" class="Document" name="Book: Managing Service Conference">
+<aTTRIBUTE name="Position" type="STRING">NODE x:3cm y:8.5cm index:9</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-02] Attribute \&quot;Fontcolor\&quot; (Group) does not exist!  \&quot;fontcolor\&quot; (Document)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<rECORD name="Technical Attributes"></rECORD>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Referenced document" type="PROGRAMCALL">ITEM &quot;&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Dokument</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Display file name" type="INTEGER">1</aTTRIBUTE>
+<rECORD name="CompetencyAndLevel"></rECORD>
+<iNTERREF name="Referenced Learning Object"></iNTERREF>
+<aTTRIBUTE name="Document Type" type="ENUMERATION">Not Specified</aTTRIBUTE>
+<aTTRIBUTE name="Document Form" type="ENUMERATION">Text</aTTRIBUTE>
+<aTTRIBUTE name="Document Format" type="ENUMERATION">doc</aTTRIBUTE>
+<aTTRIBUTE name="Document Kind" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Document Lifecycle" type="STRING"></aTTRIBUTE>
+<rECORD name="Document Tags"></rECORD>
+<aTTRIBUTE name="Document Version" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16564" class="Document" name="Video: Service Conference Management">
+<aTTRIBUTE name="Position" type="STRING">NODE x:6.5cm y:8.5cm index:10</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-02] Attribute \&quot;Fontcolor\&quot; (Group) does not exist!  \&quot;fontcolor\&quot; (Document)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<rECORD name="Technical Attributes"></rECORD>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Referenced document" type="PROGRAMCALL">ITEM &quot;&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Dokument</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Display file name" type="INTEGER">0</aTTRIBUTE>
+<rECORD name="CompetencyAndLevel"></rECORD>
+<iNTERREF name="Referenced Learning Object"></iNTERREF>
+<aTTRIBUTE name="Document Type" type="ENUMERATION">Not Specified</aTTRIBUTE>
+<aTTRIBUTE name="Document Form" type="ENUMERATION">Text</aTTRIBUTE>
+<aTTRIBUTE name="Document Format" type="ENUMERATION">doc</aTTRIBUTE>
+<aTTRIBUTE name="Document Kind" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Document Lifecycle" type="STRING"></aTTRIBUTE>
+<rECORD name="Document Tags"></rECORD>
+<aTTRIBUTE name="Document Version" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16567" class="Document" name="Course Note: Managing Service Conference">
+<aTTRIBUTE name="Position" type="STRING">NODE x:9.5cm y:8.5cm index:11</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-02] Attribute \&quot;Fontcolor\&quot; (Group) does not exist!  \&quot;fontcolor\&quot; (Document)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<rECORD name="Technical Attributes"></rECORD>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Referenced document" type="PROGRAMCALL">ITEM &quot;&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Dokument</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Display file name" type="INTEGER">0</aTTRIBUTE>
+<rECORD name="CompetencyAndLevel"></rECORD>
+<iNTERREF name="Referenced Learning Object"></iNTERREF>
+<aTTRIBUTE name="Document Type" type="ENUMERATION">Not Specified</aTTRIBUTE>
+<aTTRIBUTE name="Document Form" type="ENUMERATION">Text</aTTRIBUTE>
+<aTTRIBUTE name="Document Format" type="ENUMERATION">doc</aTTRIBUTE>
+<aTTRIBUTE name="Document Kind" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Document Lifecycle" type="STRING"></aTTRIBUTE>
+<rECORD name="Document Tags"></rECORD>
+<aTTRIBUTE name="Document Version" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<cONNECTOR id="con.16570" class="Is inside">
+<fROM instance="Acquired Competency Barnaby Barnes" class="Document"></fROM>
+<tO instance="Competency Profiles" class="Group"></tO>
+<aTTRIBUTE name="AutoConnect" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16571" class="Is inside">
+<fROM instance="SCIA Instance" class="Document"></fROM>
+<tO instance="Business Relevant Documents" class="Group"></tO>
+<aTTRIBUTE name="AutoConnect" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16572" class="Is inside">
+<fROM instance="Third Party Opinion" class="Document"></fROM>
+<tO instance="Business Relevant Documents" class="Group"></tO>
+<aTTRIBUTE name="AutoConnect" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16573" class="Is inside">
+<fROM instance="Titolo Unico Authorization Document" class="Document"></fROM>
+<tO instance="Business Relevant Documents" class="Group"></tO>
+<aTTRIBUTE name="AutoConnect" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16574" class="Is inside">
+<fROM instance="Required Compentency SUAP Officer" class="Document"></fROM>
+<tO instance="Competency Profiles" class="Group"></tO>
+<aTTRIBUTE name="AutoConnect" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16575" class="Is inside">
+<fROM instance="Book: Managing Service Conference" class="Document"></fROM>
+<tO instance="Learning Objects" class="Group"></tO>
+<aTTRIBUTE name="AutoConnect" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16576" class="Is inside">
+<fROM instance="Video: Service Conference Management" class="Document"></fROM>
+<tO instance="Learning Objects" class="Group"></tO>
+<aTTRIBUTE name="AutoConnect" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16577" class="Is inside">
+<fROM instance="Course Note: Managing Service Conference" class="Document"></fROM>
+<tO instance="Learning Objects" class="Group"></tO>
+<aTTRIBUTE name="AutoConnect" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+</mODEL>
+<mODEL id="mod.16488" name="BMM TitoloUnico" version="" modeltype="BMM" libtype="bp" applib="LearnPAd Prototype Dynamic Library 0.21">
+<mODELATTRIBUTES>
+<aTTRIBUTE name="Keywords" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Model type" type="ENUMERATION">Current model</aTTRIBUTE>
+<aTTRIBUTE name="State" type="ENUMERATION">In process</aTTRIBUTE>
+<aTTRIBUTE name="Reviewed on" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Reviewed by" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Author" type="STRING">barbara</aTTRIBUTE>
+<aTTRIBUTE name="Creation date" type="STRING">13.08.2015, 12:22</aTTRIBUTE>
+<aTTRIBUTE name="Last user" type="STRING">congyu</aTTRIBUTE>
+<aTTRIBUTE name="Date last changed" type="STRING">03.09.2015, 08:10:39</aTTRIBUTE>
+<aTTRIBUTE name="Number of objects and relations" type="INTEGER">10</aTTRIBUTE>
+<aTTRIBUTE name="Context of version" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Position" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-01] Internal error!  \&quot;fontcolor\&quot; (BPModel)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<rECORD name="Technical Attributes"></rECORD>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Keine Modellbezeichnung vergeben</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Pool Term" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="ParticipantType" type="ENUMERATION">Role</aTTRIBUTE>
+<aTTRIBUTE name="Role" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Entity" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="BoundaryVisible" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="BPD Model Attributes" type="STRING">NOTEBOOK
+
+CHAPTER &quot;Business Process Diagram Attributes&quot;
+ATTR &quot;Name&quot; write-protected
+ATTR &quot;Contact person&quot;
+ATTR &quot;Author&quot; write-protected
+ATTR &quot;Language (BPMN)&quot;
+ATTR &quot;ExpressionLanguage&quot;
+ATTR &quot;QueryLanguage&quot;
+ATTR &quot;Creation date&quot; write-protected
+ATTR &quot;Date last changed&quot; write-protected
+ATTR &quot;Documentation (Model)&quot;
+ATTR &quot;State&quot;
+
+GROUP &quot;Copyright&quot;
+ATTR &quot;Copyright info&quot; 
+ATTR &quot;Copyright info position&quot; 
+ENDGROUP
+
+CHAPTER &quot;Process Attributes&quot;
+ATTR &quot;Name&quot; write-protected
+ATTR &quot;Process Term&quot;
+ATTR &quot;ProcessType&quot;
+ATTR &quot;Status&quot;
+ATTR &quot;Assignments&quot; lines:5
+ATTR &quot;Properties (BPMN)&quot; lines:5
+ATTR &quot;AdHoc&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+GROUP &quot;AdHoc = True&quot;
+ATTR &quot;AdHocOrdering&quot;
+ATTR &quot;AdHocCompletionCondition&quot;
+ENDGROUP
+ATTR &quot;SuppressJoinFailure&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ATTR &quot;EnableInstanceCompensation&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ATTR &quot;Categories (Process)&quot;
+ATTR &quot;Documentation (Process)&quot;
+
+CHAPTER &quot;Pool Attributes&quot;
+GROUP &quot;Common Graphical Object Attributes&quot;
+ATTR &quot;Name&quot; write-protected
+ATTR &quot;Categories (Pool)&quot;
+ATTR &quot;Documentation (Pool)&quot;
+ENDGROUP
+GROUP &quot;Common Swimlane Attributes&quot;
+ATTR &quot;Pool Term&quot;
+ENDGROUP
+GROUP &quot;Pool Attributes&quot;
+ATTR &quot;ParticipantType&quot;
+ATTR &quot;Role&quot;
+ATTR &quot;Entity&quot;
+ATTR &quot;BoundaryVisible&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot; write-protected
+ENDGROUP</aTTRIBUTE>
+<aTTRIBUTE name="Language" type="ENUMERATION">System</aTTRIBUTE>
+<aTTRIBUTE name="ExpressionLanguage" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="QueryLanguage" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Process Term" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="BPD Term" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="ProcessType" type="ENUMERATION">None</aTTRIBUTE>
+<aTTRIBUTE name="Status" type="ENUMERATION">None</aTTRIBUTE>
+<rECORD name="Assignments"></rECORD>
+<aTTRIBUTE name="AdHoc" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="AdHocOrdering" type="ENUMERATION">None</aTTRIBUTE>
+<aTTRIBUTE name="AdHocCompletionCondition" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="EnableInstanceCompensation" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Categories (Process)" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation (Process)" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation (Pool)" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Categories (Pool)" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="SuppressJoinFailure" type="ENUMERATION">No</aTTRIBUTE>
+<rECORD name="Change history"></rECORD>
+<aTTRIBUTE name="RACI/DEMI visualisation" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Modelling direction" type="ENUMERATION">vertical</aTTRIBUTE>
+<aTTRIBUTE name="IT systems" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Responsible role" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Input/Output" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Products" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Use cases" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Products color" type="STRING">whitesmoke</aTTRIBUTE>
+<aTTRIBUTE name="RACI/DEMI color" type="STRING">whitesmoke</aTTRIBUTE>
+<aTTRIBUTE name="Responsible role color" type="STRING">whitesmoke</aTTRIBUTE>
+<aTTRIBUTE name="Input/Output color" type="STRING">whitesmoke</aTTRIBUTE>
+<aTTRIBUTE name="Use cases color" type="STRING">whitesmoke</aTTRIBUTE>
+<aTTRIBUTE name="IT systems color" type="STRING">whitesmoke</aTTRIBUTE>
+<aTTRIBUTE name="Contact person" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="_ToggleModelInfo_" type="PROGRAMCALL">ITEM &quot;_ToggleModelInfo_&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Display modelling information" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Documentation (Model)" type="STRING"></aTTRIBUTE>
+<rECORD name="Properties (BPMN)"></rECORD>
+<aTTRIBUTE name="CreationDate" type="EXPRESSION">EXPR val:&quot;13.08.2015, 12:22&quot;</aTTRIBUTE>
+<aTTRIBUTE name="ModificationDate" type="EXPRESSION">EXPR val:&quot;14.08.2015, 14:50:47&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Language (BPMN)" type="STRING">English</aTTRIBUTE>
+<aTTRIBUTE name="BPMN20 Model Attributes" type="LONGSTRING">NOTEBOOK
+# TODO AVAL sMfbRegistration:&quot;_MFB-Registration_&quot;
+CHAPTER &quot;Description&quot;
+ATTR &quot;Contact person&quot;
+ATTR &quot;Keywords&quot; lines:2
+ATTR &quot;Description&quot; lines:3
+ATTR &quot;Comment&quot; lines:3
+
+GROUP &quot;Copyright&quot;
+ATTR &quot;Copyright info&quot; 
+ATTR &quot;Copyright info position&quot; 
+ENDGROUP
+ATTR &quot;Name&quot; write-protected
+ATTR &quot;Id&quot; write-protected
+
+
+
+#---------------------------------------------
+CHAPTER &quot;Process properties&quot;
+#---------------------------------------------
+GROUP &quot;Process attributes&quot;
+ATTR &quot;Process type&quot; #None, Private, Public 
+ATTR &quot;Executable&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ATTR &quot;Closed&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ENDGROUP
+
+GROUP &quot;Process relevance&quot;
+ATTR &quot;Auditing&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ATTR &quot;Monitoring&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ENDGROUP
+
+CHAPTER &quot;User attributes&quot;
+ATTR &quot;Model type&quot;
+ATTR &quot;State&quot;
+ATTR &quot;Reviewed on&quot;
+ATTR &quot;Reviewed by&quot;
+
+CHAPTER &quot;System attributes&quot;
+ATTR &quot;Author&quot; write-protected
+ATTR &quot;Creation date&quot; write-protected
+ATTR &quot;Last user&quot; write-protected
+# ATTR &quot;Date last changed from&quot; write-protected
+ATTR &quot;Date last changed&quot; write-protected
+ATTR &quot;Number of objects and relations&quot; write-protected
+ATTR &quot;Context of version&quot; write-protected
+
+CHAPTER &quot;People-like view&quot;
+ATTR &quot;Action&quot;
+ATTR &quot;People-like view&quot;
+
+CHAPTER &quot;BAR Display&quot;
+ATTR &quot;BAR Display active&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot;
+AVAL s_Aktiv: &quot;BAR Display active&quot;
+ATTR &quot;Modelling direction&quot; ctrltype: radio enabled: (s_Aktiv = &quot;Yes&quot;)
+ATTR &quot;Modelling_size&quot;
+
+GROUP &quot;Responsible for execution&quot;
+ATTR &quot;Responsible for execution_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_Responsible_for_execution_display: &quot;Responsible for execution_display&quot;
+ATTR &quot;Responsible for execution_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_Responsible_for_execution_display = &quot;Yes&quot;))
+ATTR &quot;Responsible for execution_size&quot;
+ENDGROUP
+
+GROUP &quot;Accountable for approving results&quot;
+ATTR &quot;Accountable for approving results_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_Accountableforapprovingresults_display: &quot;Actor_display&quot;
+ATTR &quot;Accountable for approving results_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_Accountableforapprovingresults_display = &quot;Yes&quot;))
+ATTR &quot;Accountable for approving results_size&quot;
+ENDGROUP
+
+GROUP &quot;Cooperation/participation&quot;
+ATTR &quot;Cooperation/participation_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_Cooperationparticipation_display: &quot;Cooperation/participation_display&quot;
+ATTR &quot;Cooperation/participation_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_Cooperationparticipation_display = &quot;Yes&quot;))
+ATTR &quot;Cooperation/participation_size&quot;
+ENDGROUP
+
+GROUP &quot;To inform&quot;
+ATTR &quot;To inform_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_Toinform_display: &quot;To inform_display&quot;
+ATTR &quot;To inform_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_Toinform_display = &quot;Yes&quot;))
+ATTR &quot;To inform_size&quot;
+ENDGROUP
+
+GROUP &quot;Knowledge Product&quot;
+ATTR &quot;Knowledge Product_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_KnowledgeProduct_display: &quot;Knowledge Product_display&quot;
+ATTR &quot;Knowledge Product_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_KnowledgeProduct_display = &quot;Yes&quot;))
+ATTR &quot;Knowledge Product_size&quot;
+ENDGROUP
+
+GROUP &quot;Documents and Resources&quot;
+ATTR &quot;Documents and Resources_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_DocumentsandResources_display: &quot;Documents and Resources_display&quot;
+ATTR &quot;Documents and Resources_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_DocumentsandResources_display = &quot;Yes&quot;))
+ATTR &quot;Documents and Resources_size&quot;
+ENDGROUP
+
+GROUP &quot;Incoming Data Object&quot;
+ATTR &quot;Incoming Data Object_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_IncomingDataObject_display: &quot;Incoming Data Object_display&quot;
+ATTR &quot;Incoming Data Object_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_IncomingDataObject_display = &quot;Yes&quot;))
+ATTR &quot;Incoming Data Object_size&quot;
+ENDGROUP
+
+GROUP &quot;Outgoing Data Object&quot;
+ATTR &quot;Outgoing Data Object_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_OutgoingDataObject_display: &quot;Outgoing Data Object_display&quot;
+ATTR &quot;Outgoing Data Object_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_OutgoingDataObject_display = &quot;Yes&quot;))
+ATTR &quot;Outgoing Data Object_size&quot;
+ENDGROUP
+
+GROUP &quot;Description&quot;
+ATTR &quot;Description_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_Description_display: &quot;Description_display&quot;
+ATTR &quot;Description_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_Description_display = &quot;Yes&quot;))
+ATTR &quot;Description_size&quot;
+ENDGROUP
+
+CHAPTER &quot;Comment View&quot;
+ATTR &quot;Comment Mode&quot; ctrltype: check checked-value: &quot;No&quot; unchecked-value: &quot;Yes&quot;
+AVAL s_Aktiv: &quot;Comment Mode&quot;
+ATTR &quot;CommentAreaSize&quot;
+ATTR &quot;CommentModellingAreaSize&quot;
+ATTR &quot;CommentModellingDirection&quot;
+
+
+
+
+CHAPTER &quot;Change history&quot;
+ATTR &quot;Change history&quot; lines:30
+
+</aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;87007&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Auditing" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Monitoring" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Process type" type="ENUMERATION">None</aTTRIBUTE>
+<aTTRIBUTE name="Executable" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Closed" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Copyright info" type="STRING">Edit the model attributes to display your copyright info</aTTRIBUTE>
+<aTTRIBUTE name="Copyright info position" type="ENUMERATION">Bottom right</aTTRIBUTE>
+<aTTRIBUTE name="_GoToAceHp_" type="PROGRAMCALL">ITEM &quot;_GoToAceHp_&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="__GfxThumb__" type="LONGSTRING">iVBORw0KGgoAAAANSUhEUgAAALMAAAEACAIAAAB3X9DLAAAACXBIWXMAAAsTAAALEwEAmpwYAAAJ2UlEQVR4nO3dsWsb5x/H8Y/gh/+CkK0Bg3UBkSlDh8ek2UpsZdAQMmTxkHIpXVwKHkw8pmRICycKBYcWkg4ZSgcR0KOxhOKOncyR3CMI7ViSfyDL/YaTFTf62jlJJ1uW369JVe3HT3Qfvs/37h5JtTzPBYz432lPAHOKZMBGMmAjGbCRDNhIBmwkAzaSAVupZNRqteKC2OEHknh8Jh6X+WHjoH/0GugwDVhU5iE+7qjPdyb67XbYjDqrD3Tlyv5j7Xitd1qh0dlIGzsNKUrXO6281al1Wl7rD/aTnad68Ch6OvyBprKuUjW31A1Rut5pea13GonU3G12V+vpTr5bb7fDZrPe6250or1Wp9Zphf31+hWf766p12tnWdRU1tWvafS0kYWmOt3mbhSK5zsb6f6Vxk5Dna+/fuzzfO20X6/jjR7rs5yMe91mK613GklDkqJIWRZJmSQp2tys93pByg49eVgUqZNFW5trare7w9+NoubamtrtrhRtbq712u16NPgTH/xMrxeyTJE6HTUagxGL5yWFurJHmYrn01/Trb3dlRN6WSY0XjLOit692oNG2Ns80Re/3+tpba3Enyz9g3NmEZKBWTju3GS+VxNUafRYcz0DNqoCbNQM2OgzINFnoDyqAmxla0Zx96Vaw1AyuDn4LMYvXwjG6DMe/vVuqkn91/bVpcP/yeDm4NWOPzr4EH0GyjouGbQg58fosR63ZvT3nvVX79x4++yrl9d+vPDLUno9bby4+yTo08+3Lyro9W//Lv/8me5+93r74f2VvWf91Wsrr/64m1560Xix9ETPH96/weDzNPiRJrue0X9z6ZvVT/qvrn9/8Z/+m+VbN5clBUlavnVRvZcqnlm5oN7bv58/eX3rpn7Q9S/0U5A+OksGP/nBp9ifUavVyrdCr75d+n05/fLOcbeet68uMfjxg481/gSDHzZeBzpxn3H5/rvLk/0mg5/S4NP3GTgvxlhNKv/bDH784LMYv/xqcnb3gaJKxrHOKxASJ5cksZxzkmKfB+9DFSMPBpdin/tYkktCHpI4mW70YszhVJNYLgkhcc45l4Q8z71T7POQuNjP18xHxo99PphnSJymme4HqAqwsT8D0riryfH/92AR8UURdu8rp3PvF5fY5yFMWECLOi+pKPIhcS72ifdFTZ54WJOP5eLKVsD80OQHdX64cnmf55UtK8N1ZNplZPRYUxVg43oGbPQZkKruMz5Q+VLtk8R7n8SH2pcZrdYhDFuBWaj8lRmiz8CJo8/AEcaqMEcLiXMudq7iC6CHVVWTi4VjeGod+9zHLvahmHZInEuCj10Sch9Pu74Ui2BxXXX6mj/DmY8ea+6bQFrUz8/ATExV3vL8v1cqD04i4qLqV3gDqfLTh8EV1YOa7Jx0cL2yWLOmX0re/6GDV6byc5+QOM3ovIfVBBLvN0F5VAUcofoFqkon08TkB31MJX2Aj4tXdnD2WHQBxSllCMEPb0FXOv/q0WdAos/AGE65Zp2mwQ5QFydhuDPUVb4n6KxivYCN/RmQ6DNQHlWh0LtXeyD/dPcMfkD4jJAM2OgzIM14H+hZVFyUlEvCwbXLGd0UnXejx5qqABvnJrDRZ0jqt1c3ftWVneK70vLdOf/Os1ng8zNgYx8oyqLPwBHGOpNZLMOPCtJwZ1BS5Zsiz5LRY02fAYk+A+Wd5z6j317dSHduaz1t5VvZvUfRVqtTX3+s2Ofn9/R1iNUEEvszUB5VQVK/vfoo2tvK7nWbuyf77fJzjGTAxn0TSPQZKI+qIKnf76u7Uf/6z9if7zPVw0gGbPQZkNgHOmLwmWix94krdoOex9tpOftAUR7nJrB9JBnF93hRVxbYUYe41GoybE8Oj8LjxXh85EGnHsBEnwEbyYCNZMBGMmAjGbCRDNhIBmylknH4Stf8XKLhccnHk13v+viVLu7FLzzzEC/2+0367XZoRlm3k6baV2tvK3u/STx6VOu0ircchUYWmsq6StXcUjdE6Xqn5bXeaSRK0/3H2sl36+122GzWe92NTlR8zkbYX69fWdxNYIvfZ6ysNZWpoYaydle3G1k7RFubK9JuUK+/thvUC5kUlCra2lxRW5laSSOTkkYURVIjkaSVSN1+6KyntxO11UoaWWgkSaS+tAjvQ+B9rbCRDJTFPlDYFr/PQBnjvROJgnGeTbheFBdJKjTBNCqfwwTTmIc5zMjkfcbDv95VNYntq0uT/WKFc5h4GvMwh1mgz4BEn4HypqkZ/b1n/dU7N94+++rltR8v/LKUXk8bL+4+Cfr08+2LCnr927/LP3+mu9+93n54f2XvWX/12sqrP+6ml140Xiw90fOH929U8U+Yh2nMwxymMloFpr+e0X9z6ZvVT/qvrn9/8Z/+m+VbN5clBUlavnVRvZcqnlm5oN7bv58/eX3rpn7Q9S/0U5AqfDnmYRrzMIfKTHhHrVarley8Xn279Pty+uWd424ubF9dmuzcpHz3N6NpzMMcKnEKfcbl++8uTz/K1OZhGvMwh/I4N4E07rsXj19NqpwXV7qmmMOMLPbOHZQ13ierjG/wQSXOxT4P3sdu8IV1g2dO6vvWh19CMPgGglgu9j6Ek/zUlHmYwxhGk0BVgI39GTjCWBWmHB+7OB6U0OK7UE+mhPrYOSdJxVqWxHJJCIlzzrkk5HnunWKfh8SdzNexntbrMInRY01VgMQ+UJRHn4EjjLX2jKM4TzvdVXUe5jA/0zjO6LGmKkCiz8AYxqowH1OcK0qDk0MNTyD9SX8P6vu/nji5xIdwYiergwnMzUsxIe6bQGIfKMZwuiVrBkLiXOyTuLiZd+iqaOKKEwQf6ySXlbOK1QQ29nRBos9AeawXsHHfBDb6DEj0GSiP9QI2+gzY6DMg0WegPNYL2OgzII27muA8oyrAVrZmnPrXt/B4po+NI07NgIk+AzaSARvJgI1kwEYyYCMZsJEM2EgGbCQDNpIBG8mAjWTARjJgIxmwkQzYSAZsJAM2kgEbyYCNZMBGMmAjGbCRDNhIBmwkAzaSARvJgI1kwEYyYCMZsJEM2EgGbCQDNpIBG8mAjWTARjJgIxmwkQzYSAZsJAM2kgEbyYCNZMBGMmAjGbCRDNhIBmwkAzaSARvJgI1kwEYyYCMZsJEM2EgGbCQDNpIBG8mAjWTARjJgIxmwkQzYSAZsJAM2kgEbyYCNZMBGMmAjGbCRDNhIBmwkAzaSARvJgI1kwEYyYCMZsJEM2EgGbCQDNpIBG8mAjWTARjJgIxmwkQzYSAZsJAM2kgEbyYCNZMBGMmAjGbCRDNhIBmwkAzaSARvJgI1kwEYyYCMZsJEM2EgGbCQDNpIBG8mAjWTARjJgIxmwkQzYSAZs/wdRTP6NVpyYmgAAAABJRU5ErkJggg==</aTTRIBUTE>
+<aTTRIBUTE name="NT Model Attributes" type="LONGSTRING">NOTEBOOK
+CHAPTER &quot;Description&quot;
+#ATTR &quot;Shared&quot;
+ATTR &quot;Model state&quot; enabled:(cond(search (sMfbRegistration, &quot;MFB_VERS&quot;, 0) = -1, 1, 0))
+ATTR &quot;Description&quot;
+ATTR &quot;Show State&quot; ctrltype:check unchecked-value:&quot;No&quot; checked-value:&quot;Yes&quot; 
+ATTR &quot;Last user&quot; write-protected
+ATTR &quot;Date last changed&quot; write-protected
+#CHAPTER &quot;Suggestion for improvement&quot;
+#ATTR &quot;Suggestion for improvement&quot;
+</aTTRIBUTE>
+<aTTRIBUTE name="Model state" type="ENUMERATION">Draft</aTTRIBUTE>
+<aTTRIBUTE name="People-like view" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Action" type="ENUMERATION">Fill in</aTTRIBUTE>
+<aTTRIBUTE name="Keywords" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Description" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Model type" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Show State" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="BAR Display active" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Actor_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="Actor_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Actor_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="Description_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="Description_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Description_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="ModelingAreaSize" type="ENUMERATION">20</aTTRIBUTE>
+<aTTRIBUTE name="Modelling_size" type="ENUMERATION">3</aTTRIBUTE>
+<aTTRIBUTE name="DrawingAreaWidth" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="DrawingAreaHeight" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Reference overview settings" type="LONGSTRING">Responsible for execution|Responsible for execution
+Accountable for approving results|Accountable for approving results
+Cooperation/participation|Cooperation/participation
+To inform|To inform
+Modelling|Modelling
+Knowledge Product|Knowledge Product
+Documents and Resources|Documents and Resources
+#Data Object|Data Object
+Incoming Data Object|Incoming Data Object
+Outgoing Data Object|Outgoing Data Object
+Description|Description</aTTRIBUTE>
+<aTTRIBUTE name="Data Object_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="Data Object_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Data Object_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="Knowledge Product_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="Knowledge Product_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Knowledge Product_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="Documents and Resources_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Documents and Resources_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="Documents and Resources_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="Responsible for execution_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="Responsible for execution_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Responsible for execution_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="Accountable for approving results_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="Accountable for approving results_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Accountable for approving results_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="Cooperation/participation_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="Cooperation/participation_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Cooperation/participation_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="To inform_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="To inform_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="To inform_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="Incoming Data Object_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="Incoming Data Object_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Incoming Data Object_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="Outgoing Data Object_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="Outgoing Data Object_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Outgoing Data Object_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="id_bpmndi_diagram" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="id_bpmndi_plane" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="id_bpmndi_collaboration" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="CommentModellingAreaSize" type="ENUMERATION">3</aTTRIBUTE>
+<aTTRIBUTE name="CommentTypeSize" type="ENUMERATION">8</aTTRIBUTE>
+<aTTRIBUTE name="CommentAreaSize" type="ENUMERATION">2</aTTRIBUTE>
+<aTTRIBUTE name="Comment Mode" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="CommentxCoorTextBox" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="CommentyCoorTextBox" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="CommentModellingDirection" type="ENUMERATION">vertical</aTTRIBUTE>
+</mODELATTRIBUTES>
+<iNSTANCE id="obj.16489" class="Learning Goal" name="Proper management of user requests">
+<aTTRIBUTE name="Position" type="STRING">NODE x:3cm y:3cm w:3cm h:1cm index:1</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<rECORD name="Technical Attributes"></rECORD>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Show name" type="ENUMERATION">Yes</aTTRIBUTE>
+<iNTERREF name="Referenced Strategic Goal"></iNTERREF>
+<iNTERREF name="Referenced Operational Goal"></iNTERREF>
+<aTTRIBUTE name="Line Length" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Color" type="STRING">lightskyblue</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Cognitive Process Dimension" type="ENUMERATION">Remember</aTTRIBUTE>
+<aTTRIBUTE name="Knowledge Dimension" type="ENUMERATION">Factual</aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16492" class="Learning Goal" name="Confident check of regularity">
+<aTTRIBUTE name="Position" type="STRING">NODE x:3.5cm y:12cm w:3cm h:1cm index:2</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<rECORD name="Technical Attributes"></rECORD>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Show name" type="ENUMERATION">Yes</aTTRIBUTE>
+<iNTERREF name="Referenced Strategic Goal"></iNTERREF>
+<iNTERREF name="Referenced Operational Goal"></iNTERREF>
+<aTTRIBUTE name="Line Length" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Color" type="STRING">lightskyblue</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING">check regularity/irregularity of an request</aTTRIBUTE>
+<aTTRIBUTE name="Cognitive Process Dimension" type="ENUMERATION">Remember</aTTRIBUTE>
+<aTTRIBUTE name="Knowledge Dimension" type="ENUMERATION">Factual</aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16495" class="Group (BMM)" name="Organisation Related Goals (Role/Unit)">
+<aTTRIBUTE name="Position" type="STRING">NODE x:1cm y:1cm w:18.5cm h:8.5cm index:3</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<rECORD name="Technical Attributes"></rECORD>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Show name" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Name InOut" type="ENUMERATION">inside</aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16498" class="Group (BMM)" name="Process Related Goals">
+<aTTRIBUTE name="Position" type="STRING">NODE x:1cm y:10.5cm w:18.5cm h:5.5cm index:4</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<rECORD name="Technical Attributes"></rECORD>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Show name" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Name InOut" type="ENUMERATION">inside</aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16501" class="Learning Goal" name="Properly coordination of admin procedure">
+<aTTRIBUTE name="Position" type="STRING">NODE x:8.5cm y:12cm w:3cm h:1cm index:5</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<rECORD name="Technical Attributes"></rECORD>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Show name" type="ENUMERATION">Yes</aTTRIBUTE>
+<iNTERREF name="Referenced Strategic Goal"></iNTERREF>
+<iNTERREF name="Referenced Operational Goal"></iNTERREF>
+<aTTRIBUTE name="Line Length" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Color" type="STRING">lightskyblue</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING">Coordination of the administrative procedure in respect of timing and modality provided by the norms</aTTRIBUTE>
+<aTTRIBUTE name="Cognitive Process Dimension" type="ENUMERATION">Remember</aTTRIBUTE>
+<aTTRIBUTE name="Knowledge Dimension" type="ENUMERATION">Factual</aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16504" class="Learning Goal" name="Properly check of regularity">
+<aTTRIBUTE name="Position" type="STRING">NODE x:13.5cm y:12cm w:3cm h:1cm index:6</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<rECORD name="Technical Attributes"></rECORD>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Show name" type="ENUMERATION">Yes</aTTRIBUTE>
+<iNTERREF name="Referenced Strategic Goal"></iNTERREF>
+<iNTERREF name="Referenced Operational Goal"></iNTERREF>
+<aTTRIBUTE name="Line Length" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Color" type="STRING">lightskyblue</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Cognitive Process Dimension" type="ENUMERATION">Remember</aTTRIBUTE>
+<aTTRIBUTE name="Knowledge Dimension" type="ENUMERATION">Factual</aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16507" class="Learning Goal" name="Check regularity/irregularity of the requests">
+<aTTRIBUTE name="Position" type="STRING">NODE x:6.5cm y:3cm w:3cm h:1cm index:7</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<rECORD name="Technical Attributes"></rECORD>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Show name" type="ENUMERATION">Yes</aTTRIBUTE>
+<iNTERREF name="Referenced Strategic Goal"></iNTERREF>
+<iNTERREF name="Referenced Operational Goal"></iNTERREF>
+<aTTRIBUTE name="Line Length" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Color" type="STRING">lightskyblue</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Cognitive Process Dimension" type="ENUMERATION">Remember</aTTRIBUTE>
+<aTTRIBUTE name="Knowledge Dimension" type="ENUMERATION">Factual</aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16510" class="Learning Goal" name="Coordination of the administrative procedure in respect of timeing and modality provided by the norms">
+<aTTRIBUTE name="Position" type="STRING">NODE x:10cm y:3cm w:3cm h:1cm index:8</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<rECORD name="Technical Attributes"></rECORD>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Show name" type="ENUMERATION">Yes</aTTRIBUTE>
+<iNTERREF name="Referenced Strategic Goal"></iNTERREF>
+<iNTERREF name="Referenced Operational Goal"></iNTERREF>
+<aTTRIBUTE name="Line Length" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Color" type="STRING">lightskyblue</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Cognitive Process Dimension" type="ENUMERATION">Remember</aTTRIBUTE>
+<aTTRIBUTE name="Knowledge Dimension" type="ENUMERATION">Factual</aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16513" class="Learning Goal" name="Check regularity of data and declarations">
+<aTTRIBUTE name="Position" type="STRING">NODE x:13.5cm y:3cm w:3cm h:1cm index:9</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<rECORD name="Technical Attributes"></rECORD>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Show name" type="ENUMERATION">Yes</aTTRIBUTE>
+<iNTERREF name="Referenced Strategic Goal"></iNTERREF>
+<iNTERREF name="Referenced Operational Goal"></iNTERREF>
+<aTTRIBUTE name="Line Length" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Color" type="STRING">lightskyblue</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Cognitive Process Dimension" type="ENUMERATION">Remember</aTTRIBUTE>
+<aTTRIBUTE name="Knowledge Dimension" type="ENUMERATION">Factual</aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16516" class="Learning Goal" name="Draw up an administrative act">
+<aTTRIBUTE name="Position" type="STRING">NODE x:17cm y:3cm w:3cm h:1cm index:10</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<rECORD name="Technical Attributes"></rECORD>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Show name" type="ENUMERATION">Yes</aTTRIBUTE>
+<iNTERREF name="Referenced Strategic Goal"></iNTERREF>
+<iNTERREF name="Referenced Operational Goal"></iNTERREF>
+<aTTRIBUTE name="Line Length" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Color" type="STRING">lightskyblue</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Cognitive Process Dimension" type="ENUMERATION">Remember</aTTRIBUTE>
+<aTTRIBUTE name="Knowledge Dimension" type="ENUMERATION">Factual</aTTRIBUTE>
+</iNSTANCE>
+</mODEL>
+<mODEL id="mod.16471" name="Competency model TitoloUnico" version="" modeltype="Competency model" libtype="bp" applib="LearnPAd Prototype Dynamic Library 0.21">
+<mODELATTRIBUTES>
+<aTTRIBUTE name="Contact person" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Keywords" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Copyright info" type="STRING">Edit the model attributes to display your copyright info</aTTRIBUTE>
+<aTTRIBUTE name="Copyright info position" type="ENUMERATION">Bottom right</aTTRIBUTE>
+<aTTRIBUTE name="Model type" type="ENUMERATION">Current model</aTTRIBUTE>
+<aTTRIBUTE name="State" type="ENUMERATION">In process</aTTRIBUTE>
+<aTTRIBUTE name="Reviewed on" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Reviewed by" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Author" type="STRING">barbara</aTTRIBUTE>
+<aTTRIBUTE name="Creation date" type="STRING">13.08.2015, 12:20</aTTRIBUTE>
+<aTTRIBUTE name="Last user" type="STRING">congyu</aTTRIBUTE>
+<aTTRIBUTE name="Date last changed" type="STRING">07.09.2015, 09:50:02</aTTRIBUTE>
+<aTTRIBUTE name="Number of objects and relations" type="INTEGER">5</aTTRIBUTE>
+<aTTRIBUTE name="Context of version" type="STRING"></aTTRIBUTE>
+<rECORD name="Change history"></rECORD>
+<aTTRIBUTE name="Position" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-01] Internal error!  \&quot;fontcolor\&quot; (BPModel)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<rECORD name="Technical Attributes"></rECORD>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Keine Modellbezeichnung vergeben</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Pool Term" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="ParticipantType" type="ENUMERATION">Role</aTTRIBUTE>
+<aTTRIBUTE name="Role" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Entity" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="BoundaryVisible" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="BPD Model Attributes" type="STRING">NOTEBOOK
+
+CHAPTER &quot;Business Process Diagram Attributes&quot;
+ATTR &quot;Name&quot; write-protected
+ATTR &quot;Contact person&quot;
+ATTR &quot;Author&quot; write-protected
+ATTR &quot;Language (BPMN)&quot;
+ATTR &quot;ExpressionLanguage&quot;
+ATTR &quot;QueryLanguage&quot;
+ATTR &quot;Creation date&quot; write-protected
+ATTR &quot;Date last changed&quot; write-protected
+ATTR &quot;Documentation (Model)&quot;
+ATTR &quot;State&quot;
+
+GROUP &quot;Copyright&quot;
+ATTR &quot;Copyright info&quot; 
+ATTR &quot;Copyright info position&quot; 
+ENDGROUP
+
+CHAPTER &quot;Process Attributes&quot;
+ATTR &quot;Name&quot; write-protected
+ATTR &quot;Process Term&quot;
+ATTR &quot;ProcessType&quot;
+ATTR &quot;Status&quot;
+ATTR &quot;Assignments&quot; lines:5
+ATTR &quot;Properties (BPMN)&quot; lines:5
+ATTR &quot;AdHoc&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+GROUP &quot;AdHoc = True&quot;
+ATTR &quot;AdHocOrdering&quot;
+ATTR &quot;AdHocCompletionCondition&quot;
+ENDGROUP
+ATTR &quot;SuppressJoinFailure&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ATTR &quot;EnableInstanceCompensation&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ATTR &quot;Categories (Process)&quot;
+ATTR &quot;Documentation (Process)&quot;
+
+CHAPTER &quot;Pool Attributes&quot;
+GROUP &quot;Common Graphical Object Attributes&quot;
+ATTR &quot;Name&quot; write-protected
+ATTR &quot;Categories (Pool)&quot;
+ATTR &quot;Documentation (Pool)&quot;
+ENDGROUP
+GROUP &quot;Common Swimlane Attributes&quot;
+ATTR &quot;Pool Term&quot;
+ENDGROUP
+GROUP &quot;Pool Attributes&quot;
+ATTR &quot;ParticipantType&quot;
+ATTR &quot;Role&quot;
+ATTR &quot;Entity&quot;
+ATTR &quot;BoundaryVisible&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot; write-protected
+ENDGROUP</aTTRIBUTE>
+<aTTRIBUTE name="Language" type="ENUMERATION">System</aTTRIBUTE>
+<aTTRIBUTE name="ExpressionLanguage" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="QueryLanguage" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Process Term" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="BPD Term" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="ProcessType" type="ENUMERATION">None</aTTRIBUTE>
+<aTTRIBUTE name="Status" type="ENUMERATION">None</aTTRIBUTE>
+<rECORD name="Assignments"></rECORD>
+<aTTRIBUTE name="AdHoc" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="AdHocOrdering" type="ENUMERATION">None</aTTRIBUTE>
+<aTTRIBUTE name="AdHocCompletionCondition" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="EnableInstanceCompensation" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Categories (Process)" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation (Process)" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation (Pool)" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Categories (Pool)" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="SuppressJoinFailure" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="RACI/DEMI visualisation" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Modelling direction" type="ENUMERATION">vertical</aTTRIBUTE>
+<aTTRIBUTE name="IT systems" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Responsible role" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Input/Output" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Products" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Use cases" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Products color" type="STRING">whitesmoke</aTTRIBUTE>
+<aTTRIBUTE name="RACI/DEMI color" type="STRING">whitesmoke</aTTRIBUTE>
+<aTTRIBUTE name="Responsible role color" type="STRING">whitesmoke</aTTRIBUTE>
+<aTTRIBUTE name="Input/Output color" type="STRING">whitesmoke</aTTRIBUTE>
+<aTTRIBUTE name="Use cases color" type="STRING">whitesmoke</aTTRIBUTE>
+<aTTRIBUTE name="IT systems color" type="STRING">whitesmoke</aTTRIBUTE>
+<aTTRIBUTE name="_ToggleModelInfo_" type="PROGRAMCALL">ITEM &quot;_ToggleModelInfo_&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Display modelling information" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Documentation (Model)" type="STRING"></aTTRIBUTE>
+<rECORD name="Properties (BPMN)"></rECORD>
+<aTTRIBUTE name="CreationDate" type="EXPRESSION">EXPR val:&quot;13.08.2015, 12:20&quot;</aTTRIBUTE>
+<aTTRIBUTE name="ModificationDate" type="EXPRESSION">EXPR val:&quot;14.08.2015, 14:38:12&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Language (BPMN)" type="STRING">English</aTTRIBUTE>
+<aTTRIBUTE name="BPMN20 Model Attributes" type="LONGSTRING">NOTEBOOK
+# TODO AVAL sMfbRegistration:&quot;_MFB-Registration_&quot;
+CHAPTER &quot;Description&quot;
+ATTR &quot;Contact person&quot;
+ATTR &quot;Keywords&quot; lines:2
+ATTR &quot;Description&quot; lines:3
+ATTR &quot;Comment&quot; lines:3
+
+GROUP &quot;Copyright&quot;
+ATTR &quot;Copyright info&quot; 
+ATTR &quot;Copyright info position&quot; 
+ENDGROUP
+ATTR &quot;Name&quot; write-protected
+ATTR &quot;Id&quot; write-protected
+
+
+
+#---------------------------------------------
+CHAPTER &quot;Process properties&quot;
+#---------------------------------------------
+GROUP &quot;Process attributes&quot;
+ATTR &quot;Process type&quot; #None, Private, Public 
+ATTR &quot;Executable&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ATTR &quot;Closed&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ENDGROUP
+
+GROUP &quot;Process relevance&quot;
+ATTR &quot;Auditing&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ATTR &quot;Monitoring&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ENDGROUP
+
+CHAPTER &quot;User attributes&quot;
+ATTR &quot;Model type&quot;
+ATTR &quot;State&quot;
+ATTR &quot;Reviewed on&quot;
+ATTR &quot;Reviewed by&quot;
+
+CHAPTER &quot;System attributes&quot;
+ATTR &quot;Author&quot; write-protected
+ATTR &quot;Creation date&quot; write-protected
+ATTR &quot;Last user&quot; write-protected
+# ATTR &quot;Date last changed from&quot; write-protected
+ATTR &quot;Date last changed&quot; write-protected
+ATTR &quot;Number of objects and relations&quot; write-protected
+ATTR &quot;Context of version&quot; write-protected
+
+CHAPTER &quot;People-like view&quot;
+ATTR &quot;Action&quot;
+ATTR &quot;People-like view&quot;
+
+CHAPTER &quot;BAR Display&quot;
+ATTR &quot;BAR Display active&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot;
+AVAL s_Aktiv: &quot;BAR Display active&quot;
+ATTR &quot;Modelling direction&quot; ctrltype: radio enabled: (s_Aktiv = &quot;Yes&quot;)
+ATTR &quot;Modelling_size&quot;
+
+GROUP &quot;Responsible for execution&quot;
+ATTR &quot;Responsible for execution_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_Responsible_for_execution_display: &quot;Responsible for execution_display&quot;
+ATTR &quot;Responsible for execution_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_Responsible_for_execution_display = &quot;Yes&quot;))
+ATTR &quot;Responsible for execution_size&quot;
+ENDGROUP
+
+GROUP &quot;Accountable for approving results&quot;
+ATTR &quot;Accountable for approving results_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_Accountableforapprovingresults_display: &quot;Actor_display&quot;
+ATTR &quot;Accountable for approving results_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_Accountableforapprovingresults_display = &quot;Yes&quot;))
+ATTR &quot;Accountable for approving results_size&quot;
+ENDGROUP
+
+GROUP &quot;Cooperation/participation&quot;
+ATTR &quot;Cooperation/participation_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_Cooperationparticipation_display: &quot;Cooperation/participation_display&quot;
+ATTR &quot;Cooperation/participation_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_Cooperationparticipation_display = &quot;Yes&quot;))
+ATTR &quot;Cooperation/participation_size&quot;
+ENDGROUP
+
+GROUP &quot;To inform&quot;
+ATTR &quot;To inform_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_Toinform_display: &quot;To inform_display&quot;
+ATTR &quot;To inform_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_Toinform_display = &quot;Yes&quot;))
+ATTR &quot;To inform_size&quot;
+ENDGROUP
+
+GROUP &quot;Knowledge Product&quot;
+ATTR &quot;Knowledge Product_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_KnowledgeProduct_display: &quot;Knowledge Product_display&quot;
+ATTR &quot;Knowledge Product_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_KnowledgeProduct_display = &quot;Yes&quot;))
+ATTR &quot;Knowledge Product_size&quot;
+ENDGROUP
+
+GROUP &quot;Documents and Resources&quot;
+ATTR &quot;Documents and Resources_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_DocumentsandResources_display: &quot;Documents and Resources_display&quot;
+ATTR &quot;Documents and Resources_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_DocumentsandResources_display = &quot;Yes&quot;))
+ATTR &quot;Documents and Resources_size&quot;
+ENDGROUP
+
+GROUP &quot;Incoming Data Object&quot;
+ATTR &quot;Incoming Data Object_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_IncomingDataObject_display: &quot;Incoming Data Object_display&quot;
+ATTR &quot;Incoming Data Object_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_IncomingDataObject_display = &quot;Yes&quot;))
+ATTR &quot;Incoming Data Object_size&quot;
+ENDGROUP
+
+GROUP &quot;Outgoing Data Object&quot;
+ATTR &quot;Outgoing Data Object_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_OutgoingDataObject_display: &quot;Outgoing Data Object_display&quot;
+ATTR &quot;Outgoing Data Object_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_OutgoingDataObject_display = &quot;Yes&quot;))
+ATTR &quot;Outgoing Data Object_size&quot;
+ENDGROUP
+
+GROUP &quot;Description&quot;
+ATTR &quot;Description_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_Description_display: &quot;Description_display&quot;
+ATTR &quot;Description_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_Description_display = &quot;Yes&quot;))
+ATTR &quot;Description_size&quot;
+ENDGROUP
+
+CHAPTER &quot;Comment View&quot;
+ATTR &quot;Comment Mode&quot; ctrltype: check checked-value: &quot;No&quot; unchecked-value: &quot;Yes&quot;
+AVAL s_Aktiv: &quot;Comment Mode&quot;
+ATTR &quot;CommentAreaSize&quot;
+ATTR &quot;CommentModellingAreaSize&quot;
+ATTR &quot;CommentModellingDirection&quot;
+
+
+
+
+CHAPTER &quot;Change history&quot;
+ATTR &quot;Change history&quot; lines:30
+
+</aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;87001&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Auditing" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Monitoring" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Process type" type="ENUMERATION">None</aTTRIBUTE>
+<aTTRIBUTE name="Executable" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Closed" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="_GoToAceHp_" type="PROGRAMCALL">ITEM &quot;_GoToAceHp_&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="__GfxThumb__" type="LONGSTRING">iVBORw0KGgoAAAANSUhEUgAAALMAAAEACAIAAAB3X9DLAAAACXBIWXMAAAsTAAALEwEAmpwYAAASGklEQVR4nO3cfWwc5Z0H8O86fskLudSNeSmE5gjeqTPZggBRspNyDdU1xXbPGvXQquo/loo7jqpSW2lXaqT5465atXf1uRqXXqXdCxz+q+ooldar28dQXkJTPA5qSIEuA51nEkjdu1wCCW2DL8F2vPfH7BqTPGnzZgbo9/PHamZn5pnf2t99dtfr+SWq1eqxY8f27dsH+qA5ffp0JpNZosETU1NTBw4cuP322xsbG5999tl3bUskAHzqU5+am5sDsO7aay9q6Kd++UtN0wAEQfDZu+++cjVfot8fPRotXOwDueDxjwFAorrumiUZv36WowvLBw4cWMJwjI2NHTx46ODBQ08++eRhlT179hw8eKg6M1Odman6w6IvbZV8J512fN9J9znDfVZfn+PPyOE+x58RfWkjnXb8mWj/ycnJycnJ6ozvpIH0sBjuc3zfSaetvsULJSs9LIbTRjptlaJxSqLki1KpvsNZg0ebgL5hURquHTvsy+G+hU3GcEmUfFmvrVb8zMzBgwerMzPvrqckSr4slZxaSX1O/VxWqeSk0/Vi/OrMjByOHjuAtJEGAGO4z+obFqWzxp8RfemFsmunA4xhP1o2hkvRPY4/I/pglc45xC+Jvvohi5ejsxyKfmMHx8bGfvrTn1aXRiOA06dPAXj++eejueEsq1evPnXqVLQcIhlsvM9EiJ07EYbY2RN8r6cwCWNjD3bv8pM78NKkN4lUCLQDwMqVKwEA7domYNfuHCaBHnvnTg0SIbDzPrfnm+jZod8ng92THoZtPFrevcvFDhs/QOcOrbZnWN69y0VPpj64hvaBh/zudshHw9qxm8bLL+1yscN+uWdwEs5OAGF5967CJIyNOwYeaI/qP3W69kC0nX71Xox85psudtgv39+LTamXdiHcYe7sCb7XEz2QykbomHTH2238AJ0/BkKZfMiUPygCSN+X2TTpTaaxe1dhEuh5oDMav/6D6tyxEwhlcqMWAhh/56cZhtompJLtAIy+YQ1h8BIqGx8dR/u7Drm3PXipfkj7vZ07StZLPUjWHsXp+lmWVGJsbOzGG28E0NjY+OKLL567x5133jn91vRtn0wtui8c+cz9eOgXA+1/YfTw8GEA7evXKzeef5Bw5Gvj3T9+4C8Nf9F+Xanclkr95f0utZhLGv+i/bpSiRampqaW7tUkMTY2dm39dXf9+vXHjh1raGhYtmxZQ0MDgDVr1hz+3e8wXwVw1x23X9TQ//P661NTUwBuvPHG66+++kpXftGePXAgWrjr9ot7IO+T8SP76mcBcOzo0SVMRrVaLZVKSzE0vQeWLhmNAHp6elzXXYrR6YMrUa1W466B3o8a4y6A3qeYDFJjMkiNySA1JoPUmAxSYzJIjckgNSaD1JgMUmMySI3JIDUmg9SYDFKLMxk3PfDzVx/cVlvZcw3uORZjMXSW2P4/Y93XHlve1HDy1NzRQif2bgCA+VlsncKpV7HiplhKosVimzO+lL6huP/IM9+5e/3XHzv85WnMrcLWKQBoasPeDUg/h6bWuGojxDhntH6lvHZ18/x89VD0gjI/g4ZmAPBuQ6uBmRO49SexFEaR2OaMhgYASCQSN3/j8TPz86/96PO1Ddd+EctWIbE8rsIoElsyVrY0ArhqeeML378HAJ7+GLYewdPXY/WtmP4tAHQMx1UbIcZkrFnRdHr2zPTbc3Nnqo3LEth6BHs3INGE5Tdg+mXcxSuwYxZbMq5vbQmPTv9herZjxxP7v7v1I6uaZhrXJebfxpu/QUNbU8t1cRVGkdjegd6Sferk6blXH9x29VfFfBXHd3UB2L9/f0tLS0dHR1NTUyxV0YJ45ozW+8ttq5ujP3OFP9x2x7f3RPfn8/lEIlEoFGKpihaLIRlvTs+2XdUsnc9Fq2tWvFPD9u3bhRDvfUl0Ll6jRmr8Ro3UmAxSYzLoPC6+gZN0LEcKyxJVYcESUlhGtAzAcIQQYuEew3EswzKwsJuIVh0pLMMwDMsyDEdGI1alY1hi4QRSCAuGIxzLkdIxDMsyEI0jpLAWjpKOAUsIyxL1QSzDMBx55fpV/bW6lDlD0/3eImwzDCqo6FLXMybGgwpgOLYGAIGeMTEOU9hIJkfRm0QliHZDkNF1wC0nR0dHgXJvslApj8Mt+FoWrlfASLazuxyt5gpIOYFb8LWsadsIiga8SiBNDUHF82WI2iapFZM5XZTdggsTbsHzkJK1RmF0ya7kZ5Px/i1BdmKh79ZZq/TBwk+tpMZ3oKTGZJAak0FqTAapMRmkxmSQGpNBakwGqTEZpMZkkBqTQWpMBqmxSwKpsUsCqbFLAqmxSwKpsUsCqbFLAqmxSwKpsUsCqbFLAqmxSwKpsUsCqfF6E1LjN2qkxmSQGpNB53EhF8xH/Qui3gQLHQqiZgTCMhwpo84IAKL+BMICYFhCOIZhWVZ9B8ASwjIcKSzDAqIeCjAsIYSMehzUzyUdw3CktABLLPRQsBxZFRZgOUIIx7CsqEeDEI5hOY5lGPUeDUIIIes1RAewa8JFu5A5I5TaqBn0FyseZIh6hwLPQ6q2Cg0I9JRlZUwNQBhUAHiVAKZtawggASDQLcsPgorny6SegeEB0PSMg8GuICuDXMHX8mgPy65XwJBj25osuwCC8YX2B76WRQXwBnO6sG0TuYKrS1ODZptBrstLCaEhyHW5GWFrMqgAVsaEVkGXlswv0fPqw+wKpiyaTq6EaM64ImdfmIzo4vBTK6nxHSipMRmkxmSQGpNBakwGqTEZpMZkkBqTQWpMBqkxGaTGZJAak0FqTAapMRmkxmSQGpNBanEmIzw63X7tqtrKc924oxxjMXSW2P6n65qvjv/NysbZuerhf9+Gp9aicQ3mTuKzr8dSDJ0rtjljdn4ewCc/vvrmgccPfrEZqNZi8at78NbLuOd/4yqMIrEl45/+sWPsuSPPH/7Thuta0fr3mH2jtuHOPfjF3+IXH8dnfhdXbYQYk/HPP3vlo1c1L29qWP/RZVtLg09vr7+O7N2Aa/4BWBZXYRSJLRktTcsA6OtWb7vlmjtvbsWL9+Kzr+PRBFasw9GfAQlsdOKqjRBjMtZe1Xx69syvDr5Zym4GAPwrnlqLlRuAKhKNmDkeV2EUie2zyaZvPfX27BkAJ96aOfFQNwDs+RgaGoEEEo34u0OxVEULYpszeu647ife7197cFty8PGuf5kU306/sPaJ2dlZADOzs0ZcZVFdbMnYve+/33xrBsDGG1a/8NqfANx6y6be3l4Ao6OjcVVFC+JJRvvA4386NffH//wCgFJ2c/vA49H9zc3NiUQilpLoLPEk44//N/v6f3QtXo0WCoXCyZMnYymJzsIrnkmN37WSGpNBakwGqV1+MsKR/nK36Q8hbxYTRVOaxd6iOWEWE10FGI4cxVC5O68NbQmyo+jtxehEd7l/yIeezWqyXMz5QEUfnRhox3h/oqtgWMLWczk/ldKzpp/sgqjmO8ORLb0YHfWTSYhqNugvd+e7y/29biVl2yYAoNgV7XnZj4bqrsCcoel+bxG2GQYVVHSp6xkT40EFMBxbk+Vc1F/L8yVM24YcL7uFggdDN22tOzuK3mShUg4HBnBudy/XsGyEADTbxjltuzwPCKC7XW7GAZC6/EdCiy1do6dzGmddSvetyzuQLh0/tZIa34GSGpNBakwGqTEZpMZkkBqTQWpMBqkxGaTGZJAak0FqTAapsUsCqbFLAqmxSwKpsUsCqbFLAqmxSwKpsUsCqbFLAqmxSwKpsUsCqbFLAqmxSwKp8XoTUuN3raTGZJAak0Hncf5LXqVjAIYjHMuR0jEMy1q8IKz6JmEBhiOrQojo0mTpGIYlLMASjuXIqrAAw3KElLX9DUtUpbN4kOrCJkTnNAxLCCGkdAzDeGd/IaQQUliwRG0cYRmWENEl0dIxgOhcQliGYSw+nWE4UgheN32h/syc0a6lgIKbgweYdr1zAeyM2zUIM6tngsAt+FoWumVU0I5OWUwMerBk1OYAuhME7qALM1MBAA0yanCQ0TMmomYH2dFRlHsHo64HLsyMnrKsjKkBto1cVy4jMq7nwbHr+9sYQnf23e0YvIq+0H/Bg+U4OjQg0FMoFHyZRe10nuf1Qk68J0+3D4WLTNKSNyw4p7fCu89uKTdeSFXnO5bU+KmV1PgOlNSYDFJjMkiNySA1JoPUmAxSYzJIjckgNSaD1JgMUmMySI3JIDUmg9SYDFJjMkiNySC1OJNx0wM/f/XBbbWVPdfgnmMxFkNnie1/utZ97bHlTQ0nT80dLXRi7wYAmJ/F1imcehUrboqlJFostjnjS+kbivuPPPOdu9d//bHDX57G3CpsnQKApjbs3YD0c2hqjas2QoxzRutXymtXN8/PVw9FLyjzM2hoBgDvNrQamDmBW38SS2EUiW3OaGgAgEQicfM3Hj8zP//ajz5f23DtF7FsFRLL4yqMIrElY2VLI4Crlje+8P17AODpj2HrETx9PVbfiunfAkDHcFy1EWJMxpoVTadnz0y/PTd3ptq4LIGtR7B3AxJNWH4Dpl/GXfviKowisSXj+taW8Oj0H6ZnO3Y8sf+7Wz+yqmmmcV1i/m28+Rs0tDW1XBdXYRSJ7R3oLdmnTp6ee/XBbVd/VcxXcXxXF4D9+/e3tLR0dHQ0NTXFUhUtiGfOaL2/3La6OfozV/jDbXd8e090fz6fTyQShUIhlqposRiS8eb0bNtVzdL5XLS6ZsU7NWzfvl0I8d6XROfida2kxm/USI3JIDUmg87jcppvSMew6h2YhBBCWAAcETU9EgYQtTKJGiYZgOE4QkgpohunvsNCTyYBAFatgZNVa7xkWLU2TvWOTcIxAMt6Vw8nSwjUT0dXxOXMGaHURs1gqAivUpa2BkA3DEcLhtCdB6QHoBwODCCoeBU9AAB0o9jbi8xoPlnuHfQMx5Yh2juztZ5MumU5pgnIMOq3ZGrRsbU2TrWOTe6gZzi2CciwXGsHlTERFABfAu2X+1ShyBX/bBKO9Je78wMX8AsKR7b0YnTiQnal9x4/tZIa34GSGpNBakwGqTEZpMZkkBqTQWpMBqkxGaTGZJAak0FqTAapMRmkxmSQGpNBakwGqTEZpMZkkBqTQWpMBqkxGaTGZJAak0FqTAapMRmkxmSQGpNBakwGqTEZpMZkkBqTQWpMBqkxGaTGZJAak0FqTAapMRmkxmSQGpNBakwGqTEZpMZkkBqTQWpMBqkxGaTGZJAak0FqTAapMRmkxmSQGpNBakwGqTEZpMZkkBqTQWpMBqkxGaTGZJAak0FqTAapMRmkxmSQGpNBakwGqTEZpMZkkBqTQWpMBqkxGaTGZJAak3HpwpEtycGUEHou0GwtCHKui1QqVajockIb6kfeDLYEfso383n09yOfx8iW3GDKrpoY7+zsxHh/oqtiGKlUplIY9CxRNTEOBEHO12zkcpWUPZHvDEe2DGk2itHhgWZrSAa5pAvHntAw3oliP/LZZCilTCaTUsroHhPjxVyXblcHaqfuT+Qqjj3RnQyllAhyuUGkxKhZTOZ0kXGLvm2aQa4IW3e73IycGGhnMi5ZWHY9WJkgN4iMADTNtm0AME3IkVyhkjFNZHzdNxFGqyPuoOcBwbipJYFwJFeA5dimhgAFeJVgXHe73IywbS3IdXkeUgAAzTaDXFd0ODICQNn1AAcYBzCSK1QyWWAoQD4p+wNkg1yhkjF1t6sAR3aGI1uiUxfgWUAIORQgqyHlGbAhYQobgG1qAJDRtcD1gAwAoEofPMKxHCEXrwpZu/3zhyzsIx3DcM6/d7VaTVSr1ViecfQ+x1eTD4cTI1seHsSnReaNoPsTmlybxPFy8bfIGuj1kAG6v6ANPVI0t+i5CYxu0eRaAJ2dHw1HHhnSevTcw4Nem2G84XkwnI6U35bPb2YyPiQ0+yvVToxsecaFYfulXrSlKq9AGqb9iSA35msGKm9UdOh4wy2vteGh+wvACan1mIFXBGB0ZFLPeF4b3FcKHvL5zXw1+St0YqQ/6M5vbv+zOzEZpMZXE1JjMj6s5Pj42iS8ocDIatHtcZlMYujfiua3zOIjuQoyoz2aDAANCIDNnZ0IR/6r3G24yYcnqt9iMj6skig+0ouODEq9fu12NHu8XEFFl3rlDc8Dyscz7jO+rem5Z3x7c2e4r+y+4qItZX0afJ9B5/P/llRt7rN/xUsAAAAASUVORK5CYII=</aTTRIBUTE>
+<aTTRIBUTE name="NT Model Attributes" type="LONGSTRING">NOTEBOOK
+CHAPTER &quot;Description&quot;
+#ATTR &quot;Shared&quot;
+ATTR &quot;Model state&quot; enabled:(cond(search (sMfbRegistration, &quot;MFB_VERS&quot;, 0) = -1, 1, 0))
+ATTR &quot;Description&quot;
+ATTR &quot;Show State&quot; ctrltype:check unchecked-value:&quot;No&quot; checked-value:&quot;Yes&quot; 
+ATTR &quot;Last user&quot; write-protected
+ATTR &quot;Date last changed&quot; write-protected
+#CHAPTER &quot;Suggestion for improvement&quot;
+#ATTR &quot;Suggestion for improvement&quot;
+</aTTRIBUTE>
+<aTTRIBUTE name="Model state" type="ENUMERATION">Draft</aTTRIBUTE>
+<aTTRIBUTE name="People-like view" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Action" type="ENUMERATION">Fill in</aTTRIBUTE>
+<aTTRIBUTE name="Keywords" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Description" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Model type" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Show State" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="BAR Display active" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Actor_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="Actor_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Actor_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="Description_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="Description_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Description_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="ModelingAreaSize" type="ENUMERATION">20</aTTRIBUTE>
+<aTTRIBUTE name="Modelling_size" type="ENUMERATION">3</aTTRIBUTE>
+<aTTRIBUTE name="DrawingAreaWidth" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="DrawingAreaHeight" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Reference overview settings" type="LONGSTRING">Responsible for execution|Responsible for execution
+Accountable for approving results|Accountable for approving results
+Cooperation/participation|Cooperation/participation
+To inform|To inform
+Modelling|Modelling
+Knowledge Product|Knowledge Product
+Documents and Resources|Documents and Resources
+#Data Object|Data Object
+Incoming Data Object|Incoming Data Object
+Outgoing Data Object|Outgoing Data Object
+Description|Description</aTTRIBUTE>
+<aTTRIBUTE name="Data Object_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="Data Object_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Data Object_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="Knowledge Product_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="Knowledge Product_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Knowledge Product_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="Documents and Resources_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Documents and Resources_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="Documents and Resources_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="Responsible for execution_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="Responsible for execution_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Responsible for execution_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="Accountable for approving results_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="Accountable for approving results_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Accountable for approving results_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="Cooperation/participation_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="Cooperation/participation_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Cooperation/participation_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="To inform_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="To inform_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="To inform_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="Incoming Data Object_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="Incoming Data Object_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Incoming Data Object_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="Outgoing Data Object_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="Outgoing Data Object_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Outgoing Data Object_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="id_bpmndi_diagram" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="id_bpmndi_plane" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="id_bpmndi_collaboration" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="CommentModellingAreaSize" type="ENUMERATION">3</aTTRIBUTE>
+<aTTRIBUTE name="CommentTypeSize" type="ENUMERATION">8</aTTRIBUTE>
+<aTTRIBUTE name="CommentAreaSize" type="ENUMERATION">2</aTTRIBUTE>
+<aTTRIBUTE name="Comment Mode" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="CommentxCoorTextBox" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="CommentyCoorTextBox" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="CommentModellingDirection" type="ENUMERATION">vertical</aTTRIBUTE>
+</mODELATTRIBUTES>
+<iNSTANCE id="obj.16472" class="Competency" name="Managing front-office &amp; external services">
+<aTTRIBUTE name="Position" type="STRING">NODE x:5cm y:3.5cm index:1</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<rECORD name="Technical Attributes"></rECORD>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Competency Statement" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Competency Class" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Model Source" type="PROGRAMCALL">ITEM &quot;&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Competency Level" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Knowledge Concept" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Knowledge Product" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16475" class="Competency" name="Assessing administrative &amp; procedural regularity">
+<aTTRIBUTE name="Position" type="STRING">NODE x:5cm y:7cm index:2</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<rECORD name="Technical Attributes"></rECORD>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Competency Statement" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Competency Class" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Model Source" type="PROGRAMCALL">ITEM &quot;&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Competency Level" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Knowledge Concept" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Knowledge Product" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16478" class="Competency" name="Manage specific admin procedure">
+<aTTRIBUTE name="Position" type="STRING">NODE x:5cm y:11cm index:3</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<rECORD name="Technical Attributes"></rECORD>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Competency Statement" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Competency Class" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Model Source" type="PROGRAMCALL">ITEM &quot;&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Competency Level" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Knowledge Concept" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Knowledge Product" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16481" class="Competency" name="Competent verification of congruency and pertinency">
+<aTTRIBUTE name="Position" type="STRING">NODE x:5cm y:14.5cm index:4</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<rECORD name="Technical Attributes"></rECORD>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Competency Statement" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Competency Class" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Model Source" type="PROGRAMCALL">ITEM &quot;&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Competency Level" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Knowledge Concept" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Knowledge Product" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16484" class="Competency" name="Ability to draw up formal documents">
+<aTTRIBUTE name="Position" type="STRING">NODE x:5cm y:18.5cm index:5</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<rECORD name="Technical Attributes"></rECORD>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Competency Statement" type="STRING">Ability to draw up formal documents at the end of the administrative procedure</aTTRIBUTE>
+<aTTRIBUTE name="Competency Class" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Model Source" type="PROGRAMCALL">ITEM &quot;&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Competency Level" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Knowledge Concept" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Knowledge Product" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+</mODEL>
+<mODEL id="mod.16437" name="TitoloUnico_MonitAzzurrSUB_4" version="" modeltype="Business process diagram (BPMN 2.0)" libtype="bp" applib="LearnPAd Prototype Dynamic Library 0.21">
+<mODELATTRIBUTES>
+<aTTRIBUTE name="Contact person" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Keywords" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Copyright info" type="STRING">Edit the model attributes to display your copyright info</aTTRIBUTE>
+<aTTRIBUTE name="Copyright info position" type="ENUMERATION">Bottom right</aTTRIBUTE>
+<aTTRIBUTE name="Name" type="STRING">TitoloUnico_MonitAzzurrSUB_4</aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;86612&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Process type" type="ENUMERATION">None</aTTRIBUTE>
+<aTTRIBUTE name="Executable" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Closed" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Auditing" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Monitoring" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Model type" type="ENUMERATION">Current model</aTTRIBUTE>
+<aTTRIBUTE name="State" type="ENUMERATION">In process</aTTRIBUTE>
+<aTTRIBUTE name="Reviewed on" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Reviewed by" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Author" type="STRING">barbara</aTTRIBUTE>
+<aTTRIBUTE name="Creation date" type="STRING">11.08.2015, 15:48</aTTRIBUTE>
+<aTTRIBUTE name="Last user" type="STRING">congyu</aTTRIBUTE>
+<aTTRIBUTE name="Date last changed" type="STRING">08.09.2015, 02:19:44</aTTRIBUTE>
+<aTTRIBUTE name="Number of objects and relations" type="INTEGER">18</aTTRIBUTE>
+<aTTRIBUTE name="Context of version" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Action" type="ENUMERATION">Fill in</aTTRIBUTE>
+<aTTRIBUTE name="People-like view" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="BAR Display active" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Modelling direction" type="ENUMERATION">vertical</aTTRIBUTE>
+<aTTRIBUTE name="Modelling_size" type="ENUMERATION">3</aTTRIBUTE>
+<aTTRIBUTE name="Responsible for execution_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Responsible for execution_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="Responsible for execution_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="Accountable for approving results_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Accountable for approving results_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="Accountable for approving results_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="Cooperation/participation_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Cooperation/participation_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="Cooperation/participation_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="To inform_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="To inform_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="To inform_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="Knowledge Product_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Knowledge Product_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="Knowledge Product_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="Documents and Resources_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Documents and Resources_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="Documents and Resources_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="Incoming Data Object_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Incoming Data Object_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="Incoming Data Object_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="Outgoing Data Object_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Outgoing Data Object_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="Outgoing Data Object_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="Description_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Description_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="Description_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="Comment Mode" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="CommentAreaSize" type="ENUMERATION">2</aTTRIBUTE>
+<aTTRIBUTE name="CommentModellingAreaSize" type="ENUMERATION">3</aTTRIBUTE>
+<aTTRIBUTE name="CommentModellingDirection" type="ENUMERATION">vertical</aTTRIBUTE>
+<rECORD name="Change history"></rECORD>
+<aTTRIBUTE name="Position" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-01] Internal error!  \&quot;fontcolor\&quot; (BPModel)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<rECORD name="Technical Attributes"></rECORD>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Keine Modellbezeichnung vergeben</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Pool Term" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="ParticipantType" type="ENUMERATION">Role</aTTRIBUTE>
+<aTTRIBUTE name="Role" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Entity" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="BoundaryVisible" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="BPD Model Attributes" type="STRING">NOTEBOOK
+
+CHAPTER &quot;Business Process Diagram Attributes&quot;
+ATTR &quot;Name&quot; write-protected
+ATTR &quot;Contact person&quot;
+ATTR &quot;Author&quot; write-protected
+ATTR &quot;Language (BPMN)&quot;
+ATTR &quot;ExpressionLanguage&quot;
+ATTR &quot;QueryLanguage&quot;
+ATTR &quot;Creation date&quot; write-protected
+ATTR &quot;Date last changed&quot; write-protected
+ATTR &quot;Documentation (Model)&quot;
+ATTR &quot;State&quot;
+
+GROUP &quot;Copyright&quot;
+ATTR &quot;Copyright info&quot; 
+ATTR &quot;Copyright info position&quot; 
+ENDGROUP
+
+CHAPTER &quot;Process Attributes&quot;
+ATTR &quot;Name&quot; write-protected
+ATTR &quot;Process Term&quot;
+ATTR &quot;ProcessType&quot;
+ATTR &quot;Status&quot;
+ATTR &quot;Assignments&quot; lines:5
+ATTR &quot;Properties (BPMN)&quot; lines:5
+ATTR &quot;AdHoc&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+GROUP &quot;AdHoc = True&quot;
+ATTR &quot;AdHocOrdering&quot;
+ATTR &quot;AdHocCompletionCondition&quot;
+ENDGROUP
+ATTR &quot;SuppressJoinFailure&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ATTR &quot;EnableInstanceCompensation&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ATTR &quot;Categories (Process)&quot;
+ATTR &quot;Documentation (Process)&quot;
+
+CHAPTER &quot;Pool Attributes&quot;
+GROUP &quot;Common Graphical Object Attributes&quot;
+ATTR &quot;Name&quot; write-protected
+ATTR &quot;Categories (Pool)&quot;
+ATTR &quot;Documentation (Pool)&quot;
+ENDGROUP
+GROUP &quot;Common Swimlane Attributes&quot;
+ATTR &quot;Pool Term&quot;
+ENDGROUP
+GROUP &quot;Pool Attributes&quot;
+ATTR &quot;ParticipantType&quot;
+ATTR &quot;Role&quot;
+ATTR &quot;Entity&quot;
+ATTR &quot;BoundaryVisible&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot; write-protected
+ENDGROUP</aTTRIBUTE>
+<aTTRIBUTE name="Language" type="ENUMERATION">System</aTTRIBUTE>
+<aTTRIBUTE name="ExpressionLanguage" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="QueryLanguage" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Process Term" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="BPD Term" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="ProcessType" type="ENUMERATION">None</aTTRIBUTE>
+<aTTRIBUTE name="Status" type="ENUMERATION">None</aTTRIBUTE>
+<rECORD name="Assignments"></rECORD>
+<aTTRIBUTE name="AdHoc" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="AdHocOrdering" type="ENUMERATION">None</aTTRIBUTE>
+<aTTRIBUTE name="AdHocCompletionCondition" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="EnableInstanceCompensation" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Categories (Process)" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation (Process)" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation (Pool)" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Categories (Pool)" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="SuppressJoinFailure" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="RACI/DEMI visualisation" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="IT systems" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Responsible role" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Input/Output" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Products" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Use cases" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Products color" type="STRING">whitesmoke</aTTRIBUTE>
+<aTTRIBUTE name="RACI/DEMI color" type="STRING">whitesmoke</aTTRIBUTE>
+<aTTRIBUTE name="Responsible role color" type="STRING">whitesmoke</aTTRIBUTE>
+<aTTRIBUTE name="Input/Output color" type="STRING">whitesmoke</aTTRIBUTE>
+<aTTRIBUTE name="Use cases color" type="STRING">whitesmoke</aTTRIBUTE>
+<aTTRIBUTE name="IT systems color" type="STRING">whitesmoke</aTTRIBUTE>
+<aTTRIBUTE name="_ToggleModelInfo_" type="PROGRAMCALL">ITEM &quot;_ToggleModelInfo_&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Display modelling information" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Documentation (Model)" type="STRING"></aTTRIBUTE>
+<rECORD name="Properties (BPMN)"></rECORD>
+<aTTRIBUTE name="CreationDate" type="EXPRESSION">EXPR val:&quot;11.08.2015, 15:48&quot;</aTTRIBUTE>
+<aTTRIBUTE name="ModificationDate" type="EXPRESSION">EXPR val:&quot;20.08.2015, 15:12:47&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Language (BPMN)" type="STRING">English</aTTRIBUTE>
+<aTTRIBUTE name="BPMN20 Model Attributes" type="LONGSTRING">NOTEBOOK
+# TODO AVAL sMfbRegistration:&quot;_MFB-Registration_&quot;
+CHAPTER &quot;Description&quot;
+ATTR &quot;Contact person&quot;
+ATTR &quot;Keywords&quot; lines:2
+ATTR &quot;Description&quot; lines:3
+ATTR &quot;Comment&quot; lines:3
+
+GROUP &quot;Copyright&quot;
+ATTR &quot;Copyright info&quot; 
+ATTR &quot;Copyright info position&quot; 
+ENDGROUP
+ATTR &quot;Name&quot; write-protected
+ATTR &quot;Id&quot; write-protected
+
+
+
+#---------------------------------------------
+CHAPTER &quot;Process properties&quot;
+#---------------------------------------------
+GROUP &quot;Process attributes&quot;
+ATTR &quot;Process type&quot; #None, Private, Public 
+ATTR &quot;Executable&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ATTR &quot;Closed&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ENDGROUP
+
+GROUP &quot;Process relevance&quot;
+ATTR &quot;Auditing&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ATTR &quot;Monitoring&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ENDGROUP
+
+CHAPTER &quot;User attributes&quot;
+ATTR &quot;Model type&quot;
+ATTR &quot;State&quot;
+ATTR &quot;Reviewed on&quot;
+ATTR &quot;Reviewed by&quot;
+
+CHAPTER &quot;System attributes&quot;
+ATTR &quot;Author&quot; write-protected
+ATTR &quot;Creation date&quot; write-protected
+ATTR &quot;Last user&quot; write-protected
+# ATTR &quot;Date last changed from&quot; write-protected
+ATTR &quot;Date last changed&quot; write-protected
+ATTR &quot;Number of objects and relations&quot; write-protected
+ATTR &quot;Context of version&quot; write-protected
+
+CHAPTER &quot;People-like view&quot;
+ATTR &quot;Action&quot;
+ATTR &quot;People-like view&quot;
+
+CHAPTER &quot;BAR Display&quot;
+ATTR &quot;BAR Display active&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot;
+AVAL s_Aktiv: &quot;BAR Display active&quot;
+ATTR &quot;Modelling direction&quot; ctrltype: radio enabled: (s_Aktiv = &quot;Yes&quot;)
+ATTR &quot;Modelling_size&quot;
+
+GROUP &quot;Responsible for execution&quot;
+ATTR &quot;Responsible for execution_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_Responsible_for_execution_display: &quot;Responsible for execution_display&quot;
+ATTR &quot;Responsible for execution_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_Responsible_for_execution_display = &quot;Yes&quot;))
+ATTR &quot;Responsible for execution_size&quot;
+ENDGROUP
+
+GROUP &quot;Accountable for approving results&quot;
+ATTR &quot;Accountable for approving results_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_Accountableforapprovingresults_display: &quot;Actor_display&quot;
+ATTR &quot;Accountable for approving results_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_Accountableforapprovingresults_display = &quot;Yes&quot;))
+ATTR &quot;Accountable for approving results_size&quot;
+ENDGROUP
+
+GROUP &quot;Cooperation/participation&quot;
+ATTR &quot;Cooperation/participation_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_Cooperationparticipation_display: &quot;Cooperation/participation_display&quot;
+ATTR &quot;Cooperation/participation_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_Cooperationparticipation_display = &quot;Yes&quot;))
+ATTR &quot;Cooperation/participation_size&quot;
+ENDGROUP
+
+GROUP &quot;To inform&quot;
+ATTR &quot;To inform_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_Toinform_display: &quot;To inform_display&quot;
+ATTR &quot;To inform_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_Toinform_display = &quot;Yes&quot;))
+ATTR &quot;To inform_size&quot;
+ENDGROUP
+
+GROUP &quot;Knowledge Product&quot;
+ATTR &quot;Knowledge Product_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_KnowledgeProduct_display: &quot;Knowledge Product_display&quot;
+ATTR &quot;Knowledge Product_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_KnowledgeProduct_display = &quot;Yes&quot;))
+ATTR &quot;Knowledge Product_size&quot;
+ENDGROUP
+
+GROUP &quot;Documents and Resources&quot;
+ATTR &quot;Documents and Resources_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_DocumentsandResources_display: &quot;Documents and Resources_display&quot;
+ATTR &quot;Documents and Resources_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_DocumentsandResources_display = &quot;Yes&quot;))
+ATTR &quot;Documents and Resources_size&quot;
+ENDGROUP
+
+GROUP &quot;Incoming Data Object&quot;
+ATTR &quot;Incoming Data Object_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_IncomingDataObject_display: &quot;Incoming Data Object_display&quot;
+ATTR &quot;Incoming Data Object_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_IncomingDataObject_display = &quot;Yes&quot;))
+ATTR &quot;Incoming Data Object_size&quot;
+ENDGROUP
+
+GROUP &quot;Outgoing Data Object&quot;
+ATTR &quot;Outgoing Data Object_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_OutgoingDataObject_display: &quot;Outgoing Data Object_display&quot;
+ATTR &quot;Outgoing Data Object_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_OutgoingDataObject_display = &quot;Yes&quot;))
+ATTR &quot;Outgoing Data Object_size&quot;
+ENDGROUP
+
+GROUP &quot;Description&quot;
+ATTR &quot;Description_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_Description_display: &quot;Description_display&quot;
+ATTR &quot;Description_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_Description_display = &quot;Yes&quot;))
+ATTR &quot;Description_size&quot;
+ENDGROUP
+
+CHAPTER &quot;Comment View&quot;
+ATTR &quot;Comment Mode&quot; ctrltype: check checked-value: &quot;No&quot; unchecked-value: &quot;Yes&quot;
+AVAL s_Aktiv: &quot;Comment Mode&quot;
+ATTR &quot;CommentAreaSize&quot;
+ATTR &quot;CommentModellingAreaSize&quot;
+ATTR &quot;CommentModellingDirection&quot;
+
+
+
+
+CHAPTER &quot;Change history&quot;
+ATTR &quot;Change history&quot; lines:30
+
+</aTTRIBUTE>
+<aTTRIBUTE name="_GoToAceHp_" type="PROGRAMCALL">ITEM &quot;_GoToAceHp_&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="__GfxThumb__" type="LONGSTRING">iVBORw0KGgoAAAANSUhEUgAAANoAAAEACAIAAABarf9xAAAACXBIWXMAAAsTAAALEwEAmpwYAAAR60lEQVR4nO3db3Aj9X3H8Y8OTx4wkwlTSC9DOA5SaeEW9UHJJDnJR/gTLmEtYtT0WGgyU6egkdqkROYuCr1Bk2FSkcRRTSVoCFLvCJ4mUyzoIAskQThCCGeZdDpAGd1CdtcHF0+Z4YA8SRPAh/Xrg7V9d/5z2DrZ/tr5vB7cSLK0+sr71u7qLMs+pdTRo0efe+450Hrz7rvvmqa51lN0km9iYuL555+/9NJLu7q6fvWrX530NZ8PwKc//en3338fwHmbNy9r0T9/9llN0wDYtn3VZZd1buY2rfQ8P3/2WU27CD5l/3oFH+/sowDw/PPPb7QiR0ZGxscPj48ffuqpp44s5Omnnx4fP6wmJ9XkpLIGa7FQvGLlQqGcZeVCsdxgLB6L5axJZzCWsyZrsVA4FMpZk971x8bGxsbG1KSVCwGxwVplMB4arA3Gctb0EmoVS1UG48eXOb0cNTmpJq1cbNCpxOKVSWcwFA6F4hVrZgkhAPGKlQshXrFqlUqtUsmFAHj3YqnKYDgExCpq8sQFnjzP9CSVWsVyKpVcLDb7iLwHEq9UcqGQd4VaxVKTk86gNyeAUDgEAOHBWDw2WKsssPzwYCUXQnjQmr47HD/tfQlAzpqsxRCvTKrJyVosdPysVanFZm5iVZzBWDg0fTXvXsYPj48fHh8ZGRkeHlYbSBeAd999B8CLL77obQXn+PCHP/zOO+94p10E7G27onCxdy9cF3t77e/1FscQ3taLh/dZgd04NNYYQ9AF/ABw5plnAgD8yf1WxA/ncVff5dgP7ythG8bGUEf6Zd13KBbftSuKemZsDPXH8fC+EnYnb/ED0La93FdButetPjzWGIul4QIBfZeDwN4wemcntL/XW9pVSe8dDPfuaRyCDb3nUCwONA45LvxOYJs2dx5oey11DfKX7ylhd/rlm/twSfDQPri7o3t77e/1eg+kuQ06xkp1fxp3wbgXcJ3A/qhzVxlAaJd5yVhjLISH9xXHgN5bDJz0eLVLEAz4p+dz68e/m647+6VwbFCDax9Cc9vjdfiN3XsxfdbFNdcYuyvxQ70I+OGHE9hmXlKJXDO9jDPPPPPdmTWywfhGRka2bNkCoKur66WXXpp/jU996lO//7/f/8WfB0+4zM1ffjP2P5P0z7/6SdwjRwD4t25d5lSPJz7UW4xV1L3XfPB1l7OctuZx81+rR+695YMea9vLXzb3yJHf/e53ACYmJjbYzto3MjKyeeagcOvWrUePHt20adMZZ5yxadMmAB/5yEeO/OY3aCkAn/nkpcta9OtvvjkxMQFgy5Yt5370o52efNlWep7Vebyvv/nmbyYmvNNH33hjo+WolKpUKms9BrVpg+XYBaC3t7dUKq31JETwKaXWegaiaV1rPQDRccyRBGGOJAhzJEGmcywWi2s7B/0ROuuss+b8L9XxrWM8Hl/1eeiP14JbQO6sSRDmSIIwRxKEOZIgzJEEYY4kCHMkQZgjCcIcSRDmSIIwxxO5+byTTBpuPlGNpLRsoAe1nG4DWgSZrDZaMODmE9VIIel383knosGxM2VtSC/3WbqJfiuqCoF8d1YbipazZUBPpZDts/ShFPpOvvlaP1CpmONc9XzC1lJJP/J6zUG5GkmhWq3C1O06jICjpZJ+AH5Nc2CXMzBNuwrd1KFpNc2Am4ep21Vb16NaxPAjr5s65t+cFjb9ywnFYpFvoaDVVCwWT/WOHqI1xxxJEOZIgjBHEoQ5kiDMkQRhjiQIcyRBmCMJwhxJEOZIgjBHEuR4jvxclBWVSCQKhcJaTyHddI7xeJwfgLvSzjrrrNW/0xtuuGF4eHj177c9/PTbVeLzrc23eq3utz3radb1y2tifZWxJvhSZpV4f1GPTo3P11XCnfVScOtIgqynpw5teNw6kiDMcZXw2HEpmCMJsp6eOrThcetIgjDHVcJjx6VgjiTIenrq0IbHrSMJwhxXCY8dl4I5kiDr6alDGx63jiQIc1wlPHZcii7+AuGqWatvtbRVPP8zmI8rFAqqozq+QNpICoXC8PDwYl/lzpoEYY6rhMeOS8EcSRDmuErWahO1jjaNYI4kCnNcJWtyDDf7WQPrZRvJHDc4pdQ6+gAM5riRqfX2wUDrKUffzodWYrHqyevbvu2yRlr6lU9npHVt3eTo2/nQ5OPXtxSmWmgptBSmFFqtmRMKrda8E4td+eQr+HY+1N7q9+186PePXjfVml6yAnxdH1p8JLUKI613q5HjwMBJxy633dbmvqNTLbZOvsLpuPmmr/7ymWdef/31j33sY1dcedW//ttP13yk47M9uBnATf/xp96J/Te+0ZnlAujcOp1jxXMcGPDt2fM/wHvApFLvAZMDA772pu9Ui7NX9q5wOhqNxs6dOycmJi688MKfPXlAwkiemx/c/IPeg9+q7PDO3mE8cvODmztVZAfX6Rwrm+P8uZV679ZbS+1N39kWZ698OrZ/ZvuBAwf+8Ic/NJvNK676nISRMLNd/FZlx53XPjHVOtZSx+6o/6V3+ekX2dl1OscK5rjg3N6//f372ph+JVqcap3WY7xv/0/eV0p5C4dPwkhei57bH/vC/K+eTpEdX6dzeDm6+e4szKaljabs7qw2pJf7LN1Ef6mZS48mDdTzCWh6psdKO3omYKUd3a4C0KxSphk0h1KoOsmksdDyF5jbu7CNWWdXofvD7nv9owk78eQXos7f9fx6W+3vjYCqBZ40auou+4prrdeuTrWSgbsuqpX85YNX6T+/onTB/nS3Cpz7anbYxXk3FXq3dOhA7YyuTS20fICC76QW3fuNwHeRu6/XOvy51Pk/CvzDy/HdSf2uv+nHl+PfiBd2bVm0xU4dO36n57GWOjaljrXUsTuf+EpnFgp0dp3OMbN1NAErqGtuFaZuV6GbOoCcqQOAm8/0FxvhcK42aiBv1woG8jYA2Lpp6lrSj/y85Q4M+Pbs+a/F5lbqvWRy4AOfTN7/3w4PD3vv1pzZnLjj/qHP24kfPVJ8RUV7rsu10j2Hv+aol+H4sfNavPZo8fAnUlsBvFL+yStFtdW5AP3nbw20XnPGasXaC7jmqkLrvONbrGVZZKT5m2r/BduAfy/dh0arFf28P7fbj/NbiH45t2Mn1Dha551qI9r2PLObxu/0PPbt2rUAbv/CT+984iupq4vZA/H+K3O5p/uXvoGcs/COrNMPuMdCoRCPx9u+/XzFYjEejw8M+PbsObjY3N6/d9/97dtuW8bPDIaHhz9rmJ3aIc6euDH1EA4s8ubk9TbS8PDwE61bANxhPDK7XUxdXWypY4NPff2WK35wzy++BeD+vz7a3sK/9KWPL2WdnmIhxWLxFO8GX8Fjx1PPPbttV0ot9idtbrjhBgAn/lmUk1f8/B1iLv9F67UrU69eHmj92LnsZ33PXD1qHk4Mu9hyU6H3/AVWvLcpOsUMyxzJO+EORQLf/+946g6oqwvdBxK/vDL16uWB83/hbBnHua/2fbeKC74++o0dC7e4rJHmz+PxWpxqTXotTrWOAWipYx/4PT/1wpe4Ttu2UjnedpsaGPDdemt5sbnvvjsz+zRa7Llimqb3XTNN07fzof/9z+s/cIf42qPFV7dGXeDCFo78mdmt6mO1YvUFGJ8rtLYssOJn94yL/vbG8kaaXmYLwCdx+NGi+kRq6tHigZaugKlxfBzOaLVx6IX4jS13SvkXbHFZI504j3fJEw/eAuCfHl/gtj985nbM/Adkewtf+jptz2yObj7vRDQ4dqY8/VJmKGoFylHlvbiJlrOZZjE48yIG0JLJQD3RV0YQ0UJhwZcxwGJzK/XeEuc78bs2f8V3Z9VLA7M7RKPVQuurySmF1rhqKUx9NtlSuHSH+uIiGyFvp7lcpx6ppTDV8n95RN2oMKUKrRZan1V/pdDqS7YUppT/0svUdYvso9sbacGw/nHnj2c2kMem1KR34r5n7zidBzvjdNfpKczm6Nc0B3Y5A9OcfinjGAUH9br34sbWo6OFVL3u2Cfc2NbNqAbbdmH45y/a20D29++bP/c992TbeBp18ODsxFudDoEj7b/xjZsf3Pz9J/8WQP+VOa9Fb7uI0/7ZTMfX6RzHd9aGYcAwRk/+smH4DcNY7GwymQRgLLppnJ4+mfyXjsy9Eit+ua+s5Y+EmSK919HeJfEdtxcP3tmRn8p0dp3OseI/JPSmn3NJe4taiRXfxs5a+Eger8jZs51q0dPBdTrHaryFolOzrsSKP81NkcCRZnX2PRNzdGqdzrFu3mCmnrxe2vsd5Y3k5rsD/Y14LgdECpFqImtBT6U0pwpE7EwfhkaTCxzkC7JucoTIN6VKG0lLO46d7SsVg1oKpWKxgXg0pSGCcqC/gbgDMEdaLX7DAIzCaLIAAIZKzn7FUKqwZmMtHXMkQZjjBuDmuwP9yNVMy46ktGxfOWoWe0rxMJpAMBjUUwUt6+tpxnPpVMTu6yshmB5d/CcXa4k5bgB+LQgUSxk0gKipm1Foes7UNC0KADYc124CgAanWmo0GvE0XJlHkcxxIzAKJx4aGvB+qHHS2enjSOPEA0p5mCMJwhxJEOZIgjBHEoQ5kiDMkQRhjiRIF1bg745I+0MmtF74lv5LdESdstgvjq2nz6KkDY/HjiQIcyRBmCMJwhxJEOZIgjBHEoQ5kiDMkQRhjiQIcyRBmCMJwhxJEOZIgjBHEoQ5kiDMkQRhjiQIcyRBmCMJwhxJEOZIgjBHEoQ5kiDMkQRhjiQIcyRBmCMJwhxJEOZIgjBHEoQ5kiDMkQRhjiQIcyRBmCMJwhxJEOZIgjBHEoQ5kiDMkQRhjiQIcyRBmCMJwhxJEOZIgjBHEoQ5kiDMkQRhjiQIcyRBmCMJwhxJEOZIgjBHEoQ5kiDMkQRhjiQIcyRBmCMJwhxJEOZIgjBHEoQ5kiDMkQRhjiQIcyRBmCMJwhxJEOZIgjBHEoQ5kiDMkQRhjiQIcyRBmCMJwhxJEOZIgjBHEoQ5kiDMkQRhjiQIcyRBmCMJwhxJEOZIgjBHEoQ5kiDMkQRhjiQIcyRBmCMJwhxJEOZIgjBHEoQ5kiDMkQRhjiQIcyRBmCMJwhxJEOZIgjBHEoQ5kiDMkQRhjiQIcyRBmCMJwhxJEOZIgjBHEoQ5kiDMkQRhjiQIcyRBmCMJwhxJEOZIgjBHEoQ5kiDMkQRhjiQIcyRBmCMJwhxJEOZIgjBHEoQ5kiDMkQRhjiQIcyRBmCMJwhxJEOZIgjBHEoQ5kiDMkQRhjiQIcyRBmCMJwhzXGTffHegP1mp6xtbSmm1nSiUEg8FiU3dGtWwChajdbVtBK1ooIJFAoYB8d6Y/mFZR1A3DQD3h62mGw8Gg2Sz2N+I1FUUdsO2MpaWRyTSD6dGC4ea7s1oaZe/mtpbWELAzgRJy6VENdQPlBAqpgOs4TiAQcBzHuySKejnTo6dVcvquE75MM5cejQRcx3FgZzL9CNaGouVARq+ZpbKVjkbtTBlpvdRTMp3RpJ85ri9utdRA3LQz/TBrgKal02kAiEbh5DPFphmNwrR0KwrXO5sv9TcagF2PagHAzWeKiOfSUQ02img07bpe6imZtXRaszM9jQaCAAAtHbUzPd7NYdYAVEsNIAfUAeQzxaaZArI2CgEnYSNlZ4pNM6qXeorIOYab7/buuohGHHDhZG2kNAQbYaThIFpLA0hHNQAwdc0uNQATAHxKqbX5xtI6U88nbC2VNPyzZxEpoJpApDBz2cI30eysdx03392HodHkItcGcyRRuLOmtv02331/P3bUzLfsyEWac3YAb1fLv0YqjL4GTCByrZZ9oBzt1jOjGOrWnLMBGMafuPkHslqvnrm/v3FOOPxWo4Fw7uKgdU6hsJ05Uvu09E3KQL77YAnhtFXpwznB5itwwtH0RXZmxNLCaL7V1KHjrVL17DQaiFwL/NbReqN2owwgfLEZPNhonIPSK8UGCoXt3FnT6vhtPmFHCtsXP24EeOxIonBnTYIwR+ogp14/O4BG1g6nNO/ft51AANl/Lke/GS0/kGnCHOrVHBvQABvYbhhw849VI+FS4P5R9U3mSB0UQPmBPlxsotJnTf87lHq72kRTd/TmW40GUH3bLB200pqeOWiltxvuc9XSKyWcE4zvAI8dSZT/B652uOx4s6bxAAAAAElFTkSuQmCC</aTTRIBUTE>
+<aTTRIBUTE name="NT Model Attributes" type="LONGSTRING">NOTEBOOK
+CHAPTER &quot;Description&quot;
+#ATTR &quot;Shared&quot;
+ATTR &quot;Model state&quot; enabled:(cond(search (sMfbRegistration, &quot;MFB_VERS&quot;, 0) = -1, 1, 0))
+ATTR &quot;Description&quot;
+ATTR &quot;Show State&quot; ctrltype:check unchecked-value:&quot;No&quot; checked-value:&quot;Yes&quot; 
+ATTR &quot;Last user&quot; write-protected
+ATTR &quot;Date last changed&quot; write-protected
+#CHAPTER &quot;Suggestion for improvement&quot;
+#ATTR &quot;Suggestion for improvement&quot;
+</aTTRIBUTE>
+<aTTRIBUTE name="Model state" type="ENUMERATION">Draft</aTTRIBUTE>
+<aTTRIBUTE name="Keywords" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Description" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Model type" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Show State" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Actor_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="Actor_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Actor_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="ModelingAreaSize" type="ENUMERATION">20</aTTRIBUTE>
+<aTTRIBUTE name="DrawingAreaWidth" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="DrawingAreaHeight" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Reference overview settings" type="LONGSTRING">Responsible for execution|Responsible for execution
+Accountable for approving results|Accountable for approving results
+Cooperation/participation|Cooperation/participation
+To inform|To inform
+Modelling|Modelling
+Knowledge Product|Knowledge Product
+Documents and Resources|Documents and Resources
+#Data Object|Data Object
+Incoming Data Object|Incoming Data Object
+Outgoing Data Object|Outgoing Data Object
+Description|Description</aTTRIBUTE>
+<aTTRIBUTE name="Data Object_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="Data Object_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Data Object_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="id_bpmndi_diagram" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="id_bpmndi_plane" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="id_bpmndi_collaboration" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="CommentTypeSize" type="ENUMERATION">8</aTTRIBUTE>
+<aTTRIBUTE name="CommentxCoorTextBox" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="CommentyCoorTextBox" type="STRING"></aTTRIBUTE>
+</mODELATTRIBUTES>
+<iNSTANCE id="obj.16438" class="Pool" name="Monti Azzurri Consorsium">
+<aTTRIBUTE name="Position" type="STRING">NODE x:0cm y:7cm w:23.5cm h:4.5cm index:1</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(&quot;&quot;) val:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<rECORD name="Technical Attributes"></rECORD>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="ParticipantType" type="ENUMERATION">Role</aTTRIBUTE>
+<aTTRIBUTE name="Role" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Entity" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="BoundaryVisible" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Process Term" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="ProcessType" type="ENUMERATION">None</aTTRIBUTE>
+<aTTRIBUTE name="Status" type="ENUMERATION">None</aTTRIBUTE>
+<rECORD name="Assignments"></rECORD>
+<rECORD name="Properties"></rECORD>
+<aTTRIBUTE name="AdHoc" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="AdHocOrdering" type="ENUMERATION">None</aTTRIBUTE>
+<aTTRIBUTE name="AdHocCompletionCondition" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="EnableInstanceCompensation" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Categories (Process)" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation (Process)" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="SuppressJoinFailure" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Open questions" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16438&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Color" type="STRING">white</aTTRIBUTE>
+<aTTRIBUTE name="Orientation" type="ENUMERATION">horizontal</aTTRIBUTE>
+<aTTRIBUTE name="Boundary visible" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Auditing" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Monitoring" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Process type" type="ENUMERATION">None</aTTRIBUTE>
+<aTTRIBUTE name="Executable" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Closed" type="ENUMERATION">No</aTTRIBUTE>
+<iNTERREF name="Referenced Organizational Unit">
+<iREF type="objectreference" tmodeltype="Organizational structure" tmodelname="Org Model Monti Azzurri" tmodelver="" tclassname="Organizational unit" tobjname="Monti Azzurri"></iREF>
+</iNTERREF>
+</iNSTANCE>
+<iNSTANCE id="obj.16441" class="Start Event" name="Start Event-83232">
+<aTTRIBUTE name="Position" type="STRING">NODE x:4cm y:9cm index:2</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Process calendar" type="LONGSTRING">D@Working day@b@32400-43200@U900;1800@45000-59400@U900;1800@Free day@c@@@$cbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbcbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbcbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbcccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbccbbccb</aTTRIBUTE>
+<aTTRIBUTE name="Quantity" type="EXPRESSION">EXPR expr:(0) val:0</aTTRIBUTE>
+<aTTRIBUTE name="Time period" type="ENUMERATION">Per year</aTTRIBUTE>
+<aTTRIBUTE name="Abandon after tolerance waiting time" type="ENUMERATION">no</aTTRIBUTE>
+<aTTRIBUTE name="Tolerance waiting time" type="TIME">00:000:00:00:00</aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-02] Attribute \&quot;Fontcolor\&quot; (Pool) does not exist!  \&quot;fontcolor\&quot; (Start Event)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<rECORD name="Technical Attributes"></rECORD>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Actor"></iNTERREF>
+<rECORD name="Assignments"></rECORD>
+<aTTRIBUTE name="Term" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Trigger" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Result" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Aggregated execution time" type="TIME">00:000:00:00:00</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated waiting time" type="TIME">00:000:00:00:00</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated resting time" type="TIME">00:000:00:00:00</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated transport time" type="TIME">00:000:00:00:00</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated cycle time" type="TIME">00:000:00:00:00</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Info on results" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Cost driver" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Cost driver quantity" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated personnel costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="External documentation" type="PROGRAMCALL">ITEM &quot;&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Prozeßstart</aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Open questions" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Modelling direction" type="EXPRESSION">EXPR val:&quot;vertical&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Implementing control" type="ENUMERATION">no</aTTRIBUTE>
+<aTTRIBUTE name="Show name" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16441&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Type" type="ENUMERATION">Top-level</aTTRIBUTE>
+<aTTRIBUTE name="Message" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Timer" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Conditional" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Signal" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Escalation" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Error" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Compensation" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Parallel" type="ENUMERATION">No</aTTRIBUTE>
+<rECORD name="Properties"></rECORD>
+<aTTRIBUTE name="Auditing" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Monitoring" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Collection" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Object type" type="ENUMERATION">Information</aTTRIBUTE>
+<aTTRIBUTE name="Cardinality" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Details" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Timer type" type="ENUMERATION">Date</aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16444" class="Task" name="Activate Service Conference">
+<aTTRIBUTE name="Position" type="STRING">NODE x:8cm y:9cm w:3.36cm h:1.8cm index:3</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Performer" type="EXPRESSION">EXPR expr:(&quot;&quot;) val:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Execution time" type="TIME">00:000:00:00:00</aTTRIBUTE>
+<aTTRIBUTE name="Waiting time" type="TIME">00:000:00:00:00</aTTRIBUTE>
+<aTTRIBUTE name="Resting time" type="TIME">00:000:00:00:00</aTTRIBUTE>
+<aTTRIBUTE name="Transport time" type="TIME">00:000:00:00:00</aTTRIBUTE>
+<aTTRIBUTE name="Priority" type="INTEGER">10</aTTRIBUTE>
+<aTTRIBUTE name="Done by" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Continuous execution" type="ENUMERATION">no</aTTRIBUTE>
+<aTTRIBUTE name="Max. resource waiting time" type="TIME">00:000:00:05:00</aTTRIBUTE>
+<aTTRIBUTE name="Cooperative" type="ENUMERATION">no</aTTRIBUTE>
+<aTTRIBUTE name="Cooperation mode" type="ENUMERATION">synchron</aTTRIBUTE>
+<aTTRIBUTE name="Average number of participants" type="INTEGER">1</aTTRIBUTE>
+<aTTRIBUTE name="Min. quota of presence" type="INTEGER">100</aTTRIBUTE>
+<aTTRIBUTE name="Max. start period" type="TIME">00:001:00:00:00</aTTRIBUTE>
+<aTTRIBUTE name="Execution interruptable" type="ENUMERATION">yes</aTTRIBUTE>
+<aTTRIBUTE name="Task stack" type="ENUMERATION">personal</aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-02] Attribute \&quot;Fontcolor\&quot; (Pool) does not exist!  \&quot;fontcolor\&quot; (Task)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<rECORD name="Technical Attributes"></rECORD>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Actor"></iNTERREF>
+<rECORD name="Assignments"></rECORD>
+<aTTRIBUTE name="Term" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Status" type="ENUMERATION">None</aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING">Orig.Name = Manage Service Conference</aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="External documentation" type="PROGRAMCALL">ITEM &quot;&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Info on results" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Number" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated execution time" type="TIME">00:000:00:00:00</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated waiting time" type="TIME">00:000:00:00:00</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated resting time" type="TIME">00:000:00:00:00</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated transport time" type="TIME">00:000:00:00:00</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated personnel costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Classification" type="ENUMERATIONLIST"></aTTRIBUTE>
+<aTTRIBUTE name="EDP transaction costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="EDP batch costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Printing costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Postal costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Aktivität</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Open questions" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Type" type="ENUMERATION">Standard</aTTRIBUTE>
+<iNTERREF name="referenced subprocess"></iNTERREF>
+<aTTRIBUTE name="Display responsible role" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Subprocessname" type="EXPRESSION">EXPR val:&quot;Bezeichnung&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Modelling direction" type="EXPRESSION">EXPR val:&quot;vertical&quot;</aTTRIBUTE>
+<rECORD name="Properties"></rECORD>
+<aTTRIBUTE name="Show name" type="ENUMERATION">center</aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16444&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Task type" type="ENUMERATION">Not specified</aTTRIBUTE>
+<aTTRIBUTE name="Global task" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Auditing" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Monitoring" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="For compensation" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Loop type" type="ENUMERATION">Not specified</aTTRIBUTE>
+<iNTERREF name="Call activity"></iNTERREF>
+<aTTRIBUTE name="Sequential execution" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Cardinality" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Referenced data input"></iNTERREF>
+<iNTERREF name="Referenced data output"></iNTERREF>
+<aTTRIBUTE name="Instantiate" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Collection" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Object type" type="ENUMERATION">Information</aTTRIBUTE>
+<aTTRIBUTE name="Completion condition" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Loop condition (standard)" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Referenced message"></iNTERREF>
+<aTTRIBUTE name="People-like_view_Expression" type="EXPRESSION">EXPR expr:(maval(&quot;People-like view&quot;)) val:&quot;No&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Action" type="ENUMERATION">Fill in</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Actor_" type="EXPRESSION">EXPR expr:(maval(&quot;Actor_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Description_" type="EXPRESSION">EXPR expr:(maval(&quot;Description_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_Modelling_direction_" type="EXPRESSION">EXPR expr:(maval(&quot;Modelling direction&quot;)) val:&quot;vertical&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Modelling_" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="_REFERENCE_OVERVIEW_SETTINGS_" type="EXPRESSION">EXPR expr:(maval(&quot;Reference overview settings&quot;)) val:&quot;Responsible for execution|Responsible for execution\nAccountable for approving results|Accountable for approving results\nCooperation/participation|Cooperation/participation\nTo inform|To inform\nModelling|Modelling\nKnowledge Product|Knowledge Product\nDocuments and Resources|Documents and Resources\n#Data Object|Data Object\nIncoming Data Object|Incoming Data Object\nOutgoing Data Object|Outgoing Data Object\nDescription|Description&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Actor_" type="EXPRESSION">EXPR expr:(maval(&quot;Actor_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Description_" type="EXPRESSION">EXPR expr:(maval(&quot;Description_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Modelling_" type="EXPRESSION">EXPR expr:(maval(&quot;Modelling_size&quot;)) val:&quot;3&quot;</aTTRIBUTE>
+<aTTRIBUTE name="BoolBarDisplayActive" type="EXPRESSION">EXPR expr:(maval(&quot;BAR Display active&quot;)) val:&quot;No&quot;</aTTRIBUTE>
+<iNTERREF name="Data Object"></iNTERREF>
+<iNTERREF name="Knowledge Product"></iNTERREF>
+<iNTERREF name="Documents and Resources"></iNTERREF>
+<aTTRIBUTE name="_disp_Knowledge Product_" type="EXPRESSION">EXPR expr:(maval(&quot;Knowledge Product_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Data Object_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Documents and Resources_" type="EXPRESSION">EXPR expr:(maval(&quot;Documents and Resources_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Data Object_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Documents and Resources_" type="EXPRESSION">EXPR expr:(maval(&quot;Documents and Resources_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Knowledge Product_" type="EXPRESSION">EXPR expr:(maval(&quot;Knowledge Product_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Responsible for execution_" type="EXPRESSION">EXPR expr:(maval(&quot;Responsible for execution_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Responsible for execution_" type="EXPRESSION">EXPR expr:(maval(&quot;Responsible for execution_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Accountable for approving results_" type="EXPRESSION">EXPR expr:(maval(&quot;Accountable for approving results_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Accountable for approving results_" type="EXPRESSION">EXPR expr:(maval(&quot;Accountable for approving results_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Cooperation/participation_" type="EXPRESSION">EXPR expr:(maval(&quot;Cooperation/participation_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Cooperation/participation_" type="EXPRESSION">EXPR expr:(maval(&quot;Cooperation/participation_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_To inform_" type="EXPRESSION">EXPR expr:(maval(&quot;To inform_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_To inform_" type="EXPRESSION">EXPR expr:(maval(&quot;To inform_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<iNTERREF name="Responsible for execution"></iNTERREF>
+<iNTERREF name="To inform"></iNTERREF>
+<iNTERREF name="Cooperation/participation"></iNTERREF>
+<iNTERREF name="Accountable for approving results"></iNTERREF>
+<iNTERREF name="Incoming Data Object"></iNTERREF>
+<iNTERREF name="Outgoing Data Object"></iNTERREF>
+<aTTRIBUTE name="_size_Outgoing Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Outgoing Data Object_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Outgoing Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Outgoing Data Object_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Incoming Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Incoming Data Object_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Incoming Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Incoming Data Object_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Commentboxcomment" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="CommentAreaSizeExp" type="EXPRESSION">EXPR expr:(maval(&quot;CommentAreaSize&quot;)) val:&quot;2&quot;</aTTRIBUTE>
+<aTTRIBUTE name="CommentBool" type="ENUMERATION">0</aTTRIBUTE>
+<aTTRIBUTE name="CommentBox" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="CommentInfo" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="CommentMode" type="EXPRESSION">EXPR expr:(maval(&quot;Comment Mode&quot;)) val:&quot;No&quot;</aTTRIBUTE>
+<rECORD name="CommentTable"></rECORD>
+<aTTRIBUTE name="WriteComment" type="PROGRAMCALL">ITEM &quot;Add Comment&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="ClearComment" type="PROGRAMCALL">ITEM &quot;Clear Comment&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="CommentModellingAreaSizeExp" type="EXPRESSION">EXPR expr:(maval(&quot;CommentModellingAreaSize&quot;)) val:&quot;3&quot;</aTTRIBUTE>
+<aTTRIBUTE name="BoolCommentModeActive" type="EXPRESSION">EXPR expr:(maval(&quot;Comment Mode&quot;)) val:&quot;No&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Comment Model Direction" type="EXPRESSION">EXPR expr:(maval(&quot;CommentModellingDirection&quot;)) val:&quot;vertical&quot;</aTTRIBUTE>
+<iNTERREF name="Decision"></iNTERREF>
+<iNTERREF name="Referenced documents"></iNTERREF>
+<aTTRIBUTE name="Left border" type="EXPRESSION">EXPR
+ val:6.32</aTTRIBUTE>
+<iNTERREF name="Referenced Planning Table"></iNTERREF>
+<aTTRIBUTE name="Right border" type="EXPRESSION">EXPR
+ val:9.68</aTTRIBUTE>
+<aTTRIBUTE name="Show or Hide" type="ENUMERATION">Shown</aTTRIBUTE>
+<aTTRIBUTE name="Top border" type="EXPRESSION">EXPR
+ val:8.1</aTTRIBUTE>
+<aTTRIBUTE name="Bottom border" type="EXPRESSION">EXPR
+ val:9.9</aTTRIBUTE>
+<aTTRIBUTE name="X" type="EXPRESSION">EXPR
+ val:8</aTTRIBUTE>
+<aTTRIBUTE name="Y" type="EXPRESSION">EXPR
+ val:9</aTTRIBUTE>
+<aTTRIBUTE name="Change Visibility" type="PROGRAMCALL">ITEM &quot;Change Visibility&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Planning Table" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Bounding box" type="EXPRESSION">EXPR
+ val:&quot;[8.1,9.9,6.32,9.68,8,9]&quot;</aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16447" class="Task" name="Confirm Decision">
+<aTTRIBUTE name="Position" type="STRING">NODE x:13.5cm y:9cm w:3.36cm h:1.8cm index:4</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Performer" type="EXPRESSION">EXPR expr:(&quot;&quot;) val:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Execution time" type="TIME">00:000:00:00:00</aTTRIBUTE>
+<aTTRIBUTE name="Waiting time" type="TIME">00:000:00:00:00</aTTRIBUTE>
+<aTTRIBUTE name="Resting time" type="TIME">00:000:00:00:00</aTTRIBUTE>
+<aTTRIBUTE name="Transport time" type="TIME">00:000:00:00:00</aTTRIBUTE>
+<aTTRIBUTE name="Priority" type="INTEGER">10</aTTRIBUTE>
+<aTTRIBUTE name="Done by" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Continuous execution" type="ENUMERATION">no</aTTRIBUTE>
+<aTTRIBUTE name="Max. resource waiting time" type="TIME">00:000:00:05:00</aTTRIBUTE>
+<aTTRIBUTE name="Cooperative" type="ENUMERATION">no</aTTRIBUTE>
+<aTTRIBUTE name="Cooperation mode" type="ENUMERATION">synchron</aTTRIBUTE>
+<aTTRIBUTE name="Average number of participants" type="INTEGER">1</aTTRIBUTE>
+<aTTRIBUTE name="Min. quota of presence" type="INTEGER">100</aTTRIBUTE>
+<aTTRIBUTE name="Max. start period" type="TIME">00:001:00:00:00</aTTRIBUTE>
+<aTTRIBUTE name="Execution interruptable" type="ENUMERATION">yes</aTTRIBUTE>
+<aTTRIBUTE name="Task stack" type="ENUMERATION">personal</aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-02] Attribute \&quot;Fontcolor\&quot; (Pool) does not exist!  \&quot;fontcolor\&quot; (Task)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<rECORD name="Technical Attributes"></rECORD>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Actor"></iNTERREF>
+<rECORD name="Assignments"></rECORD>
+<aTTRIBUTE name="Term" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Status" type="ENUMERATION">None</aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING">Orig.Name = Ask for Service Conference Opinion</aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="External documentation" type="PROGRAMCALL">ITEM &quot;&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Info on results" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Number" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated execution time" type="TIME">00:000:00:00:00</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated waiting time" type="TIME">00:000:00:00:00</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated resting time" type="TIME">00:000:00:00:00</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated transport time" type="TIME">00:000:00:00:00</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated personnel costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Classification" type="ENUMERATIONLIST"></aTTRIBUTE>
+<aTTRIBUTE name="EDP transaction costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="EDP batch costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Printing costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Postal costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Aktivität</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Open questions" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Type" type="ENUMERATION">Standard</aTTRIBUTE>
+<iNTERREF name="referenced subprocess"></iNTERREF>
+<aTTRIBUTE name="Display responsible role" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Subprocessname" type="EXPRESSION">EXPR val:&quot;Bezeichnung&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Modelling direction" type="EXPRESSION">EXPR val:&quot;vertical&quot;</aTTRIBUTE>
+<rECORD name="Properties"></rECORD>
+<aTTRIBUTE name="Show name" type="ENUMERATION">center</aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16447&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Task type" type="ENUMERATION">Send</aTTRIBUTE>
+<aTTRIBUTE name="Global task" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Auditing" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Monitoring" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="For compensation" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Loop type" type="ENUMERATION">Not specified</aTTRIBUTE>
+<iNTERREF name="Call activity"></iNTERREF>
+<aTTRIBUTE name="Sequential execution" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Cardinality" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Referenced data input"></iNTERREF>
+<iNTERREF name="Referenced data output"></iNTERREF>
+<aTTRIBUTE name="Instantiate" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Collection" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Object type" type="ENUMERATION">Information</aTTRIBUTE>
+<aTTRIBUTE name="Completion condition" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Loop condition (standard)" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Referenced message"></iNTERREF>
+<aTTRIBUTE name="People-like_view_Expression" type="EXPRESSION">EXPR expr:(maval(&quot;People-like view&quot;)) val:&quot;No&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Action" type="ENUMERATION">Fill in</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Actor_" type="EXPRESSION">EXPR expr:(maval(&quot;Actor_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Description_" type="EXPRESSION">EXPR expr:(maval(&quot;Description_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_Modelling_direction_" type="EXPRESSION">EXPR expr:(maval(&quot;Modelling direction&quot;)) val:&quot;vertical&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Modelling_" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="_REFERENCE_OVERVIEW_SETTINGS_" type="EXPRESSION">EXPR expr:(maval(&quot;Reference overview settings&quot;)) val:&quot;Responsible for execution|Responsible for execution\nAccountable for approving results|Accountable for approving results\nCooperation/participation|Cooperation/participation\nTo inform|To inform\nModelling|Modelling\nKnowledge Product|Knowledge Product\nDocuments and Resources|Documents and Resources\n#Data Object|Data Object\nIncoming Data Object|Incoming Data Object\nOutgoing Data Object|Outgoing Data Object\nDescription|Description&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Actor_" type="EXPRESSION">EXPR expr:(maval(&quot;Actor_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Description_" type="EXPRESSION">EXPR expr:(maval(&quot;Description_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Modelling_" type="EXPRESSION">EXPR expr:(maval(&quot;Modelling_size&quot;)) val:&quot;3&quot;</aTTRIBUTE>
+<aTTRIBUTE name="BoolBarDisplayActive" type="EXPRESSION">EXPR expr:(maval(&quot;BAR Display active&quot;)) val:&quot;No&quot;</aTTRIBUTE>
+<iNTERREF name="Data Object"></iNTERREF>
+<iNTERREF name="Knowledge Product"></iNTERREF>
+<iNTERREF name="Documents and Resources"></iNTERREF>
+<aTTRIBUTE name="_disp_Knowledge Product_" type="EXPRESSION">EXPR expr:(maval(&quot;Knowledge Product_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Data Object_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Documents and Resources_" type="EXPRESSION">EXPR expr:(maval(&quot;Documents and Resources_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Data Object_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Documents and Resources_" type="EXPRESSION">EXPR expr:(maval(&quot;Documents and Resources_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Knowledge Product_" type="EXPRESSION">EXPR expr:(maval(&quot;Knowledge Product_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Responsible for execution_" type="EXPRESSION">EXPR expr:(maval(&quot;Responsible for execution_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Responsible for execution_" type="EXPRESSION">EXPR expr:(maval(&quot;Responsible for execution_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Accountable for approving results_" type="EXPRESSION">EXPR expr:(maval(&quot;Accountable for approving results_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Accountable for approving results_" type="EXPRESSION">EXPR expr:(maval(&quot;Accountable for approving results_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Cooperation/participation_" type="EXPRESSION">EXPR expr:(maval(&quot;Cooperation/participation_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Cooperation/participation_" type="EXPRESSION">EXPR expr:(maval(&quot;Cooperation/participation_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_To inform_" type="EXPRESSION">EXPR expr:(maval(&quot;To inform_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_To inform_" type="EXPRESSION">EXPR expr:(maval(&quot;To inform_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<iNTERREF name="Responsible for execution"></iNTERREF>
+<iNTERREF name="To inform"></iNTERREF>
+<iNTERREF name="Cooperation/participation"></iNTERREF>
+<iNTERREF name="Accountable for approving results"></iNTERREF>
+<iNTERREF name="Incoming Data Object"></iNTERREF>
+<iNTERREF name="Outgoing Data Object"></iNTERREF>
+<aTTRIBUTE name="_size_Outgoing Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Outgoing Data Object_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Outgoing Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Outgoing Data Object_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Incoming Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Incoming Data Object_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Incoming Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Incoming Data Object_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Commentboxcomment" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="CommentAreaSizeExp" type="EXPRESSION">EXPR expr:(maval(&quot;CommentAreaSize&quot;)) val:&quot;2&quot;</aTTRIBUTE>
+<aTTRIBUTE name="CommentBool" type="ENUMERATION">0</aTTRIBUTE>
+<aTTRIBUTE name="CommentBox" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="CommentInfo" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="CommentMode" type="EXPRESSION">EXPR expr:(maval(&quot;Comment Mode&quot;)) val:&quot;No&quot;</aTTRIBUTE>
+<rECORD name="CommentTable"></rECORD>
+<aTTRIBUTE name="WriteComment" type="PROGRAMCALL">ITEM &quot;Add Comment&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="ClearComment" type="PROGRAMCALL">ITEM &quot;Clear Comment&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="CommentModellingAreaSizeExp" type="EXPRESSION">EXPR expr:(maval(&quot;CommentModellingAreaSize&quot;)) val:&quot;3&quot;</aTTRIBUTE>
+<aTTRIBUTE name="BoolCommentModeActive" type="EXPRESSION">EXPR expr:(maval(&quot;Comment Mode&quot;)) val:&quot;No&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Comment Model Direction" type="EXPRESSION">EXPR expr:(maval(&quot;CommentModellingDirection&quot;)) val:&quot;vertical&quot;</aTTRIBUTE>
+<iNTERREF name="Decision"></iNTERREF>
+<iNTERREF name="Referenced documents"></iNTERREF>
+<aTTRIBUTE name="Left border" type="EXPRESSION">EXPR
+ val:11.82</aTTRIBUTE>
+<iNTERREF name="Referenced Planning Table"></iNTERREF>
+<aTTRIBUTE name="Right border" type="EXPRESSION">EXPR
+ val:15.18</aTTRIBUTE>
+<aTTRIBUTE name="Show or Hide" type="ENUMERATION">Shown</aTTRIBUTE>
+<aTTRIBUTE name="Top border" type="EXPRESSION">EXPR
+ val:8.1</aTTRIBUTE>
+<aTTRIBUTE name="Bottom border" type="EXPRESSION">EXPR
+ val:9.9</aTTRIBUTE>
+<aTTRIBUTE name="X" type="EXPRESSION">EXPR
+ val:13.5</aTTRIBUTE>
+<aTTRIBUTE name="Y" type="EXPRESSION">EXPR
+ val:9</aTTRIBUTE>
+<aTTRIBUTE name="Change Visibility" type="PROGRAMCALL">ITEM &quot;Change Visibility&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Planning Table" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Bounding box" type="EXPRESSION">EXPR
+ val:&quot;[8.1,9.9,11.82,15.18,13.5,9]&quot;</aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16450" class="Intermediate Event (sequence flow)" name="Receive Confirmation">
+<aTTRIBUTE name="Position" type="STRING">NODE x:18cm y:9cm index:5</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(&quot;&quot;) val:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<rECORD name="Technical Attributes"></rECORD>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Actor"></iNTERREF>
+<rECORD name="Assignments"></rECORD>
+<aTTRIBUTE name="Term" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="External documentation" type="PROGRAMCALL">ITEM &quot;&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Open questions" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Auslöser</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Referenced trigger"></iNTERREF>
+<aTTRIBUTE name="Modelling direction" type="EXPRESSION">EXPR val:&quot;vertical&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Type" type="ENUMERATION">catching</aTTRIBUTE>
+<aTTRIBUTE name="Show name" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16450&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Message" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Timer" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Conditional" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Signal" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Escalation" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Compensation" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Parallel" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Link" type="ENUMERATION">No</aTTRIBUTE>
+<rECORD name="Properties"></rECORD>
+<aTTRIBUTE name="Auditing" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Monitoring" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Collection" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Object type" type="ENUMERATION">Information</aTTRIBUTE>
+<aTTRIBUTE name="Cardinality" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Details" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Timer type" type="ENUMERATION">Date</aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16453" class="End Event" name="End Event-83248">
+<aTTRIBUTE name="Position" type="STRING">NODE x:21.5cm y:9cm index:6</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Type" type="ENUMERATION">local</aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-02] Attribute \&quot;Fontcolor\&quot; (Pool) does not exist!  \&quot;fontcolor\&quot; (End Event)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<rECORD name="Technical Attributes"></rECORD>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Actor"></iNTERREF>
+<aTTRIBUTE name="Representation" type="ENUMERATION">without name</aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Ende</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Show name" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Open questions" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16453&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Message" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Signal" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Escalation" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Error" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Compensation" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Terminate" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Cancel" type="ENUMERATION">No</aTTRIBUTE>
+<rECORD name="Properties"></rECORD>
+<aTTRIBUTE name="Auditing" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Monitoring" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Collection" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Object type" type="ENUMERATION">Information</aTTRIBUTE>
+<aTTRIBUTE name="Cardinality" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Details" type="LONGSTRING"></aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16456" class="Pool (collapsed)" name="Service Conforence">
+<aTTRIBUTE name="Position" type="STRING">NODE x:12cm y:3cm w:23.5cm h:3cm index:11</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(&quot;&quot;) val:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<rECORD name="Technical Attributes"></rECORD>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="ParticipantType" type="ENUMERATION">Role</aTTRIBUTE>
+<aTTRIBUTE name="Role" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Entity" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="BoundaryVisible" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Process Term" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="ProcessType" type="ENUMERATION">None</aTTRIBUTE>
+<aTTRIBUTE name="Status" type="ENUMERATION">None</aTTRIBUTE>
+<rECORD name="Assignments"></rECORD>
+<rECORD name="Properties"></rECORD>
+<aTTRIBUTE name="AdHoc" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="AdHocOrdering" type="ENUMERATION">None</aTTRIBUTE>
+<aTTRIBUTE name="AdHocCompletionCondition" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="EnableInstanceCompensation" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Categories (Process)" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation (Process)" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="SuppressJoinFailure" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Open questions" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16456&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Color" type="STRING">white</aTTRIBUTE>
+<aTTRIBUTE name="Orientation" type="ENUMERATION">horizontal</aTTRIBUTE>
+<aTTRIBUTE name="Boundary visible" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Auditing" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Monitoring" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Process type" type="ENUMERATION">None</aTTRIBUTE>
+<aTTRIBUTE name="Executable" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Closed" type="ENUMERATION">No</aTTRIBUTE>
+<iNTERREF name="Referenced Organizational Unit"></iNTERREF>
+<iNTERREF name="Referenced process"></iNTERREF>
+<aTTRIBUTE name="Cardinality" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<cONNECTOR id="con.16459" class="Is inside">
+<fROM instance="Start Event-83232" class="Start Event"></fROM>
+<tO instance="Monti Azzurri Consorsium" class="Pool"></tO>
+<aTTRIBUTE name="AutoConnect" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16460" class="Subsequent">
+<fROM instance="Start Event-83232" class="Start Event"></fROM>
+<tO instance="Activate Service Conference" class="Task"></tO>
+<aTTRIBUTE name="Transition condition" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Transition probability" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualized values" type="ENUMERATION">Denomination</aTTRIBUTE>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 0 index:7</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">1</aTTRIBUTE>
+<aTTRIBUTE name="Representation" type="ENUMERATION">above/below</aTTRIBUTE>
+<aTTRIBUTE name="Font colour" type="ENUMERATION">black</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Info zur Übergangsbedingung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Nachfolger</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Denomination" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Description" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Auditing" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Monitoring" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Default" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Immediate" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Category" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16460&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Color" type="STRING">black</aTTRIBUTE>
+<aTTRIBUTE name="Doku" type="STRING">NOTEBOOK
+
+#-----------------------
+LANG &quot;en&quot;
+#-----------------------
+CHAPTER &quot;Description&quot;
+ATTR &quot;Denomination&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+
+
+CHAPTER &quot;Details (BPMN)&quot;
+
+ATTR &quot;Auditing&quot; 
+ATTR &quot;Monitoring&quot; 
+
+ATTR &quot;Default&quot; 
+ATTR &quot;Immediate&quot; 
+ATTR &quot;Category&quot;
+ATTR &quot;Id&quot; 
+
+
+CHAPTER &quot;Details (Simulation)&quot;
+
+ATTR &quot;Transition condition&quot; dialog:transcond
+
+ATTR &quot;Transition probability&quot;
+
+</aTTRIBUTE>
+<aTTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;Task&quot;</aTTRIBUTE>
+<aTTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Start Event&quot;</aTTRIBUTE>
+<aTTRIBUTE name="ModelTypeExp" type="EXPRESSION">EXPR val:&quot;Business process diagram (BPMN 2.0)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16461" class="Is inside">
+<fROM instance="Activate Service Conference" class="Task"></fROM>
+<tO instance="Monti Azzurri Consorsium" class="Pool"></tO>
+<aTTRIBUTE name="AutoConnect" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16462" class="Subsequent">
+<fROM instance="Activate Service Conference" class="Task"></fROM>
+<tO instance="Confirm Decision" class="Task"></tO>
+<aTTRIBUTE name="Transition condition" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Transition probability" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualized values" type="ENUMERATION">Denomination</aTTRIBUTE>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 0 index:8</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">2</aTTRIBUTE>
+<aTTRIBUTE name="Representation" type="ENUMERATION">above/below</aTTRIBUTE>
+<aTTRIBUTE name="Font colour" type="ENUMERATION">black</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Info zur Übergangsbedingung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Nachfolger</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Denomination" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Description" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Auditing" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Monitoring" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Default" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Immediate" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Category" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16462&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Color" type="STRING">black</aTTRIBUTE>
+<aTTRIBUTE name="Doku" type="STRING">NOTEBOOK
+
+#-----------------------
+LANG &quot;en&quot;
+#-----------------------
+CHAPTER &quot;Description&quot;
+ATTR &quot;Denomination&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+
+
+CHAPTER &quot;Details (BPMN)&quot;
+
+ATTR &quot;Auditing&quot; 
+ATTR &quot;Monitoring&quot; 
+
+ATTR &quot;Default&quot; 
+ATTR &quot;Immediate&quot; 
+ATTR &quot;Category&quot;
+ATTR &quot;Id&quot; 
+
+
+CHAPTER &quot;Details (Simulation)&quot;
+
+ATTR &quot;Transition condition&quot; dialog:transcond
+
+ATTR &quot;Transition probability&quot;
+
+</aTTRIBUTE>
+<aTTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;Task&quot;</aTTRIBUTE>
+<aTTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Task&quot;</aTTRIBUTE>
+<aTTRIBUTE name="ModelTypeExp" type="EXPRESSION">EXPR val:&quot;Business process diagram (BPMN 2.0)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16463" class="Is inside">
+<fROM instance="Confirm Decision" class="Task"></fROM>
+<tO instance="Monti Azzurri Consorsium" class="Pool"></tO>
+<aTTRIBUTE name="AutoConnect" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16464" class="Subsequent">
+<fROM instance="Confirm Decision" class="Task"></fROM>
+<tO instance="Receive Confirmation" class="Intermediate Event (sequence flow)"></tO>
+<aTTRIBUTE name="Transition condition" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Transition probability" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualized values" type="ENUMERATION">Denomination</aTTRIBUTE>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 0 index:9</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">3</aTTRIBUTE>
+<aTTRIBUTE name="Representation" type="ENUMERATION">above/below</aTTRIBUTE>
+<aTTRIBUTE name="Font colour" type="ENUMERATION">black</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Info zur Übergangsbedingung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Nachfolger</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Denomination" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Description" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Auditing" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Monitoring" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Default" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Immediate" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Category" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16464&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Color" type="STRING">black</aTTRIBUTE>
+<aTTRIBUTE name="Doku" type="STRING">NOTEBOOK
+
+#-----------------------
+LANG &quot;en&quot;
+#-----------------------
+CHAPTER &quot;Description&quot;
+ATTR &quot;Denomination&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+
+
+CHAPTER &quot;Details (BPMN)&quot;
+
+ATTR &quot;Auditing&quot; 
+ATTR &quot;Monitoring&quot; 
+
+ATTR &quot;Default&quot; 
+ATTR &quot;Immediate&quot; 
+ATTR &quot;Category&quot;
+ATTR &quot;Id&quot; 
+
+
+CHAPTER &quot;Details (Simulation)&quot;
+
+ATTR &quot;Transition condition&quot; dialog:transcond
+
+ATTR &quot;Transition probability&quot;
+
+</aTTRIBUTE>
+<aTTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;Intermediate Event (sequence flow)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Task&quot;</aTTRIBUTE>
+<aTTRIBUTE name="ModelTypeExp" type="EXPRESSION">EXPR val:&quot;Business process diagram (BPMN 2.0)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16465" class="Message Flow">
+<fROM instance="Confirm Decision" class="Task"></fROM>
+<tO instance="Service Conforence" class="Pool (collapsed)"></tO>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 1 x1:13.5cm y1:5cm index:12</aTTRIBUTE>
+<aTTRIBUTE name="Message Name" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="ParticipantType (from)" type="ENUMERATION">Role</aTTRIBUTE>
+<aTTRIBUTE name="Role (from)" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Entity (from)" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="ParticipantType (to)" type="ENUMERATION">Role</aTTRIBUTE>
+<aTTRIBUTE name="Role (to)" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Entity (to)" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Name" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Message Properties" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;Pool (collapsed)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Task&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Number" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Show Name" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Show Number" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Representation" type="ENUMERATION">above/below</aTTRIBUTE>
+<aTTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Description" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Show name" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Doku" type="STRING">NOTEBOOK
+
+#-----------------------
+CHAPTER &quot;Description&quot;
+#-----------------------
+ATTR &quot;Name&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+ATTR &quot;Id&quot; </aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16465&quot;</aTTRIBUTE>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16466" class="Is inside">
+<fROM instance="Receive Confirmation" class="Intermediate Event (sequence flow)"></fROM>
+<tO instance="Monti Azzurri Consorsium" class="Pool"></tO>
+<aTTRIBUTE name="AutoConnect" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16467" class="Subsequent">
+<fROM instance="Receive Confirmation" class="Intermediate Event (sequence flow)"></fROM>
+<tO instance="End Event-83248" class="End Event"></tO>
+<aTTRIBUTE name="Transition condition" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Transition probability" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualized values" type="ENUMERATION">Denomination</aTTRIBUTE>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 0 index:10</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">4</aTTRIBUTE>
+<aTTRIBUTE name="Representation" type="ENUMERATION">above/below</aTTRIBUTE>
+<aTTRIBUTE name="Font colour" type="ENUMERATION">black</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Info zur Übergangsbedingung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Nachfolger</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Denomination" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Description" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Auditing" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Monitoring" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Default" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Immediate" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Category" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16467&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Color" type="STRING">black</aTTRIBUTE>
+<aTTRIBUTE name="Doku" type="STRING">NOTEBOOK
+
+#-----------------------
+LANG &quot;en&quot;
+#-----------------------
+CHAPTER &quot;Description&quot;
+ATTR &quot;Denomination&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+
+
+CHAPTER &quot;Details (BPMN)&quot;
+
+ATTR &quot;Auditing&quot; 
+ATTR &quot;Monitoring&quot; 
+
+ATTR &quot;Default&quot; 
+ATTR &quot;Immediate&quot; 
+ATTR &quot;Category&quot;
+ATTR &quot;Id&quot; 
+
+
+CHAPTER &quot;Details (Simulation)&quot;
+
+ATTR &quot;Transition condition&quot; dialog:transcond
+
+ATTR &quot;Transition probability&quot;
+
+</aTTRIBUTE>
+<aTTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;End Event&quot;</aTTRIBUTE>
+<aTTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Intermediate Event (sequence flow)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="ModelTypeExp" type="EXPRESSION">EXPR val:&quot;Business process diagram (BPMN 2.0)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16468" class="Is inside">
+<fROM instance="End Event-83248" class="End Event"></fROM>
+<tO instance="Monti Azzurri Consorsium" class="Pool"></tO>
+<aTTRIBUTE name="AutoConnect" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16469" class="Message Flow">
+<fROM instance="Service Conforence" class="Pool (collapsed)"></fROM>
+<tO instance="Receive Confirmation" class="Intermediate Event (sequence flow)"></tO>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 1 x1:18cm y1:6cm index:13</aTTRIBUTE>
+<aTTRIBUTE name="Message Name" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="ParticipantType (from)" type="ENUMERATION">Role</aTTRIBUTE>
+<aTTRIBUTE name="Role (from)" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Entity (from)" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="ParticipantType (to)" type="ENUMERATION">Role</aTTRIBUTE>
+<aTTRIBUTE name="Role (to)" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Entity (to)" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Name" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Message Properties" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;Intermediate Event (sequence flow)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Pool (collapsed)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Number" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Show Name" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Show Number" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Representation" type="ENUMERATION">above/below</aTTRIBUTE>
+<aTTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Description" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Show name" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Doku" type="STRING">NOTEBOOK
+
+#-----------------------
+CHAPTER &quot;Description&quot;
+#-----------------------
+ATTR &quot;Name&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+ATTR &quot;Id&quot; </aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16469&quot;</aTTRIBUTE>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+</cONNECTOR>
+</mODEL>
+<mODEL id="mod.16350" name="TitoloUnico_MontiAzzurrSUB_3" version="" modeltype="Business process diagram (BPMN 2.0)" libtype="bp" applib="LearnPAd Prototype Dynamic Library 0.21">
+<mODELATTRIBUTES>
+<aTTRIBUTE name="Contact person" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Keywords" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Copyright info" type="STRING">Edit the model attributes to display your copyright info</aTTRIBUTE>
+<aTTRIBUTE name="Copyright info position" type="ENUMERATION">Bottom right</aTTRIBUTE>
+<aTTRIBUTE name="Name" type="STRING">TitoloUnico_MontiAzzurrSUB_3</aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;86524&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Process type" type="ENUMERATION">None</aTTRIBUTE>
+<aTTRIBUTE name="Executable" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Closed" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Auditing" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Monitoring" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Model type" type="ENUMERATION">Current model</aTTRIBUTE>
+<aTTRIBUTE name="State" type="ENUMERATION">In process</aTTRIBUTE>
+<aTTRIBUTE name="Reviewed on" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Reviewed by" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Author" type="STRING">barbara</aTTRIBUTE>
+<aTTRIBUTE name="Creation date" type="STRING">11.08.2015, 15:15</aTTRIBUTE>
+<aTTRIBUTE name="Last user" type="STRING">barbara</aTTRIBUTE>
+<aTTRIBUTE name="Date last changed" type="STRING">20.08.2015, 15:12:47</aTTRIBUTE>
+<aTTRIBUTE name="Number of objects and relations" type="INTEGER">55</aTTRIBUTE>
+<aTTRIBUTE name="Context of version" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Action" type="ENUMERATION">Fill in</aTTRIBUTE>
+<aTTRIBUTE name="People-like view" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="BAR Display active" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Modelling direction" type="ENUMERATION">vertical</aTTRIBUTE>
+<aTTRIBUTE name="Modelling_size" type="ENUMERATION">3</aTTRIBUTE>
+<aTTRIBUTE name="Responsible for execution_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Responsible for execution_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="Responsible for execution_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="Accountable for approving results_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Accountable for approving results_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="Accountable for approving results_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="Cooperation/participation_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Cooperation/participation_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="Cooperation/participation_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="To inform_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="To inform_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="To inform_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="Knowledge Product_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Knowledge Product_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="Knowledge Product_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="Documents and Resources_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Documents and Resources_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="Documents and Resources_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="Incoming Data Object_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Incoming Data Object_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="Incoming Data Object_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="Outgoing Data Object_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Outgoing Data Object_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="Outgoing Data Object_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="Description_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Description_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="Description_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="Comment Mode" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="CommentAreaSize" type="ENUMERATION">2</aTTRIBUTE>
+<aTTRIBUTE name="CommentModellingAreaSize" type="ENUMERATION">3</aTTRIBUTE>
+<aTTRIBUTE name="CommentModellingDirection" type="ENUMERATION">vertical</aTTRIBUTE>
+<rECORD name="Change history"></rECORD>
+<aTTRIBUTE name="Position" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-01] Internal error!  \&quot;fontcolor\&quot; (BPModel)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<rECORD name="Technical Attributes"></rECORD>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Keine Modellbezeichnung vergeben</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Pool Term" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="ParticipantType" type="ENUMERATION">Role</aTTRIBUTE>
+<aTTRIBUTE name="Role" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Entity" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="BoundaryVisible" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="BPD Model Attributes" type="STRING">NOTEBOOK
+
+CHAPTER &quot;Business Process Diagram Attributes&quot;
+ATTR &quot;Name&quot; write-protected
+ATTR &quot;Contact person&quot;
+ATTR &quot;Author&quot; write-protected
+ATTR &quot;Language (BPMN)&quot;
+ATTR &quot;ExpressionLanguage&quot;
+ATTR &quot;QueryLanguage&quot;
+ATTR &quot;Creation date&quot; write-protected
+ATTR &quot;Date last changed&quot; write-protected
+ATTR &quot;Documentation (Model)&quot;
+ATTR &quot;State&quot;
+
+GROUP &quot;Copyright&quot;
+ATTR &quot;Copyright info&quot; 
+ATTR &quot;Copyright info position&quot; 
+ENDGROUP
+
+CHAPTER &quot;Process Attributes&quot;
+ATTR &quot;Name&quot; write-protected
+ATTR &quot;Process Term&quot;
+ATTR &quot;ProcessType&quot;
+ATTR &quot;Status&quot;
+ATTR &quot;Assignments&quot; lines:5
+ATTR &quot;Properties (BPMN)&quot; lines:5
+ATTR &quot;AdHoc&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+GROUP &quot;AdHoc = True&quot;
+ATTR &quot;AdHocOrdering&quot;
+ATTR &quot;AdHocCompletionCondition&quot;
+ENDGROUP
+ATTR &quot;SuppressJoinFailure&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ATTR &quot;EnableInstanceCompensation&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ATTR &quot;Categories (Process)&quot;
+ATTR &quot;Documentation (Process)&quot;
+
+CHAPTER &quot;Pool Attributes&quot;
+GROUP &quot;Common Graphical Object Attributes&quot;
+ATTR &quot;Name&quot; write-protected
+ATTR &quot;Categories (Pool)&quot;
+ATTR &quot;Documentation (Pool)&quot;
+ENDGROUP
+GROUP &quot;Common Swimlane Attributes&quot;
+ATTR &quot;Pool Term&quot;
+ENDGROUP
+GROUP &quot;Pool Attributes&quot;
+ATTR &quot;ParticipantType&quot;
+ATTR &quot;Role&quot;
+ATTR &quot;Entity&quot;
+ATTR &quot;BoundaryVisible&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot; write-protected
+ENDGROUP</aTTRIBUTE>
+<aTTRIBUTE name="Language" type="ENUMERATION">System</aTTRIBUTE>
+<aTTRIBUTE name="ExpressionLanguage" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="QueryLanguage" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Process Term" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="BPD Term" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="ProcessType" type="ENUMERATION">None</aTTRIBUTE>
+<aTTRIBUTE name="Status" type="ENUMERATION">None</aTTRIBUTE>
+<rECORD name="Assignments"></rECORD>
+<aTTRIBUTE name="AdHoc" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="AdHocOrdering" type="ENUMERATION">None</aTTRIBUTE>
+<aTTRIBUTE name="AdHocCompletionCondition" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="EnableInstanceCompensation" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Categories (Process)" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation (Process)" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation (Pool)" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Categories (Pool)" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="SuppressJoinFailure" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="RACI/DEMI visualisation" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="IT systems" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Responsible role" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Input/Output" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Products" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Use cases" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Products color" type="STRING">whitesmoke</aTTRIBUTE>
+<aTTRIBUTE name="RACI/DEMI color" type="STRING">whitesmoke</aTTRIBUTE>
+<aTTRIBUTE name="Responsible role color" type="STRING">whitesmoke</aTTRIBUTE>
+<aTTRIBUTE name="Input/Output color" type="STRING">whitesmoke</aTTRIBUTE>
+<aTTRIBUTE name="Use cases color" type="STRING">whitesmoke</aTTRIBUTE>
+<aTTRIBUTE name="IT systems color" type="STRING">whitesmoke</aTTRIBUTE>
+<aTTRIBUTE name="_ToggleModelInfo_" type="PROGRAMCALL">ITEM &quot;_ToggleModelInfo_&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Display modelling information" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Documentation (Model)" type="STRING"></aTTRIBUTE>
+<rECORD name="Properties (BPMN)"></rECORD>
+<aTTRIBUTE name="CreationDate" type="EXPRESSION">EXPR val:&quot;11.08.2015, 15:15&quot;</aTTRIBUTE>
+<aTTRIBUTE name="ModificationDate" type="EXPRESSION">EXPR val:&quot;20.08.2015, 15:00:51&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Language (BPMN)" type="STRING">English</aTTRIBUTE>
+<aTTRIBUTE name="BPMN20 Model Attributes" type="LONGSTRING">NOTEBOOK
+# TODO AVAL sMfbRegistration:&quot;_MFB-Registration_&quot;
+CHAPTER &quot;Description&quot;
+ATTR &quot;Contact person&quot;
+ATTR &quot;Keywords&quot; lines:2
+ATTR &quot;Description&quot; lines:3
+ATTR &quot;Comment&quot; lines:3
+
+GROUP &quot;Copyright&quot;
+ATTR &quot;Copyright info&quot; 
+ATTR &quot;Copyright info position&quot; 
+ENDGROUP
+ATTR &quot;Name&quot; write-protected
+ATTR &quot;Id&quot; write-protected
+
+
+
+#---------------------------------------------
+CHAPTER &quot;Process properties&quot;
+#---------------------------------------------
+GROUP &quot;Process attributes&quot;
+ATTR &quot;Process type&quot; #None, Private, Public 
+ATTR &quot;Executable&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ATTR &quot;Closed&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ENDGROUP
+
+GROUP &quot;Process relevance&quot;
+ATTR &quot;Auditing&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ATTR &quot;Monitoring&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ENDGROUP
+
+CHAPTER &quot;User attributes&quot;
+ATTR &quot;Model type&quot;
+ATTR &quot;State&quot;
+ATTR &quot;Reviewed on&quot;
+ATTR &quot;Reviewed by&quot;
+
+CHAPTER &quot;System attributes&quot;
+ATTR &quot;Author&quot; write-protected
+ATTR &quot;Creation date&quot; write-protected
+ATTR &quot;Last user&quot; write-protected
+# ATTR &quot;Date last changed from&quot; write-protected
+ATTR &quot;Date last changed&quot; write-protected
+ATTR &quot;Number of objects and relations&quot; write-protected
+ATTR &quot;Context of version&quot; write-protected
+
+CHAPTER &quot;People-like view&quot;
+ATTR &quot;Action&quot;
+ATTR &quot;People-like view&quot;
+
+CHAPTER &quot;BAR Display&quot;
+ATTR &quot;BAR Display active&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot;
+AVAL s_Aktiv: &quot;BAR Display active&quot;
+ATTR &quot;Modelling direction&quot; ctrltype: radio enabled: (s_Aktiv = &quot;Yes&quot;)
+ATTR &quot;Modelling_size&quot;
+
+GROUP &quot;Responsible for execution&quot;
+ATTR &quot;Responsible for execution_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_Responsible_for_execution_display: &quot;Responsible for execution_display&quot;
+ATTR &quot;Responsible for execution_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_Responsible_for_execution_display = &quot;Yes&quot;))
+ATTR &quot;Responsible for execution_size&quot;
+ENDGROUP
+
+GROUP &quot;Accountable for approving results&quot;
+ATTR &quot;Accountable for approving results_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_Accountableforapprovingresults_display: &quot;Actor_display&quot;
+ATTR &quot;Accountable for approving results_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_Accountableforapprovingresults_display = &quot;Yes&quot;))
+ATTR &quot;Accountable for approving results_size&quot;
+ENDGROUP
+
+GROUP &quot;Cooperation/participation&quot;
+ATTR &quot;Cooperation/participation_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_Cooperationparticipation_display: &quot;Cooperation/participation_display&quot;
+ATTR &quot;Cooperation/participation_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_Cooperationparticipation_display = &quot;Yes&quot;))
+ATTR &quot;Cooperation/participation_size&quot;
+ENDGROUP
+
+GROUP &quot;To inform&quot;
+ATTR &quot;To inform_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_Toinform_display: &quot;To inform_display&quot;
+ATTR &quot;To inform_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_Toinform_display = &quot;Yes&quot;))
+ATTR &quot;To inform_size&quot;
+ENDGROUP
+
+GROUP &quot;Knowledge Product&quot;
+ATTR &quot;Knowledge Product_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_KnowledgeProduct_display: &quot;Knowledge Product_display&quot;
+ATTR &quot;Knowledge Product_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_KnowledgeProduct_display = &quot;Yes&quot;))
+ATTR &quot;Knowledge Product_size&quot;
+ENDGROUP
+
+GROUP &quot;Documents and Resources&quot;
+ATTR &quot;Documents and Resources_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_DocumentsandResources_display: &quot;Documents and Resources_display&quot;
+ATTR &quot;Documents and Resources_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_DocumentsandResources_display = &quot;Yes&quot;))
+ATTR &quot;Documents and Resources_size&quot;
+ENDGROUP
+
+GROUP &quot;Incoming Data Object&quot;
+ATTR &quot;Incoming Data Object_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_IncomingDataObject_display: &quot;Incoming Data Object_display&quot;
+ATTR &quot;Incoming Data Object_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_IncomingDataObject_display = &quot;Yes&quot;))
+ATTR &quot;Incoming Data Object_size&quot;
+ENDGROUP
+
+GROUP &quot;Outgoing Data Object&quot;
+ATTR &quot;Outgoing Data Object_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_OutgoingDataObject_display: &quot;Outgoing Data Object_display&quot;
+ATTR &quot;Outgoing Data Object_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_OutgoingDataObject_display = &quot;Yes&quot;))
+ATTR &quot;Outgoing Data Object_size&quot;
+ENDGROUP
+
+GROUP &quot;Description&quot;
+ATTR &quot;Description_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_Description_display: &quot;Description_display&quot;
+ATTR &quot;Description_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_Description_display = &quot;Yes&quot;))
+ATTR &quot;Description_size&quot;
+ENDGROUP
+
+CHAPTER &quot;Comment View&quot;
+ATTR &quot;Comment Mode&quot; ctrltype: check checked-value: &quot;No&quot; unchecked-value: &quot;Yes&quot;
+AVAL s_Aktiv: &quot;Comment Mode&quot;
+ATTR &quot;CommentAreaSize&quot;
+ATTR &quot;CommentModellingAreaSize&quot;
+ATTR &quot;CommentModellingDirection&quot;
+
+
+
+
+CHAPTER &quot;Change history&quot;
+ATTR &quot;Change history&quot; lines:30
+
+</aTTRIBUTE>
+<aTTRIBUTE name="_GoToAceHp_" type="PROGRAMCALL">ITEM &quot;_GoToAceHp_&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="__GfxThumb__" type="LONGSTRING">iVBORw0KGgoAAAANSUhEUgAAAQAAAAC4CAIAAACD/qWdAAAACXBIWXMAAAsTAAALEwEAmpwYAAAR7UlEQVR4nO2df3AT55nHvwsu/YfOpTnSpJAATVYKGLd3+dG0rKBk0nDJSg5xUyymucspUzKrOXqZNWEUYM53HVp3EtcpSMmUudWE3DmTDrXsSx2IVnRoksmlko+kOa4MKFOvakJyMEwHKH9cAs5Yeu+PldeyLRtLWv1Yv8/nD5As6dUj7ff7vs++++p9hPPnzx87dgxEBVy9etXv99c7CqIcmo4dO/a1r/3V5xd9rn9g4PLly4IgNDU1LV68WH5QblrUNPLHkfvWr5+9iTPnzgJYsXRZVQN98513br31VgArl5X/RrY0YvLh2bPmjRMnTlTYFFFHmgB8+uknyeTx+++/v/CBof8auv322+9b/+VMJhPfutf99lPDG7amd2/Gph3RtWulIeCJNS1YHdr/pJiXfiayoTm9+xA2PdOc3p1ufubk2qHU0Npwend66zMnh4ZSAADpZz9r2fFB22dPDW/YigO7083PNKcPYO/eNIBTp7B7dxtE+UExsW2R90UzkLXh9AFs3et+e/+fjh+/544vRDYs6hhaK60dSg2tVQ5txqYdUTyhf7ZfRiayYWtszebe/XJ8Q3PHkPl2h/wfGL79cnxbwrf/yfvWr3/XbGTbtvSpU80HDmDr1hjgP3AAe/emTwGbgYFTzQfeVkUkXtg2OIC2t/fjhW2DH6wO7Xf1LDrU9tl+vPCC68knxWXL0sZw7Q4UUR2E1157bdmypWfPnrt8+fKiRYvMv2az2euvv37lypUAVovi7E18kMnM5WkVYr5LhW9kSyNWU598+gmAc2fPUQrkXJoAnD17bvny5YyxhQsXCoIgCMLChQtvu+22dDp9xx13fHz+/OxNGIYBYPHixVUNdPHixcePH6/wjWxpxMT81ITTERhjsVis3mE4HhoBHIrAGKt3DARRN5rqHQBB1BMyAME1ZIB5giAI1m1Ka+dOUzQarXcMREUEg0FN0wCY/wKgY1oCmqYxwoEAmHI3LAGQFD2sQNGZEZYAKDpjjOmKJEmQpPxfjLAkSUrYYLqSfwKnaJomaJqmKEpdPUjMkQwSgCwCEISp03fT/0Jck2g0SucAjkEQXBjP74tqPRL0xKKAlIJf98e6YoC/1x8LoDfpi3sCMQBIpVJS2OhFIIBef8wVg9TSmQy5MqIoJoLCYBvT5Np+qLpDI0CjM8eunUaAMqARoNEhWVcbMkDDYU5ozpLqzETQEwSi0RQgKUpLc0jzGYn4oDcGvVeTxUQk4lLdPcHh5pNpdzLkyiAecHWkJJ0leUt7CqEUaJ5AY0UZUApUIzKJSHw4nUZbyAcjDvhkWcwkEsZwVxd6k6qYSSQMDMOluowEZBkRTwC9SbW6C8wJAHQdYL4AICxJkiQpum4YYQnjM/2KzpiuQAob5r+MmdcBJElSJAkAFJ3pCiRJ4u6aAF0HmD9QClQGlAIRvEMGmD9EPEKHOQUEtCU1GZmIx9WRksJGZzowHEqqIhJBoeukAkThN3rRE4hFUykoOjMnhXrcSboQRjgTSoHKgFKgeUUiKHjzy0DN9Q497mQIifigtyMqSVIKUPy9mi8ejPs0mmHKQyPAPIFGgDKgEYDgHTLA/MH6URgNBXOHDDBPINGXRxPoF3QEx9DGWLVjy5YtfX199j6TqBCaOqgRhYuc7X0yUQl0DtCIkPRrBo0ABNfQCNDQ0OWtakPfb9UhETcydGwIrqEUyAHQGFI96JutLnZplzxQJehrrSKk2saHjpBjIDtVA/pOnQR5wHboC60KpFSnQMeJ4BqaBnUeNLzYCH2V9kMCdRA0AtgMqd9Z0NFyKuQ0W6AvkeAaSoFsg7pkJ0LHzNmQ6ypEsKorEw7FKpRNlEETgPK2RoxGo7SnokUde2I6CmVDWyPaQ93zkLoH4FzIADZQd/ExxsgD5UEGmCeY6icblAoZoFIaR3PW5rjE3CEDVETjqB/jiVC9o3AYZIAiCBv7K3kyO9puazilBHB/rKTgaxxqA+J4AwwMrMnlfuj3++1qUNjY//t9ay5cuJhj+OL1f7lCbM7mkGXI5pDNYazgdjaHMcas21mGsRyyOQgb+2smrEee/o9zr9zLGC5c+vMtX3HnI5wcz5SwxwoerWWojUndDNDdnR+sd+4sP4UYGFjz0ENPHz68JxaDjR547G8fvfHGLzHGLly4dOQ/359Z/Ziu/mzOrijmxJZ7Fv7Pf/9uwYIF//fJJ0tXuEtSf41DtRdb9IO6GMAMfceOdxm7Alwx75bxMUz1A6OtrcHXX7fTA72/+OXFi5dyDH9x3Rct6byxXXjiZemv725RDrW9sXTwWx9r3yimtmxtzwj63h2LbPcwhouX/jweQ+bFB1w/fg+4O6wfdr/0Ze/AXeFXf+V+efmgZ0T7ev28ahemYJ566m3gCmPl68ekPiOApX7GrmzffnDfvu+V2oKl/sOHI62tj9sb3srbVt38FUzJfNY9x079NH/36x/LRft+8/m15FfH2YHrbsjmsOgLN4zHID6ms0fHw979v+zpHLI57BiRp48MDsVSP3C1o+OlcPj7ZTdVawN0dwuF6geuMnZFVX/e3S3MbmJBEPr6+sw+3lI/Y1cBMDbq830nHq9oEChsf2xCzZmRP+LoPwT01S3BbaGRfwwcYakTkL76fsvjp0NLTxu/uK/rlqOdS0/Ld67Lq78GqjKneqxoxxObxNMbBxmiB98D7lbaVzX/fbf735Z1sd7epzfg4COBkR90+lfgzGn5rnUTeZEjKDw03d1CofoZu8LYFVV97pr6mYk6jABT1G/eNR+afRZvy5YtZumUhx/O9/3m3+Pxg16v1+v9tq7vEYQtZQdmtV/Q94vLVuCxeNLsUL8xmGwvzPuXi+qwnM0hu2xC/eYIUIPpSDNaAG/G+zwP+LM5ueuIPJbT/qUg79/1kWzefiSWNPv+JcsmnRXUJtTKsQ4NgOniYexK2S3XJQWa8QPMsV7T4cM/bW0NtrY+ztioqX5gVNffyOV+aEthoVLPegvVb3arNS48Nfez3imP1j7Uyikmnqtlt1ZrA+zcybq7he3bDxZ+gOef/2dr/JpbDuMfGFgDwOf7TqH65/zy2RA29n/0N+Wr3zoHsHFWavZoz8Tay1P/WG1DtQl/d7fQ0fFSofqff/4nDjsJ3rfve6r6c0v9ZbSwefOpWCwWj+/xer9to/pNZlZ/5qPTxpnT8l3rZ1R/7adWZtB35sxp48yIfPe3ZvOGQwmHv6+qz1nqr6SpOhjANGvl87h+v98cCuxVPzBL3y/etFxccvNs6q/91MoM+hZvukW84eZrjAxOxNLPrl3o6+tz3nUAkwrjtmhvT/f12al+drS9pNUERVuwK5i5vFcl0bKj7UUrUvb3T1vfwVhDZUo7d7Jdu2w4fXf8UohqULmCa7lIrsJozSV00wNub2/v7+9vb28H0N/fLwhCLBZrHA/YNXlVoQESkchgrCOKsJFURSCTSBgAAJcsI5EwgGFAleVEUBhsY5psQ8COoaEWis5OYZxW2OYgUDgUNJoHbKFCA8iqKquq9YtsUZbFicdkETA1L2uMK/EXWZnc+EmFyXTTmoMAin2EOmLX2m9KgaqFpSSrT23wpGIKhdHOY8gAVcdygpVUmKoyFdbgHqh3CFWHDFAHCtPrBh8H5j1kgNpRNKloqMSaQ8gANYWHpMJZkAGI4nAyNJEBqo6DLghYtLe3O2uJaNmQAaqO49Rvwsl5ORmgKsxxgU1Dkol4AulOP7zpNhYa9rg6UpKid4ZcrnhP3Kep4rVbcBJkgKpQ9HqqQ5IKUU0mAYABgJxk6vgDqqbO9BrnQgawjaK9fiHOSSoyEY8r5tf9MW9HCoCis9Cwp8ednIerucgANmCe5haTfiaTQTwQiLW0dIZCw4FADKkUJCnV0sk0BAVvFIrONDkT8QTQm2yY9EJUzY5fnej+5eT8rMFhGiCTCAa6mv2dwGA6jea2NrdLlkUzHYS/RXUjgzbD5XJBFMVMIoHCRW+cM+skjyiKUJNJU0by+I08GmN5UY1nHUTNMQ0gyloyv25z0qMTB0YExiUvyvNvICwdS/cOneQhTCgFKofSp/YziYQx3NUVQyqVkiQJ/t7OtGuwTYcsz8/UwimQAUqggl5flGVRluVJKRBnv5FoTPLnAJlMPN6DNNAW8g0HXGl/uNmtqrI5JdwZggsyEDF63ND4S4Bsz3aceG14vpI/BxDFid91yUnr2Ew+OVNFDkdrEuv8hlKg4lT1HJcc1ThUZIBoNGpXHBVibyRm6enG+XTELFR4mCoyQCOUaA4Gg3ZFYl3KrfbnorTKFio/9FQoexIkSg7h3QDXXMBTDchpjYOzDVD5zjCkRc5xtgHKpr5ZeF2GHaIozjZAqduDNc4CnroHQJg4wABz2f14pueYG8daJqml7GYL+1rlrDmv3VtLGt0Awsb+s6/cCyzIMYxlc4uvu2HKZvxZxn7/VuzEy+1Fi7gIG/vxG3/tu1thY//VRPssNQRmrz1D9atrRqMbAMBvfn1k/fp1CxYseOvNt7ybH58uo9Xr/TOVMEIpvb69RefLVr9zC7c4EQcYYOHChR9++CEAQRCqV7R9YGDNQw/tsrHofNnqJwPUEgcYwHPvRggLcjksvbWlJBnNvQSQqX5gtLV12+uv7xkY2FP5UFC2+h1aucihOMAAVt7/uQkZZf7d63r2dwCAu8IDr/re2RX/Zpd605yLtk8ru70LGGVsFBj1+f4OGC2j7PaU+tVlq59GgFriAAMUk5H46CG2pUBG3+1Si5YuxcwXywrKbk+o3/wXGPV6Hyiv7HZh/ep1D/qzOWRzmRcfdP3kPeVfz4dGWgMs3JtVXXvfB+4MH+z3/faf4vf8SL1xzmET9uIEA0yoPzMygrd+EDiyCrlXUifukr76PtidKfjCK38cG7kD659NbrplatH2ooWgC8qO4/DhZ1tbtxWqn7FRXf91qWW3Td33FbzGKtj4WJxZtebHGLKvsu+OK77tR+oU084SNlGI+YVXiBMMMNH3izevwKOHkltyGHtmcgrxWBEZWcn09EzG7/cX7MrvHxhYY2Y+heov+kIgEwkGYtGWThYaDk7aKc1s07whbOz/qL+91MznmmEThdTdAH+KeIRYS9jf5nMjDvhcMOKAG3CZP6HMGD2uwTYWQr5ynknJZfPKltHsyfQ0ec1F/QBEVUuav56Tp+2UVviSKoVN2EslBviSOrFvnvm/OEkRopivjTdpE6GSy+aVLaO5K2nz5lMDA2u83geupf4SqEHYROU4IQUqV0YlFW03PWBj0fnahE1USKMboPJK6LM+ngh6hkNJd49nEIhGU4BbN/7QGQlGKtwGucphE7bR6AZAddWQ3xFPS8qAZu15Ycs2yCRiR+AAAxBE9eDZAJmIx9WRAiRJSgFKSwuAkyfR2dk8OOzTVCMScakNs2EzUR14NoBYMIs1GVkGIKrzsB4EMQWeDUAQZIACClfIEZxABpjA/IWxLRfYiRrQV9JSrRkgA0yClqA5i8qHazLAVCgFmoY5Xaboc1u75SzIAMQ1mXm6zPmQAQiuIQMQXCNoGodlXwgij0DzHgTPUKUGgmvoHIDgGjIAwTVkAIJryAAE15ABCK4hAxBcQwYguIYMQHANGYDgGjIAwTVkAIJryAAE15ABCK4hAxBcQwYguIYMQHANGYDgGjIAwTVkAIJryAAE15ABCK4hAxBcQwYguIYMQHANGYDgGjIAwTVkAIJryAAE15ABCK4hAxBcQwYguIYMQHANGYDgGjIAwTVkAIJryAAE15ABCK4hAxBcQwYguIYMQHANGYDgGjIAwTVkAIJryAAE15ABCK4hAxBcQwYguIYMQPANI4hqYYQlAJDCBmOGruthSZIkRWdGWIIUNu9KkiSFDSMsSYqu67oeDisKzOfpYUmSlLCRf62iW21KiiIBsFqzGtIZM8KKokz8xWrNYExXMP6cfGtMYIzV2YIEUT8oBSK4hgxAOJ1LEc9LHaklknQhlVqi6Kvg/W0Uq3TWKuNSxHMo1rKqV3PHPS91pABACj/sT1/0ae54cFjVvkkpEME1NAIQXEMGILiGDEDMJ8zzAcDM9WOvdaRW6ez2QSF5UlnSArSFbh90JaFv0uSLQeEPGmulcwCCa/4fLqZUDDFfaz0AAAAASUVORK5CYII=</aTTRIBUTE>
+<aTTRIBUTE name="NT Model Attributes" type="LONGSTRING">NOTEBOOK
+CHAPTER &quot;Description&quot;
+#ATTR &quot;Shared&quot;
+ATTR &quot;Model state&quot; enabled:(cond(search (sMfbRegistration, &quot;MFB_VERS&quot;, 0) = -1, 1, 0))
+ATTR &quot;Description&quot;
+ATTR &quot;Show State&quot; ctrltype:check unchecked-value:&quot;No&quot; checked-value:&quot;Yes&quot; 
+ATTR &quot;Last user&quot; write-protected
+ATTR &quot;Date last changed&quot; write-protected
+#CHAPTER &quot;Suggestion for improvement&quot;
+#ATTR &quot;Suggestion for improvement&quot;
+</aTTRIBUTE>
+<aTTRIBUTE name="Model state" type="ENUMERATION">Draft</aTTRIBUTE>
+<aTTRIBUTE name="Keywords" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Description" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Model type" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Show State" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Actor_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="Actor_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Actor_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="ModelingAreaSize" type="ENUMERATION">20</aTTRIBUTE>
+<aTTRIBUTE name="DrawingAreaWidth" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="DrawingAreaHeight" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Reference overview settings" type="LONGSTRING">Responsible for execution|Responsible for execution
+Accountable for approving results|Accountable for approving results
+Cooperation/participation|Cooperation/participation
+To inform|To inform
+Modelling|Modelling
+Knowledge Product|Knowledge Product
+Documents and Resources|Documents and Resources
+#Data Object|Data Object
+Incoming Data Object|Incoming Data Object
+Outgoing Data Object|Outgoing Data Object
+Description|Description</aTTRIBUTE>
+<aTTRIBUTE name="Data Object_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="Data Object_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Data Object_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="id_bpmndi_diagram" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="id_bpmndi_plane" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="id_bpmndi_collaboration" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="CommentTypeSize" type="ENUMERATION">8</aTTRIBUTE>
+<aTTRIBUTE name="CommentxCoorTextBox" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="CommentyCoorTextBox" type="STRING"></aTTRIBUTE>
+</mODELATTRIBUTES>
+<iNSTANCE id="obj.16351" class="Pool (collapsed)" name="Third Party PA">
+<aTTRIBUTE name="Position" type="STRING">NODE x:20cm y:3cm w:40cm h:3cm index:1</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(&quot;&quot;) val:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<rECORD name="Technical Attributes"></rECORD>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="ParticipantType" type="ENUMERATION">Role</aTTRIBUTE>
+<aTTRIBUTE name="Role" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Entity" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="BoundaryVisible" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Process Term" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="ProcessType" type="ENUMERATION">None</aTTRIBUTE>
+<aTTRIBUTE name="Status" type="ENUMERATION">None</aTTRIBUTE>
+<rECORD name="Assignments"></rECORD>
+<rECORD name="Properties"></rECORD>
+<aTTRIBUTE name="AdHoc" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="AdHocOrdering" type="ENUMERATION">None</aTTRIBUTE>
+<aTTRIBUTE name="AdHocCompletionCondition" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="EnableInstanceCompensation" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Categories (Process)" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation (Process)" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="SuppressJoinFailure" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Open questions" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16351&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Color" type="STRING">white</aTTRIBUTE>
+<aTTRIBUTE name="Orientation" type="ENUMERATION">horizontal</aTTRIBUTE>
+<aTTRIBUTE name="Boundary visible" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Auditing" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Monitoring" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Process type" type="ENUMERATION">None</aTTRIBUTE>
+<aTTRIBUTE name="Executable" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Closed" type="ENUMERATION">No</aTTRIBUTE>
+<iNTERREF name="Referenced Organizational Unit"></iNTERREF>
+<iNTERREF name="Referenced process"></iNTERREF>
+<aTTRIBUTE name="Cardinality" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16354" class="Pool" name="Monti Azzurri Consorsium">
+<aTTRIBUTE name="Position" type="STRING">NODE x:0cm y:8cm w:40cm h:11.5cm index:2</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(&quot;&quot;) val:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<rECORD name="Technical Attributes"></rECORD>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="ParticipantType" type="ENUMERATION">Role</aTTRIBUTE>
+<aTTRIBUTE name="Role" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Entity" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="BoundaryVisible" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Process Term" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="ProcessType" type="ENUMERATION">None</aTTRIBUTE>
+<aTTRIBUTE name="Status" type="ENUMERATION">None</aTTRIBUTE>
+<rECORD name="Assignments"></rECORD>
+<rECORD name="Properties"></rECORD>
+<aTTRIBUTE name="AdHoc" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="AdHocOrdering" type="ENUMERATION">None</aTTRIBUTE>
+<aTTRIBUTE name="AdHocCompletionCondition" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="EnableInstanceCompensation" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Categories (Process)" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation (Process)" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="SuppressJoinFailure" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Open questions" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16354&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Color" type="STRING">white</aTTRIBUTE>
+<aTTRIBUTE name="Orientation" type="ENUMERATION">horizontal</aTTRIBUTE>
+<aTTRIBUTE name="Boundary visible" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Auditing" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Monitoring" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Process type" type="ENUMERATION">None</aTTRIBUTE>
+<aTTRIBUTE name="Executable" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Closed" type="ENUMERATION">No</aTTRIBUTE>
+<iNTERREF name="Referenced Organizational Unit">
+<iREF type="objectreference" tmodeltype="Organizational structure" tmodelname="Org Model Monti Azzurri" tmodelver="" tclassname="Organizational unit" tobjname="Monti Azzurri"></iREF>
+</iNTERREF>
+</iNSTANCE>
+<iNSTANCE id="obj.16357" class="Lane" name="SUAP Office">
+<aTTRIBUTE name="Position" type="STRING">NODE x:3cm y:8cm w:37cm h:6.5cm index:3</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(&quot;&quot;) val:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<rECORD name="Technical Attributes"></rECORD>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Open questions" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16357&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Color" type="STRING">white</aTTRIBUTE>
+<aTTRIBUTE name="Orientation" type="ENUMERATION">horizontal</aTTRIBUTE>
+<aTTRIBUTE name="Line break" type="ENUMERATION">No</aTTRIBUTE>
+<rECORD name="Properties"></rECORD>
+<aTTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Cardinality" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Referenced Organizational Unit">
+<iREF type="objectreference" tmodeltype="Organizational structure" tmodelname="Org Model Monti Azzurri" tmodelver="" tclassname="Organizational unit" tobjname="SUAP Office"></iREF>
+</iNTERREF>
+<iNTERREF name="Referenced Role"></iNTERREF>
+<iNTERREF name="Referenced Performer"></iNTERREF>
+</iNSTANCE>
+<iNSTANCE id="obj.16360" class="Lane" name="Agriculture Office">
+<aTTRIBUTE name="Position" type="STRING">NODE x:3cm y:14.5cm w:37cm h:5cm index:4</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(&quot;&quot;) val:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<rECORD name="Technical Attributes"></rECORD>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Open questions" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16360&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Color" type="STRING">white</aTTRIBUTE>
+<aTTRIBUTE name="Orientation" type="ENUMERATION">horizontal</aTTRIBUTE>
+<aTTRIBUTE name="Line break" type="ENUMERATION">No</aTTRIBUTE>
+<rECORD name="Properties"></rECORD>
+<aTTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Cardinality" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Referenced Organizational Unit">
+<iREF type="objectreference" tmodeltype="Organizational structure" tmodelname="Org Model Monti Azzurri" tmodelver="" tclassname="Organizational unit" tobjname="Agriculture Office"></iREF>
+</iNTERREF>
+<iNTERREF name="Referenced Role"></iNTERREF>
+<iNTERREF name="Referenced Performer"></iNTERREF>
+</iNSTANCE>
+<iNSTANCE id="obj.16363" class="Text Annotation" name="Text Annotation-83144">
+<aTTRIBUTE name="Position" type="STRING">NODE x:24cm y:1.5cm index:5</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-02] Attribute \&quot;Fontcolor\&quot; (Pool (collapsed)) does not exist!  \&quot;fontcolor\&quot; (Text Annotation)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<rECORD name="Technical Attributes"></rECORD>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Collection" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16363&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Text" type="STRING">here we could use semantic annotation to check for 1 -n third parties - e.g. based on which PA is involved in SUAP process</aTTRIBUTE>
+<aTTRIBUTE name="Cardinality" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Open questions" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16366" class="Start Event" name="Start Event-83148">
+<aTTRIBUTE name="Position" type="STRING">NODE x:6.5cm y:10cm index:7</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Process calendar" type="LONGSTRING">D@Working day@b@32400-43200@U900;1800@45000-59400@U900;1800@Free day@c@@@$cbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbcbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbcbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbcccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbccbbccb</aTTRIBUTE>
+<aTTRIBUTE name="Quantity" type="EXPRESSION">EXPR expr:(0) val:0</aTTRIBUTE>
+<aTTRIBUTE name="Time period" type="ENUMERATION">Per year</aTTRIBUTE>
+<aTTRIBUTE name="Abandon after tolerance waiting time" type="ENUMERATION">no</aTTRIBUTE>
+<aTTRIBUTE name="Tolerance waiting time" type="TIME">00:000:00:00:00</aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-02] Attribute \&quot;Fontcolor\&quot; (Lane) does not exist!  \&quot;fontcolor\&quot; (Start Event)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<rECORD name="Technical Attributes"></rECORD>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Actor"></iNTERREF>
+<rECORD name="Assignments"></rECORD>
+<aTTRIBUTE name="Term" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Trigger" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Result" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Aggregated execution time" type="TIME">00:000:00:00:00</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated waiting time" type="TIME">00:000:00:00:00</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated resting time" type="TIME">00:000:00:00:00</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated transport time" type="TIME">00:000:00:00:00</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated cycle time" type="TIME">00:000:00:00:00</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Info on results" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Cost driver" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Cost driver quantity" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated personnel costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="External documentation" type="PROGRAMCALL">ITEM &quot;&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Prozeßstart</aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Open questions" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Modelling direction" type="EXPRESSION">EXPR val:&quot;vertical&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Implementing control" type="ENUMERATION">no</aTTRIBUTE>
+<aTTRIBUTE name="Show name" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16366&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Type" type="ENUMERATION">Top-level</aTTRIBUTE>
+<aTTRIBUTE name="Message" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Timer" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Conditional" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Signal" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Escalation" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Error" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Compensation" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Parallel" type="ENUMERATION">No</aTTRIBUTE>
+<rECORD name="Properties"></rECORD>
+<aTTRIBUTE name="Auditing" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Monitoring" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Collection" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Object type" type="ENUMERATION">Information</aTTRIBUTE>
+<aTTRIBUTE name="Cardinality" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Details" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Timer type" type="ENUMERATION">Date</aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16369" class="Task" name="Send Instance to Third Party">
+<aTTRIBUTE name="Position" type="STRING">NODE x:16cm y:10cm w:3.36cm h:1.8cm index:8</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Performer" type="EXPRESSION">EXPR expr:(&quot;&quot;) val:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Execution time" type="TIME">00:000:00:00:00</aTTRIBUTE>
+<aTTRIBUTE name="Waiting time" type="TIME">00:000:00:00:00</aTTRIBUTE>
+<aTTRIBUTE name="Resting time" type="TIME">00:000:00:00:00</aTTRIBUTE>
+<aTTRIBUTE name="Transport time" type="TIME">00:000:00:00:00</aTTRIBUTE>
+<aTTRIBUTE name="Priority" type="INTEGER">10</aTTRIBUTE>
+<aTTRIBUTE name="Done by" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Continuous execution" type="ENUMERATION">no</aTTRIBUTE>
+<aTTRIBUTE name="Max. resource waiting time" type="TIME">00:000:00:05:00</aTTRIBUTE>
+<aTTRIBUTE name="Cooperative" type="ENUMERATION">no</aTTRIBUTE>
+<aTTRIBUTE name="Cooperation mode" type="ENUMERATION">synchron</aTTRIBUTE>
+<aTTRIBUTE name="Average number of participants" type="INTEGER">1</aTTRIBUTE>
+<aTTRIBUTE name="Min. quota of presence" type="INTEGER">100</aTTRIBUTE>
+<aTTRIBUTE name="Max. start period" type="TIME">00:001:00:00:00</aTTRIBUTE>
+<aTTRIBUTE name="Execution interruptable" type="ENUMERATION">yes</aTTRIBUTE>
+<aTTRIBUTE name="Task stack" type="ENUMERATION">personal</aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-02] Attribute \&quot;Fontcolor\&quot; (Lane) does not exist!  \&quot;fontcolor\&quot; (Task)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<rECORD name="Technical Attributes"></rECORD>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Actor"></iNTERREF>
+<rECORD name="Assignments"></rECORD>
+<aTTRIBUTE name="Term" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Status" type="ENUMERATION">None</aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="External documentation" type="PROGRAMCALL">ITEM &quot;&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Info on results" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Number" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated execution time" type="TIME">00:000:00:00:00</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated waiting time" type="TIME">00:000:00:00:00</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated resting time" type="TIME">00:000:00:00:00</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated transport time" type="TIME">00:000:00:00:00</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated personnel costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Classification" type="ENUMERATIONLIST"></aTTRIBUTE>
+<aTTRIBUTE name="EDP transaction costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="EDP batch costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Printing costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Postal costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Aktivität</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Open questions" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Type" type="ENUMERATION">Standard</aTTRIBUTE>
+<iNTERREF name="referenced subprocess"></iNTERREF>
+<aTTRIBUTE name="Display responsible role" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Subprocessname" type="EXPRESSION">EXPR val:&quot;Bezeichnung&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Modelling direction" type="EXPRESSION">EXPR val:&quot;vertical&quot;</aTTRIBUTE>
+<rECORD name="Properties"></rECORD>
+<aTTRIBUTE name="Show name" type="ENUMERATION">center</aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16369&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Task type" type="ENUMERATION">Send</aTTRIBUTE>
+<aTTRIBUTE name="Global task" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Auditing" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Monitoring" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="For compensation" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Loop type" type="ENUMERATION">Multi-instance</aTTRIBUTE>
+<iNTERREF name="Call activity"></iNTERREF>
+<aTTRIBUTE name="Sequential execution" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Cardinality" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Referenced data input"></iNTERREF>
+<iNTERREF name="Referenced data output"></iNTERREF>
+<aTTRIBUTE name="Instantiate" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Collection" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Object type" type="ENUMERATION">Information</aTTRIBUTE>
+<aTTRIBUTE name="Completion condition" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Loop condition (standard)" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Referenced message"></iNTERREF>
+<aTTRIBUTE name="People-like_view_Expression" type="EXPRESSION">EXPR expr:(maval(&quot;People-like view&quot;)) val:&quot;No&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Action" type="ENUMERATION">Fill in</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Actor_" type="EXPRESSION">EXPR expr:(maval(&quot;Actor_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Description_" type="EXPRESSION">EXPR expr:(maval(&quot;Description_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_Modelling_direction_" type="EXPRESSION">EXPR expr:(maval(&quot;Modelling direction&quot;)) val:&quot;vertical&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Modelling_" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="_REFERENCE_OVERVIEW_SETTINGS_" type="EXPRESSION">EXPR expr:(maval(&quot;Reference overview settings&quot;)) val:&quot;Responsible for execution|Responsible for execution\nAccountable for approving results|Accountable for approving results\nCooperation/participation|Cooperation/participation\nTo inform|To inform\nModelling|Modelling\nKnowledge Product|Knowledge Product\nDocuments and Resources|Documents and Resources\n#Data Object|Data Object\nIncoming Data Object|Incoming Data Object\nOutgoing Data Object|Outgoing Data Object\nDescription|Description&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Actor_" type="EXPRESSION">EXPR expr:(maval(&quot;Actor_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Description_" type="EXPRESSION">EXPR expr:(maval(&quot;Description_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Modelling_" type="EXPRESSION">EXPR expr:(maval(&quot;Modelling_size&quot;)) val:&quot;3&quot;</aTTRIBUTE>
+<aTTRIBUTE name="BoolBarDisplayActive" type="EXPRESSION">EXPR expr:(maval(&quot;BAR Display active&quot;)) val:&quot;No&quot;</aTTRIBUTE>
+<iNTERREF name="Data Object"></iNTERREF>
+<iNTERREF name="Knowledge Product"></iNTERREF>
+<iNTERREF name="Documents and Resources"></iNTERREF>
+<aTTRIBUTE name="_disp_Knowledge Product_" type="EXPRESSION">EXPR expr:(maval(&quot;Knowledge Product_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Data Object_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Documents and Resources_" type="EXPRESSION">EXPR expr:(maval(&quot;Documents and Resources_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Data Object_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Documents and Resources_" type="EXPRESSION">EXPR expr:(maval(&quot;Documents and Resources_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Knowledge Product_" type="EXPRESSION">EXPR expr:(maval(&quot;Knowledge Product_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Responsible for execution_" type="EXPRESSION">EXPR expr:(maval(&quot;Responsible for execution_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Responsible for execution_" type="EXPRESSION">EXPR expr:(maval(&quot;Responsible for execution_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Accountable for approving results_" type="EXPRESSION">EXPR expr:(maval(&quot;Accountable for approving results_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Accountable for approving results_" type="EXPRESSION">EXPR expr:(maval(&quot;Accountable for approving results_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Cooperation/participation_" type="EXPRESSION">EXPR expr:(maval(&quot;Cooperation/participation_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Cooperation/participation_" type="EXPRESSION">EXPR expr:(maval(&quot;Cooperation/participation_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_To inform_" type="EXPRESSION">EXPR expr:(maval(&quot;To inform_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_To inform_" type="EXPRESSION">EXPR expr:(maval(&quot;To inform_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<iNTERREF name="Responsible for execution"></iNTERREF>
+<iNTERREF name="To inform"></iNTERREF>
+<iNTERREF name="Cooperation/participation"></iNTERREF>
+<iNTERREF name="Accountable for approving results"></iNTERREF>
+<iNTERREF name="Incoming Data Object"></iNTERREF>
+<iNTERREF name="Outgoing Data Object"></iNTERREF>
+<aTTRIBUTE name="_size_Outgoing Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Outgoing Data Object_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Outgoing Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Outgoing Data Object_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Incoming Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Incoming Data Object_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Incoming Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Incoming Data Object_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Commentboxcomment" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="CommentAreaSizeExp" type="EXPRESSION">EXPR expr:(maval(&quot;CommentAreaSize&quot;)) val:&quot;2&quot;</aTTRIBUTE>
+<aTTRIBUTE name="CommentBool" type="ENUMERATION">0</aTTRIBUTE>
+<aTTRIBUTE name="CommentBox" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="CommentInfo" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="CommentMode" type="EXPRESSION">EXPR expr:(maval(&quot;Comment Mode&quot;)) val:&quot;No&quot;</aTTRIBUTE>
+<rECORD name="CommentTable"></rECORD>
+<aTTRIBUTE name="WriteComment" type="PROGRAMCALL">ITEM &quot;Add Comment&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="ClearComment" type="PROGRAMCALL">ITEM &quot;Clear Comment&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="CommentModellingAreaSizeExp" type="EXPRESSION">EXPR expr:(maval(&quot;CommentModellingAreaSize&quot;)) val:&quot;3&quot;</aTTRIBUTE>
+<aTTRIBUTE name="BoolCommentModeActive" type="EXPRESSION">EXPR expr:(maval(&quot;Comment Mode&quot;)) val:&quot;No&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Comment Model Direction" type="EXPRESSION">EXPR expr:(maval(&quot;CommentModellingDirection&quot;)) val:&quot;vertical&quot;</aTTRIBUTE>
+<iNTERREF name="Decision"></iNTERREF>
+<iNTERREF name="Referenced documents"></iNTERREF>
+<aTTRIBUTE name="Left border" type="EXPRESSION">EXPR
+ val:14.32</aTTRIBUTE>
+<iNTERREF name="Referenced Planning Table"></iNTERREF>
+<aTTRIBUTE name="Right border" type="EXPRESSION">EXPR
+ val:17.68</aTTRIBUTE>
+<aTTRIBUTE name="Show or Hide" type="ENUMERATION">Shown</aTTRIBUTE>
+<aTTRIBUTE name="Top border" type="EXPRESSION">EXPR
+ val:9.1</aTTRIBUTE>
+<aTTRIBUTE name="Bottom border" type="EXPRESSION">EXPR
+ val:10.9</aTTRIBUTE>
+<aTTRIBUTE name="X" type="EXPRESSION">EXPR
+ val:16</aTTRIBUTE>
+<aTTRIBUTE name="Y" type="EXPRESSION">EXPR
+ val:10</aTTRIBUTE>
+<aTTRIBUTE name="Change Visibility" type="PROGRAMCALL">ITEM &quot;Change Visibility&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Planning Table" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Bounding box" type="EXPRESSION">EXPR
+ val:&quot;[9.1,10.9,14.32,17.68,16,10]&quot;</aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16372" class="Task" name="Receive check of 3rd Party">
+<aTTRIBUTE name="Position" type="STRING">NODE x:25cm y:10cm w:3.36cm h:1.8cm index:9</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Performer" type="EXPRESSION">EXPR expr:(&quot;&quot;) val:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Execution time" type="TIME">00:000:00:00:00</aTTRIBUTE>
+<aTTRIBUTE name="Waiting time" type="TIME">00:000:00:00:00</aTTRIBUTE>
+<aTTRIBUTE name="Resting time" type="TIME">00:000:00:00:00</aTTRIBUTE>
+<aTTRIBUTE name="Transport time" type="TIME">00:000:00:00:00</aTTRIBUTE>
+<aTTRIBUTE name="Priority" type="INTEGER">10</aTTRIBUTE>
+<aTTRIBUTE name="Done by" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Continuous execution" type="ENUMERATION">no</aTTRIBUTE>
+<aTTRIBUTE name="Max. resource waiting time" type="TIME">00:000:00:05:00</aTTRIBUTE>
+<aTTRIBUTE name="Cooperative" type="ENUMERATION">no</aTTRIBUTE>
+<aTTRIBUTE name="Cooperation mode" type="ENUMERATION">synchron</aTTRIBUTE>
+<aTTRIBUTE name="Average number of participants" type="INTEGER">1</aTTRIBUTE>
+<aTTRIBUTE name="Min. quota of presence" type="INTEGER">100</aTTRIBUTE>
+<aTTRIBUTE name="Max. start period" type="TIME">00:001:00:00:00</aTTRIBUTE>
+<aTTRIBUTE name="Execution interruptable" type="ENUMERATION">yes</aTTRIBUTE>
+<aTTRIBUTE name="Task stack" type="ENUMERATION">personal</aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-02] Attribute \&quot;Fontcolor\&quot; (Lane) does not exist!  \&quot;fontcolor\&quot; (Task)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<rECORD name="Technical Attributes"></rECORD>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Actor"></iNTERREF>
+<rECORD name="Assignments"></rECORD>
+<aTTRIBUTE name="Term" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Status" type="ENUMERATION">None</aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="External documentation" type="PROGRAMCALL">ITEM &quot;&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Info on results" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Number" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated execution time" type="TIME">00:000:00:00:00</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated waiting time" type="TIME">00:000:00:00:00</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated resting time" type="TIME">00:000:00:00:00</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated transport time" type="TIME">00:000:00:00:00</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated personnel costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Classification" type="ENUMERATIONLIST"></aTTRIBUTE>
+<aTTRIBUTE name="EDP transaction costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="EDP batch costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Printing costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Postal costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Aktivität</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Open questions" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Type" type="ENUMERATION">Standard</aTTRIBUTE>
+<iNTERREF name="referenced subprocess"></iNTERREF>
+<aTTRIBUTE name="Display responsible role" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Subprocessname" type="EXPRESSION">EXPR val:&quot;Bezeichnung&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Modelling direction" type="EXPRESSION">EXPR val:&quot;vertical&quot;</aTTRIBUTE>
+<rECORD name="Properties"></rECORD>
+<aTTRIBUTE name="Show name" type="ENUMERATION">center</aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16372&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Task type" type="ENUMERATION">Receive</aTTRIBUTE>
+<aTTRIBUTE name="Global task" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Auditing" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Monitoring" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="For compensation" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Loop type" type="ENUMERATION">Multi-instance</aTTRIBUTE>
+<iNTERREF name="Call activity"></iNTERREF>
+<aTTRIBUTE name="Sequential execution" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Cardinality" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Referenced data input"></iNTERREF>
+<iNTERREF name="Referenced data output"></iNTERREF>
+<aTTRIBUTE name="Instantiate" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Collection" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Object type" type="ENUMERATION">Information</aTTRIBUTE>
+<aTTRIBUTE name="Completion condition" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Loop condition (standard)" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Referenced message"></iNTERREF>
+<aTTRIBUTE name="People-like_view_Expression" type="EXPRESSION">EXPR expr:(maval(&quot;People-like view&quot;)) val:&quot;No&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Action" type="ENUMERATION">Fill in</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Actor_" type="EXPRESSION">EXPR expr:(maval(&quot;Actor_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Description_" type="EXPRESSION">EXPR expr:(maval(&quot;Description_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_Modelling_direction_" type="EXPRESSION">EXPR expr:(maval(&quot;Modelling direction&quot;)) val:&quot;vertical&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Modelling_" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="_REFERENCE_OVERVIEW_SETTINGS_" type="EXPRESSION">EXPR expr:(maval(&quot;Reference overview settings&quot;)) val:&quot;Responsible for execution|Responsible for execution\nAccountable for approving results|Accountable for approving results\nCooperation/participation|Cooperation/participation\nTo inform|To inform\nModelling|Modelling\nKnowledge Product|Knowledge Product\nDocuments and Resources|Documents and Resources\n#Data Object|Data Object\nIncoming Data Object|Incoming Data Object\nOutgoing Data Object|Outgoing Data Object\nDescription|Description&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Actor_" type="EXPRESSION">EXPR expr:(maval(&quot;Actor_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Description_" type="EXPRESSION">EXPR expr:(maval(&quot;Description_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Modelling_" type="EXPRESSION">EXPR expr:(maval(&quot;Modelling_size&quot;)) val:&quot;3&quot;</aTTRIBUTE>
+<aTTRIBUTE name="BoolBarDisplayActive" type="EXPRESSION">EXPR expr:(maval(&quot;BAR Display active&quot;)) val:&quot;No&quot;</aTTRIBUTE>
+<iNTERREF name="Data Object"></iNTERREF>
+<iNTERREF name="Knowledge Product"></iNTERREF>
+<iNTERREF name="Documents and Resources"></iNTERREF>
+<aTTRIBUTE name="_disp_Knowledge Product_" type="EXPRESSION">EXPR expr:(maval(&quot;Knowledge Product_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Data Object_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Documents and Resources_" type="EXPRESSION">EXPR expr:(maval(&quot;Documents and Resources_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Data Object_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Documents and Resources_" type="EXPRESSION">EXPR expr:(maval(&quot;Documents and Resources_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Knowledge Product_" type="EXPRESSION">EXPR expr:(maval(&quot;Knowledge Product_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Responsible for execution_" type="EXPRESSION">EXPR expr:(maval(&quot;Responsible for execution_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Responsible for execution_" type="EXPRESSION">EXPR expr:(maval(&quot;Responsible for execution_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Accountable for approving results_" type="EXPRESSION">EXPR expr:(maval(&quot;Accountable for approving results_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Accountable for approving results_" type="EXPRESSION">EXPR expr:(maval(&quot;Accountable for approving results_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Cooperation/participation_" type="EXPRESSION">EXPR expr:(maval(&quot;Cooperation/participation_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Cooperation/participation_" type="EXPRESSION">EXPR expr:(maval(&quot;Cooperation/participation_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_To inform_" type="EXPRESSION">EXPR expr:(maval(&quot;To inform_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_To inform_" type="EXPRESSION">EXPR expr:(maval(&quot;To inform_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<iNTERREF name="Responsible for execution"></iNTERREF>
+<iNTERREF name="To inform"></iNTERREF>
+<iNTERREF name="Cooperation/participation"></iNTERREF>
+<iNTERREF name="Accountable for approving results"></iNTERREF>
+<iNTERREF name="Incoming Data Object"></iNTERREF>
+<iNTERREF name="Outgoing Data Object"></iNTERREF>
+<aTTRIBUTE name="_size_Outgoing Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Outgoing Data Object_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Outgoing Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Outgoing Data Object_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Incoming Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Incoming Data Object_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Incoming Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Incoming Data Object_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Commentboxcomment" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="CommentAreaSizeExp" type="EXPRESSION">EXPR expr:(maval(&quot;CommentAreaSize&quot;)) val:&quot;2&quot;</aTTRIBUTE>
+<aTTRIBUTE name="CommentBool" type="ENUMERATION">0</aTTRIBUTE>
+<aTTRIBUTE name="CommentBox" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="CommentInfo" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="CommentMode" type="EXPRESSION">EXPR expr:(maval(&quot;Comment Mode&quot;)) val:&quot;No&quot;</aTTRIBUTE>
+<rECORD name="CommentTable"></rECORD>
+<aTTRIBUTE name="WriteComment" type="PROGRAMCALL">ITEM &quot;Add Comment&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="ClearComment" type="PROGRAMCALL">ITEM &quot;Clear Comment&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="CommentModellingAreaSizeExp" type="EXPRESSION">EXPR expr:(maval(&quot;CommentModellingAreaSize&quot;)) val:&quot;3&quot;</aTTRIBUTE>
+<aTTRIBUTE name="BoolCommentModeActive" type="EXPRESSION">EXPR expr:(maval(&quot;Comment Mode&quot;)) val:&quot;No&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Comment Model Direction" type="EXPRESSION">EXPR expr:(maval(&quot;CommentModellingDirection&quot;)) val:&quot;vertical&quot;</aTTRIBUTE>
+<iNTERREF name="Decision"></iNTERREF>
+<iNTERREF name="Referenced documents"></iNTERREF>
+<aTTRIBUTE name="Left border" type="EXPRESSION">EXPR
+ val:23.32</aTTRIBUTE>
+<iNTERREF name="Referenced Planning Table"></iNTERREF>
+<aTTRIBUTE name="Right border" type="EXPRESSION">EXPR
+ val:26.68</aTTRIBUTE>
+<aTTRIBUTE name="Show or Hide" type="ENUMERATION">Shown</aTTRIBUTE>
+<aTTRIBUTE name="Top border" type="EXPRESSION">EXPR
+ val:9.1</aTTRIBUTE>
+<aTTRIBUTE name="Bottom border" type="EXPRESSION">EXPR
+ val:10.9</aTTRIBUTE>
+<aTTRIBUTE name="X" type="EXPRESSION">EXPR
+ val:25</aTTRIBUTE>
+<aTTRIBUTE name="Y" type="EXPRESSION">EXPR
+ val:10</aTTRIBUTE>
+<aTTRIBUTE name="Change Visibility" type="PROGRAMCALL">ITEM &quot;Change Visibility&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Planning Table" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Bounding box" type="EXPRESSION">EXPR
+ val:&quot;[9.1,10.9,23.32,26.68,25,10]&quot;</aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16375" class="Task" name="Do Check">
+<aTTRIBUTE name="Position" type="STRING">NODE x:19.5cm y:16.5cm w:3.36cm h:1.8cm index:10</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Performer" type="EXPRESSION">EXPR expr:(&quot;&quot;) val:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Execution time" type="TIME">00:000:00:00:00</aTTRIBUTE>
+<aTTRIBUTE name="Waiting time" type="TIME">00:000:00:00:00</aTTRIBUTE>
+<aTTRIBUTE name="Resting time" type="TIME">00:000:00:00:00</aTTRIBUTE>
+<aTTRIBUTE name="Transport time" type="TIME">00:000:00:00:00</aTTRIBUTE>
+<aTTRIBUTE name="Priority" type="INTEGER">10</aTTRIBUTE>
+<aTTRIBUTE name="Done by" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Continuous execution" type="ENUMERATION">no</aTTRIBUTE>
+<aTTRIBUTE name="Max. resource waiting time" type="TIME">00:000:00:05:00</aTTRIBUTE>
+<aTTRIBUTE name="Cooperative" type="ENUMERATION">no</aTTRIBUTE>
+<aTTRIBUTE name="Cooperation mode" type="ENUMERATION">synchron</aTTRIBUTE>
+<aTTRIBUTE name="Average number of participants" type="INTEGER">1</aTTRIBUTE>
+<aTTRIBUTE name="Min. quota of presence" type="INTEGER">100</aTTRIBUTE>
+<aTTRIBUTE name="Max. start period" type="TIME">00:001:00:00:00</aTTRIBUTE>
+<aTTRIBUTE name="Execution interruptable" type="ENUMERATION">yes</aTTRIBUTE>
+<aTTRIBUTE name="Task stack" type="ENUMERATION">personal</aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-02] Attribute \&quot;Fontcolor\&quot; (Lane) does not exist!  \&quot;fontcolor\&quot; (Task)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<rECORD name="Technical Attributes"></rECORD>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Actor"></iNTERREF>
+<rECORD name="Assignments"></rECORD>
+<aTTRIBUTE name="Term" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Status" type="ENUMERATION">None</aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING">what ever ...</aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="External documentation" type="PROGRAMCALL">ITEM &quot;&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Info on results" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Number" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated execution time" type="TIME">00:000:00:00:00</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated waiting time" type="TIME">00:000:00:00:00</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated resting time" type="TIME">00:000:00:00:00</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated transport time" type="TIME">00:000:00:00:00</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated personnel costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Classification" type="ENUMERATIONLIST"></aTTRIBUTE>
+<aTTRIBUTE name="EDP transaction costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="EDP batch costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Printing costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Postal costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Aktivität</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Open questions" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Type" type="ENUMERATION">Standard</aTTRIBUTE>
+<iNTERREF name="referenced subprocess"></iNTERREF>
+<aTTRIBUTE name="Display responsible role" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Subprocessname" type="EXPRESSION">EXPR val:&quot;Bezeichnung&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Modelling direction" type="EXPRESSION">EXPR val:&quot;vertical&quot;</aTTRIBUTE>
+<rECORD name="Properties"></rECORD>
+<aTTRIBUTE name="Show name" type="ENUMERATION">center</aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16375&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Task type" type="ENUMERATION">Not specified</aTTRIBUTE>
+<aTTRIBUTE name="Global task" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Auditing" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Monitoring" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="For compensation" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Loop type" type="ENUMERATION">Not specified</aTTRIBUTE>
+<iNTERREF name="Call activity"></iNTERREF>
+<aTTRIBUTE name="Sequential execution" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Cardinality" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Referenced data input"></iNTERREF>
+<iNTERREF name="Referenced data output"></iNTERREF>
+<aTTRIBUTE name="Instantiate" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Collection" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Object type" type="ENUMERATION">Information</aTTRIBUTE>
+<aTTRIBUTE name="Completion condition" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Loop condition (standard)" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Referenced message"></iNTERREF>
+<aTTRIBUTE name="People-like_view_Expression" type="EXPRESSION">EXPR expr:(maval(&quot;People-like view&quot;)) val:&quot;No&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Action" type="ENUMERATION">Fill in</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Actor_" type="EXPRESSION">EXPR expr:(maval(&quot;Actor_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Description_" type="EXPRESSION">EXPR expr:(maval(&quot;Description_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_Modelling_direction_" type="EXPRESSION">EXPR expr:(maval(&quot;Modelling direction&quot;)) val:&quot;vertical&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Modelling_" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="_REFERENCE_OVERVIEW_SETTINGS_" type="EXPRESSION">EXPR expr:(maval(&quot;Reference overview settings&quot;)) val:&quot;Responsible for execution|Responsible for execution\nAccountable for approving results|Accountable for approving results\nCooperation/participation|Cooperation/participation\nTo inform|To inform\nModelling|Modelling\nKnowledge Product|Knowledge Product\nDocuments and Resources|Documents and Resources\n#Data Object|Data Object\nIncoming Data Object|Incoming Data Object\nOutgoing Data Object|Outgoing Data Object\nDescription|Description&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Actor_" type="EXPRESSION">EXPR expr:(maval(&quot;Actor_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Description_" type="EXPRESSION">EXPR expr:(maval(&quot;Description_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Modelling_" type="EXPRESSION">EXPR expr:(maval(&quot;Modelling_size&quot;)) val:&quot;3&quot;</aTTRIBUTE>
+<aTTRIBUTE name="BoolBarDisplayActive" type="EXPRESSION">EXPR expr:(maval(&quot;BAR Display active&quot;)) val:&quot;No&quot;</aTTRIBUTE>
+<iNTERREF name="Data Object"></iNTERREF>
+<iNTERREF name="Knowledge Product"></iNTERREF>
+<iNTERREF name="Documents and Resources"></iNTERREF>
+<aTTRIBUTE name="_disp_Knowledge Product_" type="EXPRESSION">EXPR expr:(maval(&quot;Knowledge Product_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Data Object_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Documents and Resources_" type="EXPRESSION">EXPR expr:(maval(&quot;Documents and Resources_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Data Object_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Documents and Resources_" type="EXPRESSION">EXPR expr:(maval(&quot;Documents and Resources_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Knowledge Product_" type="EXPRESSION">EXPR expr:(maval(&quot;Knowledge Product_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Responsible for execution_" type="EXPRESSION">EXPR expr:(maval(&quot;Responsible for execution_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Responsible for execution_" type="EXPRESSION">EXPR expr:(maval(&quot;Responsible for execution_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Accountable for approving results_" type="EXPRESSION">EXPR expr:(maval(&quot;Accountable for approving results_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Accountable for approving results_" type="EXPRESSION">EXPR expr:(maval(&quot;Accountable for approving results_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Cooperation/participation_" type="EXPRESSION">EXPR expr:(maval(&quot;Cooperation/participation_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Cooperation/participation_" type="EXPRESSION">EXPR expr:(maval(&quot;Cooperation/participation_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_To inform_" type="EXPRESSION">EXPR expr:(maval(&quot;To inform_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_To inform_" type="EXPRESSION">EXPR expr:(maval(&quot;To inform_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<iNTERREF name="Responsible for execution"></iNTERREF>
+<iNTERREF name="To inform"></iNTERREF>
+<iNTERREF name="Cooperation/participation"></iNTERREF>
+<iNTERREF name="Accountable for approving results"></iNTERREF>
+<iNTERREF name="Incoming Data Object"></iNTERREF>
+<iNTERREF name="Outgoing Data Object"></iNTERREF>
+<aTTRIBUTE name="_size_Outgoing Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Outgoing Data Object_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Outgoing Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Outgoing Data Object_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Incoming Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Incoming Data Object_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Incoming Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Incoming Data Object_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Commentboxcomment" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="CommentAreaSizeExp" type="EXPRESSION">EXPR expr:(maval(&quot;CommentAreaSize&quot;)) val:&quot;2&quot;</aTTRIBUTE>
+<aTTRIBUTE name="CommentBool" type="ENUMERATION">0</aTTRIBUTE>
+<aTTRIBUTE name="CommentBox" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="CommentInfo" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="CommentMode" type="EXPRESSION">EXPR expr:(maval(&quot;Comment Mode&quot;)) val:&quot;No&quot;</aTTRIBUTE>
+<rECORD name="CommentTable"></rECORD>
+<aTTRIBUTE name="WriteComment" type="PROGRAMCALL">ITEM &quot;Add Comment&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="ClearComment" type="PROGRAMCALL">ITEM &quot;Clear Comment&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="CommentModellingAreaSizeExp" type="EXPRESSION">EXPR expr:(maval(&quot;CommentModellingAreaSize&quot;)) val:&quot;3&quot;</aTTRIBUTE>
+<aTTRIBUTE name="BoolCommentModeActive" type="EXPRESSION">EXPR expr:(maval(&quot;Comment Mode&quot;)) val:&quot;No&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Comment Model Direction" type="EXPRESSION">EXPR expr:(maval(&quot;CommentModellingDirection&quot;)) val:&quot;vertical&quot;</aTTRIBUTE>
+<iNTERREF name="Decision"></iNTERREF>
+<iNTERREF name="Referenced documents"></iNTERREF>
+<aTTRIBUTE name="Left border" type="EXPRESSION">EXPR
+ val:17.82</aTTRIBUTE>
+<iNTERREF name="Referenced Planning Table"></iNTERREF>
+<aTTRIBUTE name="Right border" type="EXPRESSION">EXPR
+ val:21.18</aTTRIBUTE>
+<aTTRIBUTE name="Show or Hide" type="ENUMERATION">Shown</aTTRIBUTE>
+<aTTRIBUTE name="Top border" type="EXPRESSION">EXPR
+ val:15.6</aTTRIBUTE>
+<aTTRIBUTE name="Bottom border" type="EXPRESSION">EXPR
+ val:17.4</aTTRIBUTE>
+<aTTRIBUTE name="X" type="EXPRESSION">EXPR
+ val:19.5</aTTRIBUTE>
+<aTTRIBUTE name="Y" type="EXPRESSION">EXPR
+ val:16.5</aTTRIBUTE>
+<aTTRIBUTE name="Change Visibility" type="PROGRAMCALL">ITEM &quot;Change Visibility&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Planning Table" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Bounding box" type="EXPRESSION">EXPR
+ val:&quot;[15.6,17.4,17.82,21.18,19.5,16.5]&quot;</aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16378" class="Exclusive Gateway" name="is check necessary?">
+<aTTRIBUTE name="Position" type="STRING">NODE x:14cm y:16.5cm index:11</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Variable type" type="ENUMERATION">enumeration</aTTRIBUTE>
+<aTTRIBUTE name="Variable scope" type="ENUMERATION">global</aTTRIBUTE>
+<aTTRIBUTE name="Variable name" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Variable value" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-02] Attribute \&quot;Fontcolor\&quot; (Lane) does not exist!  \&quot;fontcolor\&quot; (Exclusive Gateway)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<rECORD name="Technical Attributes"></rECORD>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Actor"></iNTERREF>
+<rECORD name="Assignments"></rECORD>
+<aTTRIBUTE name="Term" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Entscheidung</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Open questions" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Sum" type="EXPRESSION">EXPR
+ val:0</aTTRIBUTE>
+<aTTRIBUTE name="Type" type="ENUMERATION">Data-based (without marker)</aTTRIBUTE>
+<aTTRIBUTE name="Show name" type="ENUMERATION">below</aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16378&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Constraints" type="ENUMERATION">Unspecified</aTTRIBUTE>
+<rECORD name="Properties"></rECORD>
+<aTTRIBUTE name="Cardinality" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16381" class="Data Object" name="Instance SCIA (update)">
+<aTTRIBUTE name="Position" type="STRING">NODE x:19.5cm y:12cm index:13</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(&quot;&quot;) val:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<rECORD name="Technical Attributes"></rECORD>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Collection" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Open questions" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Data type" type="ENUMERATION">Data Input</aTTRIBUTE>
+<iNTERREF name="Referenced input data (optional)">
+<iREF type="objectreference" tmodeltype="Document and Knowledge model" tmodelname="Document and Knowledge model TitoloUnico" tmodelver="" tclassname="Document" tobjname="SCIA Instance"></iREF>
+</iNTERREF>
+<iNTERREF name="Referenced input data (while executing)"></iNTERREF>
+<aTTRIBUTE name="Collection (input)" type="ENUMERATION">No</aTTRIBUTE>
+<iNTERREF name="Referenced output data (optional)"></iNTERREF>
+<iNTERREF name="Referenced output data (while executing)"></iNTERREF>
+<aTTRIBUTE name="Collection (output)" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Capacity" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Unlimited" type="ENUMERATION">No</aTTRIBUTE>
+<iNTERREF name="Referenced data store (global)"></iNTERREF>
+<aTTRIBUTE name="Auditing" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Monitoring" type="ENUMERATION">No</aTTRIBUTE>
+<rECORD name="Properties"></rECORD>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16381&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Cardinality" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16384" class="Non-exclusive Gateway" name="Non-exclusive Gateway-83191">
+<aTTRIBUTE name="Position" type="STRING">NODE x:10cm y:10cm index:16</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-02] Attribute \&quot;Fontcolor\&quot; (Lane) does not exist!  \&quot;fontcolor\&quot; (Non-exclusive Gateway)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<rECORD name="Technical Attributes"></rECORD>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Actor"></iNTERREF>
+<rECORD name="Assignments"></rECORD>
+<aTTRIBUTE name="Term" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Representation" type="ENUMERATION">without name</aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Parallelität</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Modelling direction (Model)" type="EXPRESSION">EXPR val:&quot;vertical&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Modelling direction" type="ENUMERATION">undefined</aTTRIBUTE>
+<aTTRIBUTE name="Change modelling direction (global)" type="PROGRAMCALL">ITEM &quot;Change modelling direction (global)&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Type" type="ENUMERATION">AND</aTTRIBUTE>
+<aTTRIBUTE name="Show name" type="ENUMERATION">do not show</aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16384&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Gateway type" type="ENUMERATION">Parallel</aTTRIBUTE>
+<aTTRIBUTE name="Type (parallel)" type="ENUMERATION">Data-based</aTTRIBUTE>
+<aTTRIBUTE name="Activation condition (complex)" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Open questions" type="STRING"></aTTRIBUTE>
+<rECORD name="Properties"></rECORD>
+<aTTRIBUTE name="Cardinality" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16387" class="End Event" name="End Event-83205">
+<aTTRIBUTE name="Position" type="STRING">NODE x:36.5cm y:10cm index:19</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Type" type="ENUMERATION">local</aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-02] Attribute \&quot;Fontcolor\&quot; (Lane) does not exist!  \&quot;fontcolor\&quot; (End Event)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<rECORD name="Technical Attributes"></rECORD>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Actor"></iNTERREF>
+<aTTRIBUTE name="Representation" type="ENUMERATION">without name</aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Ende</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Show name" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Open questions" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16387&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Message" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Signal" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Escalation" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Error" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Compensation" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Terminate" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Cancel" type="ENUMERATION">No</aTTRIBUTE>
+<rECORD name="Properties"></rECORD>
+<aTTRIBUTE name="Auditing" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Monitoring" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Collection" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Object type" type="ENUMERATION">Information</aTTRIBUTE>
+<aTTRIBUTE name="Cardinality" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Details" type="LONGSTRING"></aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16390" class="Data Object" name="3rd Party Opinion">
+<aTTRIBUTE name="Position" type="STRING">NODE x:28.5cm y:11.5cm index:21</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(&quot;&quot;) val:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<rECORD name="Technical Attributes"></rECORD>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Collection" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Open questions" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Data type" type="ENUMERATION">Data Input</aTTRIBUTE>
+<iNTERREF name="Referenced input data (optional)">
+<iREF type="objectreference" tmodeltype="Document and Knowledge model" tmodelname="Document and Knowledge model TitoloUnico" tmodelver="" tclassname="Document" tobjname="Third Party Opinion"></iREF>
+</iNTERREF>
+<iNTERREF name="Referenced input data (while executing)"></iNTERREF>
+<aTTRIBUTE name="Collection (input)" type="ENUMERATION">No</aTTRIBUTE>
+<iNTERREF name="Referenced output data (optional)"></iNTERREF>
+<iNTERREF name="Referenced output data (while executing)"></iNTERREF>
+<aTTRIBUTE name="Collection (output)" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Capacity" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Unlimited" type="ENUMERATION">No</aTTRIBUTE>
+<iNTERREF name="Referenced data store (global)"></iNTERREF>
+<aTTRIBUTE name="Auditing" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Monitoring" type="ENUMERATION">No</aTTRIBUTE>
+<rECORD name="Properties"></rECORD>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16390&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Cardinality" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16393" class="Task" name="Check Involvement">
+<aTTRIBUTE name="Position" type="STRING">NODE x:10cm y:16.5cm w:3.36cm h:1.8cm index:27</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Performer" type="EXPRESSION">EXPR expr:(&quot;&quot;) val:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Execution time" type="TIME">00:000:00:00:00</aTTRIBUTE>
+<aTTRIBUTE name="Waiting time" type="TIME">00:000:00:00:00</aTTRIBUTE>
+<aTTRIBUTE name="Resting time" type="TIME">00:000:00:00:00</aTTRIBUTE>
+<aTTRIBUTE name="Transport time" type="TIME">00:000:00:00:00</aTTRIBUTE>
+<aTTRIBUTE name="Priority" type="INTEGER">10</aTTRIBUTE>
+<aTTRIBUTE name="Done by" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Continuous execution" type="ENUMERATION">no</aTTRIBUTE>
+<aTTRIBUTE name="Max. resource waiting time" type="TIME">00:000:00:05:00</aTTRIBUTE>
+<aTTRIBUTE name="Cooperative" type="ENUMERATION">no</aTTRIBUTE>
+<aTTRIBUTE name="Cooperation mode" type="ENUMERATION">synchron</aTTRIBUTE>
+<aTTRIBUTE name="Average number of participants" type="INTEGER">1</aTTRIBUTE>
+<aTTRIBUTE name="Min. quota of presence" type="INTEGER">100</aTTRIBUTE>
+<aTTRIBUTE name="Max. start period" type="TIME">00:001:00:00:00</aTTRIBUTE>
+<aTTRIBUTE name="Execution interruptable" type="ENUMERATION">yes</aTTRIBUTE>
+<aTTRIBUTE name="Task stack" type="ENUMERATION">personal</aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-02] Attribute \&quot;Fontcolor\&quot; (Lane) does not exist!  \&quot;fontcolor\&quot; (Task)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<rECORD name="Technical Attributes"></rECORD>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Actor"></iNTERREF>
+<rECORD name="Assignments"></rECORD>
+<aTTRIBUTE name="Term" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Status" type="ENUMERATION">None</aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING">in original BPMN model not considered</aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="External documentation" type="PROGRAMCALL">ITEM &quot;&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Info on results" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Number" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated execution time" type="TIME">00:000:00:00:00</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated waiting time" type="TIME">00:000:00:00:00</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated resting time" type="TIME">00:000:00:00:00</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated transport time" type="TIME">00:000:00:00:00</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated personnel costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Classification" type="ENUMERATIONLIST"></aTTRIBUTE>
+<aTTRIBUTE name="EDP transaction costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="EDP batch costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Printing costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Postal costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Aktivität</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Open questions" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Type" type="ENUMERATION">Standard</aTTRIBUTE>
+<iNTERREF name="referenced subprocess"></iNTERREF>
+<aTTRIBUTE name="Display responsible role" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Subprocessname" type="EXPRESSION">EXPR val:&quot;Bezeichnung&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Modelling direction" type="EXPRESSION">EXPR val:&quot;vertical&quot;</aTTRIBUTE>
+<rECORD name="Properties"></rECORD>
+<aTTRIBUTE name="Show name" type="ENUMERATION">center</aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16393&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Task type" type="ENUMERATION">Receive</aTTRIBUTE>
+<aTTRIBUTE name="Global task" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Auditing" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Monitoring" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="For compensation" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Loop type" type="ENUMERATION">Not specified</aTTRIBUTE>
+<iNTERREF name="Call activity"></iNTERREF>
+<aTTRIBUTE name="Sequential execution" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Cardinality" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Referenced data input"></iNTERREF>
+<iNTERREF name="Referenced data output"></iNTERREF>
+<aTTRIBUTE name="Instantiate" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Collection" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Object type" type="ENUMERATION">Information</aTTRIBUTE>
+<aTTRIBUTE name="Completion condition" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Loop condition (standard)" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Referenced message"></iNTERREF>
+<aTTRIBUTE name="People-like_view_Expression" type="EXPRESSION">EXPR expr:(maval(&quot;People-like view&quot;)) val:&quot;No&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Action" type="ENUMERATION">Fill in</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Actor_" type="EXPRESSION">EXPR expr:(maval(&quot;Actor_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Description_" type="EXPRESSION">EXPR expr:(maval(&quot;Description_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_Modelling_direction_" type="EXPRESSION">EXPR expr:(maval(&quot;Modelling direction&quot;)) val:&quot;vertical&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Modelling_" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="_REFERENCE_OVERVIEW_SETTINGS_" type="EXPRESSION">EXPR expr:(maval(&quot;Reference overview settings&quot;)) val:&quot;Responsible for execution|Responsible for execution\nAccountable for approving results|Accountable for approving results\nCooperation/participation|Cooperation/participation\nTo inform|To inform\nModelling|Modelling\nKnowledge Product|Knowledge Product\nDocuments and Resources|Documents and Resources\n#Data Object|Data Object\nIncoming Data Object|Incoming Data Object\nOutgoing Data Object|Outgoing Data Object\nDescription|Description&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Actor_" type="EXPRESSION">EXPR expr:(maval(&quot;Actor_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Description_" type="EXPRESSION">EXPR expr:(maval(&quot;Description_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Modelling_" type="EXPRESSION">EXPR expr:(maval(&quot;Modelling_size&quot;)) val:&quot;3&quot;</aTTRIBUTE>
+<aTTRIBUTE name="BoolBarDisplayActive" type="EXPRESSION">EXPR expr:(maval(&quot;BAR Display active&quot;)) val:&quot;No&quot;</aTTRIBUTE>
+<iNTERREF name="Data Object"></iNTERREF>
+<iNTERREF name="Knowledge Product"></iNTERREF>
+<iNTERREF name="Documents and Resources"></iNTERREF>
+<aTTRIBUTE name="_disp_Knowledge Product_" type="EXPRESSION">EXPR expr:(maval(&quot;Knowledge Product_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Data Object_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Documents and Resources_" type="EXPRESSION">EXPR expr:(maval(&quot;Documents and Resources_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Data Object_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Documents and Resources_" type="EXPRESSION">EXPR expr:(maval(&quot;Documents and Resources_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Knowledge Product_" type="EXPRESSION">EXPR expr:(maval(&quot;Knowledge Product_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Responsible for execution_" type="EXPRESSION">EXPR expr:(maval(&quot;Responsible for execution_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Responsible for execution_" type="EXPRESSION">EXPR expr:(maval(&quot;Responsible for execution_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Accountable for approving results_" type="EXPRESSION">EXPR expr:(maval(&quot;Accountable for approving results_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Accountable for approving results_" type="EXPRESSION">EXPR expr:(maval(&quot;Accountable for approving results_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Cooperation/participation_" type="EXPRESSION">EXPR expr:(maval(&quot;Cooperation/participation_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Cooperation/participation_" type="EXPRESSION">EXPR expr:(maval(&quot;Cooperation/participation_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_To inform_" type="EXPRESSION">EXPR expr:(maval(&quot;To inform_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_To inform_" type="EXPRESSION">EXPR expr:(maval(&quot;To inform_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<iNTERREF name="Responsible for execution"></iNTERREF>
+<iNTERREF name="To inform"></iNTERREF>
+<iNTERREF name="Cooperation/participation"></iNTERREF>
+<iNTERREF name="Accountable for approving results"></iNTERREF>
+<iNTERREF name="Incoming Data Object"></iNTERREF>
+<iNTERREF name="Outgoing Data Object"></iNTERREF>
+<aTTRIBUTE name="_size_Outgoing Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Outgoing Data Object_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Outgoing Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Outgoing Data Object_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Incoming Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Incoming Data Object_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Incoming Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Incoming Data Object_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Commentboxcomment" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="CommentAreaSizeExp" type="EXPRESSION">EXPR expr:(maval(&quot;CommentAreaSize&quot;)) val:&quot;2&quot;</aTTRIBUTE>
+<aTTRIBUTE name="CommentBool" type="ENUMERATION">0</aTTRIBUTE>
+<aTTRIBUTE name="CommentBox" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="CommentInfo" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="CommentMode" type="EXPRESSION">EXPR expr:(maval(&quot;Comment Mode&quot;)) val:&quot;No&quot;</aTTRIBUTE>
+<rECORD name="CommentTable"></rECORD>
+<aTTRIBUTE name="WriteComment" type="PROGRAMCALL">ITEM &quot;Add Comment&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="ClearComment" type="PROGRAMCALL">ITEM &quot;Clear Comment&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="CommentModellingAreaSizeExp" type="EXPRESSION">EXPR expr:(maval(&quot;CommentModellingAreaSize&quot;)) val:&quot;3&quot;</aTTRIBUTE>
+<aTTRIBUTE name="BoolCommentModeActive" type="EXPRESSION">EXPR expr:(maval(&quot;Comment Mode&quot;)) val:&quot;No&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Comment Model Direction" type="EXPRESSION">EXPR expr:(maval(&quot;CommentModellingDirection&quot;)) val:&quot;vertical&quot;</aTTRIBUTE>
+<iNTERREF name="Decision"></iNTERREF>
+<iNTERREF name="Referenced documents"></iNTERREF>
+<aTTRIBUTE name="Left border" type="EXPRESSION">EXPR
+ val:8.32</aTTRIBUTE>
+<iNTERREF name="Referenced Planning Table"></iNTERREF>
+<aTTRIBUTE name="Right border" type="EXPRESSION">EXPR
+ val:11.68</aTTRIBUTE>
+<aTTRIBUTE name="Show or Hide" type="ENUMERATION">Shown</aTTRIBUTE>
+<aTTRIBUTE name="Top border" type="EXPRESSION">EXPR
+ val:15.6</aTTRIBUTE>
+<aTTRIBUTE name="Bottom border" type="EXPRESSION">EXPR
+ val:17.4</aTTRIBUTE>
+<aTTRIBUTE name="X" type="EXPRESSION">EXPR
+ val:10</aTTRIBUTE>
+<aTTRIBUTE name="Y" type="EXPRESSION">EXPR
+ val:16.5</aTTRIBUTE>
+<aTTRIBUTE name="Change Visibility" type="PROGRAMCALL">ITEM &quot;Change Visibility&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Planning Table" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Bounding box" type="EXPRESSION">EXPR
+ val:&quot;[15.6,17.4,8.32,11.68,10,16.5]&quot;</aTTRIBUTE>
+</iNSTANCE>
+<cONNECTOR id="con.16396" class="Message Flow">
+<fROM instance="Third Party PA" class="Pool (collapsed)"></fROM>
+<tO instance="Receive check of 3rd Party" class="Task"></tO>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 0 index:22</aTTRIBUTE>
+<aTTRIBUTE name="Message Name" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="ParticipantType (from)" type="ENUMERATION">Role</aTTRIBUTE>
+<aTTRIBUTE name="Role (from)" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Entity (from)" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="ParticipantType (to)" type="ENUMERATION">Role</aTTRIBUTE>
+<aTTRIBUTE name="Role (to)" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Entity (to)" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Name" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Message Properties" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;Task&quot;</aTTRIBUTE>
+<aTTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Pool (collapsed)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Number" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Show Name" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Show Number" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Representation" type="ENUMERATION">above/below</aTTRIBUTE>
+<aTTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Description" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Show name" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Doku" type="STRING">NOTEBOOK
+
+#-----------------------
+CHAPTER &quot;Description&quot;
+#-----------------------
+ATTR &quot;Name&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+ATTR &quot;Id&quot; </aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16396&quot;</aTTRIBUTE>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16397" class="Is inside">
+<fROM instance="SUAP Office" class="Lane"></fROM>
+<tO instance="Monti Azzurri Consorsium" class="Pool"></tO>
+<aTTRIBUTE name="AutoConnect" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16398" class="Is inside">
+<fROM instance="Agriculture Office" class="Lane"></fROM>
+<tO instance="Monti Azzurri Consorsium" class="Pool"></tO>
+<aTTRIBUTE name="AutoConnect" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16399" class="Is inside">
+<fROM instance="Agriculture Office" class="Lane"></fROM>
+<tO instance="SUAP Office" class="Lane"></tO>
+<aTTRIBUTE name="AutoConnect" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16400" class="Association">
+<fROM instance="Text Annotation-83144" class="Text Annotation"></fROM>
+<tO instance="Third Party PA" class="Pool (collapsed)"></tO>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 0 index:6</aTTRIBUTE>
+<aTTRIBUTE name="Direction" type="ENUMERATION">None</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Name" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;Pool (collapsed)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Text Annotation&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Show Name" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Representation" type="ENUMERATION">above/below</aTTRIBUTE>
+<aTTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Description" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Show name" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Doku" type="STRING">NOTEBOOK
+
+#-----------------------
+CHAPTER &quot;Description&quot;
+#-----------------------
+ATTR &quot;Name&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+
+ATTR &quot;Id&quot; </aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16400&quot;</aTTRIBUTE>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16401" class="Is inside">
+<fROM instance="Text Annotation-83144" class="Text Annotation"></fROM>
+<tO instance="Third Party PA" class="Pool (collapsed)"></tO>
+<aTTRIBUTE name="AutoConnect" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16402" class="Is inside">
+<fROM instance="Start Event-83148" class="Start Event"></fROM>
+<tO instance="Monti Azzurri Consorsium" class="Pool"></tO>
+<aTTRIBUTE name="AutoConnect" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16403" class="Is inside">
+<fROM instance="Start Event-83148" class="Start Event"></fROM>
+<tO instance="SUAP Office" class="Lane"></tO>
+<aTTRIBUTE name="AutoConnect" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16404" class="Subsequent">
+<fROM instance="Start Event-83148" class="Start Event"></fROM>
+<tO instance="Non-exclusive Gateway-83191" class="Non-exclusive Gateway"></tO>
+<aTTRIBUTE name="Transition condition" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Transition probability" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualized values" type="ENUMERATION">Denomination</aTTRIBUTE>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 0 index:17</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">2</aTTRIBUTE>
+<aTTRIBUTE name="Representation" type="ENUMERATION">above/below</aTTRIBUTE>
+<aTTRIBUTE name="Font colour" type="ENUMERATION">black</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Info zur Übergangsbedingung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Nachfolger</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Denomination" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Description" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Auditing" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Monitoring" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Default" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Immediate" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Category" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16404&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Color" type="STRING">black</aTTRIBUTE>
+<aTTRIBUTE name="Doku" type="STRING">NOTEBOOK
+
+#-----------------------
+LANG &quot;en&quot;
+#-----------------------
+CHAPTER &quot;Description&quot;
+ATTR &quot;Denomination&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+
+
+CHAPTER &quot;Details (BPMN)&quot;
+
+ATTR &quot;Auditing&quot; 
+ATTR &quot;Monitoring&quot; 
+
+ATTR &quot;Default&quot; 
+ATTR &quot;Immediate&quot; 
+ATTR &quot;Category&quot;
+ATTR &quot;Id&quot; 
+
+
+CHAPTER &quot;Details (Simulation)&quot;
+
+ATTR &quot;Transition condition&quot; dialog:transcond
+
+ATTR &quot;Transition probability&quot;
+
+</aTTRIBUTE>
+<aTTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;Non-exclusive Gateway&quot;</aTTRIBUTE>
+<aTTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Start Event&quot;</aTTRIBUTE>
+<aTTRIBUTE name="ModelTypeExp" type="EXPRESSION">EXPR val:&quot;Business process diagram (BPMN 2.0)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16405" class="Is inside">
+<fROM instance="Send Instance to Third Party" class="Task"></fROM>
+<tO instance="Monti Azzurri Consorsium" class="Pool"></tO>
+<aTTRIBUTE name="AutoConnect" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16406" class="Is inside">
+<fROM instance="Send Instance to Third Party" class="Task"></fROM>
+<tO instance="SUAP Office" class="Lane"></tO>
+<aTTRIBUTE name="AutoConnect" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16407" class="Message Flow">
+<fROM instance="Send Instance to Third Party" class="Task"></fROM>
+<tO instance="Third Party PA" class="Pool (collapsed)"></tO>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 0 index:20</aTTRIBUTE>
+<aTTRIBUTE name="Message Name" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="ParticipantType (from)" type="ENUMERATION">Role</aTTRIBUTE>
+<aTTRIBUTE name="Role (from)" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Entity (from)" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="ParticipantType (to)" type="ENUMERATION">Role</aTTRIBUTE>
+<aTTRIBUTE name="Role (to)" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Entity (to)" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Name" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Message Properties" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;Pool (collapsed)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Task&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Number" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Show Name" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Show Number" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Representation" type="ENUMERATION">above/below</aTTRIBUTE>
+<aTTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Description" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Show name" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Doku" type="STRING">NOTEBOOK
+
+#-----------------------
+CHAPTER &quot;Description&quot;
+#-----------------------
+ATTR &quot;Name&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+ATTR &quot;Id&quot; </aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16407&quot;</aTTRIBUTE>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16408" class="Subsequent">
+<fROM instance="Send Instance to Third Party" class="Task"></fROM>
+<tO instance="Receive check of 3rd Party" class="Task"></tO>
+<aTTRIBUTE name="Transition condition" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Transition probability" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualized values" type="ENUMERATION">Denomination</aTTRIBUTE>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 0 index:26</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">8</aTTRIBUTE>
+<aTTRIBUTE name="Representation" type="ENUMERATION">above/below</aTTRIBUTE>
+<aTTRIBUTE name="Font colour" type="ENUMERATION">black</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Info zur Übergangsbedingung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Nachfolger</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Denomination" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Description" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Auditing" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Monitoring" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Default" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Immediate" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Category" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16408&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Color" type="STRING">black</aTTRIBUTE>
+<aTTRIBUTE name="Doku" type="STRING">NOTEBOOK
+
+#-----------------------
+LANG &quot;en&quot;
+#-----------------------
+CHAPTER &quot;Description&quot;
+ATTR &quot;Denomination&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+
+
+CHAPTER &quot;Details (BPMN)&quot;
+
+ATTR &quot;Auditing&quot; 
+ATTR &quot;Monitoring&quot; 
+
+ATTR &quot;Default&quot; 
+ATTR &quot;Immediate&quot; 
+ATTR &quot;Category&quot;
+ATTR &quot;Id&quot; 
+
+
+CHAPTER &quot;Details (Simulation)&quot;
+
+ATTR &quot;Transition condition&quot; dialog:transcond
+
+ATTR &quot;Transition probability&quot;
+
+</aTTRIBUTE>
+<aTTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;Task&quot;</aTTRIBUTE>
+<aTTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Task&quot;</aTTRIBUTE>
+<aTTRIBUTE name="ModelTypeExp" type="EXPRESSION">EXPR val:&quot;Business process diagram (BPMN 2.0)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16409" class="Is inside">
+<fROM instance="Receive check of 3rd Party" class="Task"></fROM>
+<tO instance="Monti Azzurri Consorsium" class="Pool"></tO>
+<aTTRIBUTE name="AutoConnect" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16410" class="Is inside">
+<fROM instance="Receive check of 3rd Party" class="Task"></fROM>
+<tO instance="SUAP Office" class="Lane"></tO>
+<aTTRIBUTE name="AutoConnect" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16411" class="Subsequent">
+<fROM instance="Receive check of 3rd Party" class="Task"></fROM>
+<tO instance="End Event-83205" class="End Event"></tO>
+<aTTRIBUTE name="Transition condition" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Transition probability" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualized values" type="ENUMERATION">Denomination</aTTRIBUTE>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 0 index:30</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">9</aTTRIBUTE>
+<aTTRIBUTE name="Representation" type="ENUMERATION">above/below</aTTRIBUTE>
+<aTTRIBUTE name="Font colour" type="ENUMERATION">black</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Info zur Übergangsbedingung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Nachfolger</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Denomination" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Description" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Auditing" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Monitoring" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Default" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Immediate" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Category" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16411&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Color" type="STRING">black</aTTRIBUTE>
+<aTTRIBUTE name="Doku" type="STRING">NOTEBOOK
+
+#-----------------------
+LANG &quot;en&quot;
+#-----------------------
+CHAPTER &quot;Description&quot;
+ATTR &quot;Denomination&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+
+
+CHAPTER &quot;Details (BPMN)&quot;
+
+ATTR &quot;Auditing&quot; 
+ATTR &quot;Monitoring&quot; 
+
+ATTR &quot;Default&quot; 
+ATTR &quot;Immediate&quot; 
+ATTR &quot;Category&quot;
+ATTR &quot;Id&quot; 
+
+
+CHAPTER &quot;Details (Simulation)&quot;
+
+ATTR &quot;Transition condition&quot; dialog:transcond
+
+ATTR &quot;Transition probability&quot;
+
+</aTTRIBUTE>
+<aTTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;End Event&quot;</aTTRIBUTE>
+<aTTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Task&quot;</aTTRIBUTE>
+<aTTRIBUTE name="ModelTypeExp" type="EXPRESSION">EXPR val:&quot;Business process diagram (BPMN 2.0)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16412" class="Is inside">
+<fROM instance="Do Check" class="Task"></fROM>
+<tO instance="Monti Azzurri Consorsium" class="Pool"></tO>
+<aTTRIBUTE name="AutoConnect" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16413" class="Is inside">
+<fROM instance="Do Check" class="Task"></fROM>
+<tO instance="Agriculture Office" class="Lane"></tO>
+<aTTRIBUTE name="AutoConnect" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16414" class="Subsequent">
+<fROM instance="Do Check" class="Task"></fROM>
+<tO instance="End Event-83205" class="End Event"></tO>
+<aTTRIBUTE name="Transition condition" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Transition probability" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualized values" type="ENUMERATION">Denomination</aTTRIBUTE>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 1 x1:36.5cm y1:16.5cm index:24</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">6</aTTRIBUTE>
+<aTTRIBUTE name="Representation" type="ENUMERATION">above/below</aTTRIBUTE>
+<aTTRIBUTE name="Font colour" type="ENUMERATION">black</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Info zur Übergangsbedingung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Nachfolger</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Denomination" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Description" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Auditing" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Monitoring" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Default" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Immediate" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Category" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16414&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Color" type="STRING">black</aTTRIBUTE>
+<aTTRIBUTE name="Doku" type="STRING">NOTEBOOK
+
+#-----------------------
+LANG &quot;en&quot;
+#-----------------------
+CHAPTER &quot;Description&quot;
+ATTR &quot;Denomination&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+
+
+CHAPTER &quot;Details (BPMN)&quot;
+
+ATTR &quot;Auditing&quot; 
+ATTR &quot;Monitoring&quot; 
+
+ATTR &quot;Default&quot; 
+ATTR &quot;Immediate&quot; 
+ATTR &quot;Category&quot;
+ATTR &quot;Id&quot; 
+
+
+CHAPTER &quot;Details (Simulation)&quot;
+
+ATTR &quot;Transition condition&quot; dialog:transcond
+
+ATTR &quot;Transition probability&quot;
+
+</aTTRIBUTE>
+<aTTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;End Event&quot;</aTTRIBUTE>
+<aTTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Task&quot;</aTTRIBUTE>
+<aTTRIBUTE name="ModelTypeExp" type="EXPRESSION">EXPR val:&quot;Business process diagram (BPMN 2.0)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16415" class="Is inside">
+<fROM instance="is check necessary?" class="Exclusive Gateway"></fROM>
+<tO instance="Monti Azzurri Consorsium" class="Pool"></tO>
+<aTTRIBUTE name="AutoConnect" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16416" class="Subsequent">
+<fROM instance="is check necessary?" class="Exclusive Gateway"></fROM>
+<tO instance="Do Check" class="Task"></tO>
+<aTTRIBUTE name="Transition condition" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Transition probability" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualized values" type="ENUMERATION">Denomination</aTTRIBUTE>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 0 index:12</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">1</aTTRIBUTE>
+<aTTRIBUTE name="Representation" type="ENUMERATION">above/below</aTTRIBUTE>
+<aTTRIBUTE name="Font colour" type="ENUMERATION">black</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Info zur Übergangsbedingung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Nachfolger</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Denomination" type="STRING">yes</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Auditing" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Monitoring" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Default" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Immediate" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Category" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16416&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Color" type="STRING">black</aTTRIBUTE>
+<aTTRIBUTE name="Doku" type="STRING">NOTEBOOK
+
+#-----------------------
+LANG &quot;en&quot;
+#-----------------------
+CHAPTER &quot;Description&quot;
+ATTR &quot;Denomination&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+
+
+CHAPTER &quot;Details (BPMN)&quot;
+
+ATTR &quot;Auditing&quot; 
+ATTR &quot;Monitoring&quot; 
+
+ATTR &quot;Default&quot; 
+ATTR &quot;Immediate&quot; 
+ATTR &quot;Category&quot;
+ATTR &quot;Id&quot; 
+
+
+CHAPTER &quot;Details (Simulation)&quot;
+
+ATTR &quot;Transition condition&quot; dialog:transcond
+
+ATTR &quot;Transition probability&quot;
+
+</aTTRIBUTE>
+<aTTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;Task&quot;</aTTRIBUTE>
+<aTTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Exclusive Gateway&quot;</aTTRIBUTE>
+<aTTRIBUTE name="ModelTypeExp" type="EXPRESSION">EXPR val:&quot;Business process diagram (BPMN 2.0)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16417" class="Is inside">
+<fROM instance="is check necessary?" class="Exclusive Gateway"></fROM>
+<tO instance="Agriculture Office" class="Lane"></tO>
+<aTTRIBUTE name="AutoConnect" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16418" class="Subsequent">
+<fROM instance="is check necessary?" class="Exclusive Gateway"></fROM>
+<tO instance="End Event-83205" class="End Event"></tO>
+<aTTRIBUTE name="Transition condition" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Transition probability" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualized values" type="ENUMERATION">Denomination</aTTRIBUTE>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 2 x1:14cm y1:18.5cm x2:36.5cm y2:18.5cm index:25</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">7</aTTRIBUTE>
+<aTTRIBUTE name="Representation" type="ENUMERATION">above/below</aTTRIBUTE>
+<aTTRIBUTE name="Font colour" type="ENUMERATION">black</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Info zur Übergangsbedingung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Nachfolger</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Denomination" type="STRING">no</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Auditing" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Monitoring" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Default" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Immediate" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Category" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16418&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Color" type="STRING">black</aTTRIBUTE>
+<aTTRIBUTE name="Doku" type="STRING">NOTEBOOK
+
+#-----------------------
+LANG &quot;en&quot;
+#-----------------------
+CHAPTER &quot;Description&quot;
+ATTR &quot;Denomination&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+
+
+CHAPTER &quot;Details (BPMN)&quot;
+
+ATTR &quot;Auditing&quot; 
+ATTR &quot;Monitoring&quot; 
+
+ATTR &quot;Default&quot; 
+ATTR &quot;Immediate&quot; 
+ATTR &quot;Category&quot;
+ATTR &quot;Id&quot; 
+
+
+CHAPTER &quot;Details (Simulation)&quot;
+
+ATTR &quot;Transition condition&quot; dialog:transcond
+
+ATTR &quot;Transition probability&quot;
+
+</aTTRIBUTE>
+<aTTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;End Event&quot;</aTTRIBUTE>
+<aTTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Exclusive Gateway&quot;</aTTRIBUTE>
+<aTTRIBUTE name="ModelTypeExp" type="EXPRESSION">EXPR val:&quot;Business process diagram (BPMN 2.0)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16419" class="Is inside">
+<fROM instance="Instance SCIA (update)" class="Data Object"></fROM>
+<tO instance="Monti Azzurri Consorsium" class="Pool"></tO>
+<aTTRIBUTE name="AutoConnect" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16420" class="Is inside">
+<fROM instance="Instance SCIA (update)" class="Data Object"></fROM>
+<tO instance="SUAP Office" class="Lane"></tO>
+<aTTRIBUTE name="AutoConnect" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16421" class="Data Association">
+<fROM instance="Instance SCIA (update)" class="Data Object"></fROM>
+<tO instance="Send Instance to Third Party" class="Task"></tO>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 0 index:14</aTTRIBUTE>
+<aTTRIBUTE name="Name" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Representation" type="ENUMERATION">above/below</aTTRIBUTE>
+<aTTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Show name" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Doku" type="STRING">#-----------------------
+CHAPTER &quot;Description&quot;
+#-----------------------
+ATTR &quot;Name&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+ATTR &quot;Id&quot; </aTTRIBUTE>
+<aTTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Data Object&quot;</aTTRIBUTE>
+<aTTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;Task&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16421&quot;</aTTRIBUTE>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16422" class="Data Association">
+<fROM instance="Instance SCIA (update)" class="Data Object"></fROM>
+<tO instance="Do Check" class="Task"></tO>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 0 index:15</aTTRIBUTE>
+<aTTRIBUTE name="Name" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Representation" type="ENUMERATION">above/below</aTTRIBUTE>
+<aTTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Show name" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Doku" type="STRING">#-----------------------
+CHAPTER &quot;Description&quot;
+#-----------------------
+ATTR &quot;Name&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+ATTR &quot;Id&quot; </aTTRIBUTE>
+<aTTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Data Object&quot;</aTTRIBUTE>
+<aTTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;Task&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16422&quot;</aTTRIBUTE>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16423" class="Data Association">
+<fROM instance="Instance SCIA (update)" class="Data Object"></fROM>
+<tO instance="Check Involvement" class="Task"></tO>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 0 index:31</aTTRIBUTE>
+<aTTRIBUTE name="Name" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Representation" type="ENUMERATION">above/below</aTTRIBUTE>
+<aTTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Show name" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Doku" type="STRING">#-----------------------
+CHAPTER &quot;Description&quot;
+#-----------------------
+ATTR &quot;Name&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+ATTR &quot;Id&quot; </aTTRIBUTE>
+<aTTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Data Object&quot;</aTTRIBUTE>
+<aTTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;Task&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16423&quot;</aTTRIBUTE>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16424" class="Is inside">
+<fROM instance="Non-exclusive Gateway-83191" class="Non-exclusive Gateway"></fROM>
+<tO instance="Monti Azzurri Consorsium" class="Pool"></tO>
+<aTTRIBUTE name="AutoConnect" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16425" class="Is inside">
+<fROM instance="Non-exclusive Gateway-83191" class="Non-exclusive Gateway"></fROM>
+<tO instance="SUAP Office" class="Lane"></tO>
+<aTTRIBUTE name="AutoConnect" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16426" class="Subsequent">
+<fROM instance="Non-exclusive Gateway-83191" class="Non-exclusive Gateway"></fROM>
+<tO instance="Send Instance to Third Party" class="Task"></tO>
+<aTTRIBUTE name="Transition condition" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Transition probability" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualized values" type="ENUMERATION">Denomination</aTTRIBUTE>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 0 index:18</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">3</aTTRIBUTE>
+<aTTRIBUTE name="Representation" type="ENUMERATION">above/below</aTTRIBUTE>
+<aTTRIBUTE name="Font colour" type="ENUMERATION">black</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Info zur Übergangsbedingung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Nachfolger</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Denomination" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Description" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Auditing" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Monitoring" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Default" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Immediate" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Category" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16426&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Color" type="STRING">black</aTTRIBUTE>
+<aTTRIBUTE name="Doku" type="STRING">NOTEBOOK
+
+#-----------------------
+LANG &quot;en&quot;
+#-----------------------
+CHAPTER &quot;Description&quot;
+ATTR &quot;Denomination&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+
+
+CHAPTER &quot;Details (BPMN)&quot;
+
+ATTR &quot;Auditing&quot; 
+ATTR &quot;Monitoring&quot; 
+
+ATTR &quot;Default&quot; 
+ATTR &quot;Immediate&quot; 
+ATTR &quot;Category&quot;
+ATTR &quot;Id&quot; 
+
+
+CHAPTER &quot;Details (Simulation)&quot;
+
+ATTR &quot;Transition condition&quot; dialog:transcond
+
+ATTR &quot;Transition probability&quot;
+
+</aTTRIBUTE>
+<aTTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;Task&quot;</aTTRIBUTE>
+<aTTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Non-exclusive Gateway&quot;</aTTRIBUTE>
+<aTTRIBUTE name="ModelTypeExp" type="EXPRESSION">EXPR val:&quot;Business process diagram (BPMN 2.0)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16427" class="Subsequent">
+<fROM instance="Non-exclusive Gateway-83191" class="Non-exclusive Gateway"></fROM>
+<tO instance="Check Involvement" class="Task"></tO>
+<aTTRIBUTE name="Transition condition" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Transition probability" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualized values" type="ENUMERATION">Denomination</aTTRIBUTE>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 0 index:28</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">10</aTTRIBUTE>
+<aTTRIBUTE name="Representation" type="ENUMERATION">above/below</aTTRIBUTE>
+<aTTRIBUTE name="Font colour" type="ENUMERATION">black</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Info zur Übergangsbedingung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Nachfolger</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Denomination" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Description" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Auditing" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Monitoring" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Default" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Immediate" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Category" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16427&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Color" type="STRING">black</aTTRIBUTE>
+<aTTRIBUTE name="Doku" type="STRING">NOTEBOOK
+
+#-----------------------
+LANG &quot;en&quot;
+#-----------------------
+CHAPTER &quot;Description&quot;
+ATTR &quot;Denomination&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+
+
+CHAPTER &quot;Details (BPMN)&quot;
+
+ATTR &quot;Auditing&quot; 
+ATTR &quot;Monitoring&quot; 
+
+ATTR &quot;Default&quot; 
+ATTR &quot;Immediate&quot; 
+ATTR &quot;Category&quot;
+ATTR &quot;Id&quot; 
+
+
+CHAPTER &quot;Details (Simulation)&quot;
+
+ATTR &quot;Transition condition&quot; dialog:transcond
+
+ATTR &quot;Transition probability&quot;
+
+</aTTRIBUTE>
+<aTTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;Task&quot;</aTTRIBUTE>
+<aTTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Non-exclusive Gateway&quot;</aTTRIBUTE>
+<aTTRIBUTE name="ModelTypeExp" type="EXPRESSION">EXPR val:&quot;Business process diagram (BPMN 2.0)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16428" class="Is inside">
+<fROM instance="End Event-83205" class="End Event"></fROM>
+<tO instance="Monti Azzurri Consorsium" class="Pool"></tO>
+<aTTRIBUTE name="AutoConnect" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16429" class="Is inside">
+<fROM instance="End Event-83205" class="End Event"></fROM>
+<tO instance="SUAP Office" class="Lane"></tO>
+<aTTRIBUTE name="AutoConnect" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16430" class="Is inside">
+<fROM instance="3rd Party Opinion" class="Data Object"></fROM>
+<tO instance="Monti Azzurri Consorsium" class="Pool"></tO>
+<aTTRIBUTE name="AutoConnect" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16431" class="Is inside">
+<fROM instance="3rd Party Opinion" class="Data Object"></fROM>
+<tO instance="SUAP Office" class="Lane"></tO>
+<aTTRIBUTE name="AutoConnect" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16432" class="Data Association">
+<fROM instance="3rd Party Opinion" class="Data Object"></fROM>
+<tO instance="Receive check of 3rd Party" class="Task"></tO>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 0 index:23</aTTRIBUTE>
+<aTTRIBUTE name="Name" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Representation" type="ENUMERATION">above/below</aTTRIBUTE>
+<aTTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Show name" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Doku" type="STRING">#-----------------------
+CHAPTER &quot;Description&quot;
+#-----------------------
+ATTR &quot;Name&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+ATTR &quot;Id&quot; </aTTRIBUTE>
+<aTTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Data Object&quot;</aTTRIBUTE>
+<aTTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;Task&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16432&quot;</aTTRIBUTE>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16433" class="Is inside">
+<fROM instance="Check Involvement" class="Task"></fROM>
+<tO instance="Monti Azzurri Consorsium" class="Pool"></tO>
+<aTTRIBUTE name="AutoConnect" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16434" class="Is inside">
+<fROM instance="Check Involvement" class="Task"></fROM>
+<tO instance="Agriculture Office" class="Lane"></tO>
+<aTTRIBUTE name="AutoConnect" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16435" class="Subsequent">
+<fROM instance="Check Involvement" class="Task"></fROM>
+<tO instance="is check necessary?" class="Exclusive Gateway"></tO>
+<aTTRIBUTE name="Transition condition" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Transition probability" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualized values" type="ENUMERATION">Denomination</aTTRIBUTE>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 0 index:29</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">11</aTTRIBUTE>
+<aTTRIBUTE name="Representation" type="ENUMERATION">above/below</aTTRIBUTE>
+<aTTRIBUTE name="Font colour" type="ENUMERATION">black</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Info zur Übergangsbedingung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Nachfolger</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Denomination" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Description" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Auditing" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Monitoring" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Default" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Immediate" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Category" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16435&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Color" type="STRING">black</aTTRIBUTE>
+<aTTRIBUTE name="Doku" type="STRING">NOTEBOOK
+
+#-----------------------
+LANG &quot;en&quot;
+#-----------------------
+CHAPTER &quot;Description&quot;
+ATTR &quot;Denomination&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+
+
+CHAPTER &quot;Details (BPMN)&quot;
+
+ATTR &quot;Auditing&quot; 
+ATTR &quot;Monitoring&quot; 
+
+ATTR &quot;Default&quot; 
+ATTR &quot;Immediate&quot; 
+ATTR &quot;Category&quot;
+ATTR &quot;Id&quot; 
+
+
+CHAPTER &quot;Details (Simulation)&quot;
+
+ATTR &quot;Transition condition&quot; dialog:transcond
+
+ATTR &quot;Transition probability&quot;
+
+</aTTRIBUTE>
+<aTTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;Exclusive Gateway&quot;</aTTRIBUTE>
+<aTTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Task&quot;</aTTRIBUTE>
+<aTTRIBUTE name="ModelTypeExp" type="EXPRESSION">EXPR val:&quot;Business process diagram (BPMN 2.0)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+</mODEL>
+<mODEL id="mod.16231" name="TitoloUnico_MontiAzzurrSUB" version="" modeltype="Business process diagram (BPMN 2.0)" libtype="bp" applib="LearnPAd Prototype Dynamic Library 0.21">
+<mODELATTRIBUTES>
+<aTTRIBUTE name="Contact person" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Keywords" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Copyright info" type="STRING">Edit the model attributes to display your copyright info</aTTRIBUTE>
+<aTTRIBUTE name="Copyright info position" type="ENUMERATION">Bottom right</aTTRIBUTE>
+<aTTRIBUTE name="Name" type="STRING">TitoloUnico_MontiAzzurrSUB</aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;86405&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Process type" type="ENUMERATION">None</aTTRIBUTE>
+<aTTRIBUTE name="Executable" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Closed" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Auditing" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Monitoring" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Model type" type="ENUMERATION">Current model</aTTRIBUTE>
+<aTTRIBUTE name="State" type="ENUMERATION">In process</aTTRIBUTE>
+<aTTRIBUTE name="Reviewed on" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Reviewed by" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Author" type="STRING">barbara</aTTRIBUTE>
+<aTTRIBUTE name="Creation date" type="STRING">11.08.2015, 14:04</aTTRIBUTE>
+<aTTRIBUTE name="Last user" type="STRING">barbara</aTTRIBUTE>
+<aTTRIBUTE name="Date last changed" type="STRING">20.08.2015, 15:51:40</aTTRIBUTE>
+<aTTRIBUTE name="Number of objects and relations" type="INTEGER">77</aTTRIBUTE>
+<aTTRIBUTE name="Context of version" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Action" type="ENUMERATION">Fill in</aTTRIBUTE>
+<aTTRIBUTE name="People-like view" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="BAR Display active" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Modelling direction" type="ENUMERATION">vertical</aTTRIBUTE>
+<aTTRIBUTE name="Modelling_size" type="ENUMERATION">3</aTTRIBUTE>
+<aTTRIBUTE name="Responsible for execution_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Responsible for execution_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="Responsible for execution_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="Accountable for approving results_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Accountable for approving results_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="Accountable for approving results_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="Cooperation/participation_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Cooperation/participation_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="Cooperation/participation_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="To inform_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="To inform_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="To inform_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="Knowledge Product_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Knowledge Product_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="Knowledge Product_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="Documents and Resources_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Documents and Resources_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="Documents and Resources_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="Incoming Data Object_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Incoming Data Object_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="Incoming Data Object_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="Outgoing Data Object_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Outgoing Data Object_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="Outgoing Data Object_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="Description_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Description_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="Description_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="Comment Mode" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="CommentAreaSize" type="ENUMERATION">2</aTTRIBUTE>
+<aTTRIBUTE name="CommentModellingAreaSize" type="ENUMERATION">3</aTTRIBUTE>
+<aTTRIBUTE name="CommentModellingDirection" type="ENUMERATION">vertical</aTTRIBUTE>
+<rECORD name="Change history"></rECORD>
+<aTTRIBUTE name="Position" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-01] Internal error!  \&quot;fontcolor\&quot; (BPModel)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<rECORD name="Technical Attributes"></rECORD>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Keine Modellbezeichnung vergeben</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Pool Term" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="ParticipantType" type="ENUMERATION">Role</aTTRIBUTE>
+<aTTRIBUTE name="Role" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Entity" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="BoundaryVisible" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="BPD Model Attributes" type="STRING">NOTEBOOK
+
+CHAPTER &quot;Business Process Diagram Attributes&quot;
+ATTR &quot;Name&quot; write-protected
+ATTR &quot;Contact person&quot;
+ATTR &quot;Author&quot; write-protected
+ATTR &quot;Language (BPMN)&quot;
+ATTR &quot;ExpressionLanguage&quot;
+ATTR &quot;QueryLanguage&quot;
+ATTR &quot;Creation date&quot; write-protected
+ATTR &quot;Date last changed&quot; write-protected
+ATTR &quot;Documentation (Model)&quot;
+ATTR &quot;State&quot;
+
+GROUP &quot;Copyright&quot;
+ATTR &quot;Copyright info&quot; 
+ATTR &quot;Copyright info position&quot; 
+ENDGROUP
+
+CHAPTER &quot;Process Attributes&quot;
+ATTR &quot;Name&quot; write-protected
+ATTR &quot;Process Term&quot;
+ATTR &quot;ProcessType&quot;
+ATTR &quot;Status&quot;
+ATTR &quot;Assignments&quot; lines:5
+ATTR &quot;Properties (BPMN)&quot; lines:5
+ATTR &quot;AdHoc&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+GROUP &quot;AdHoc = True&quot;
+ATTR &quot;AdHocOrdering&quot;
+ATTR &quot;AdHocCompletionCondition&quot;
+ENDGROUP
+ATTR &quot;SuppressJoinFailure&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ATTR &quot;EnableInstanceCompensation&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ATTR &quot;Categories (Process)&quot;
+ATTR &quot;Documentation (Process)&quot;
+
+CHAPTER &quot;Pool Attributes&quot;
+GROUP &quot;Common Graphical Object Attributes&quot;
+ATTR &quot;Name&quot; write-protected
+ATTR &quot;Categories (Pool)&quot;
+ATTR &quot;Documentation (Pool)&quot;
+ENDGROUP
+GROUP &quot;Common Swimlane Attributes&quot;
+ATTR &quot;Pool Term&quot;
+ENDGROUP
+GROUP &quot;Pool Attributes&quot;
+ATTR &quot;ParticipantType&quot;
+ATTR &quot;Role&quot;
+ATTR &quot;Entity&quot;
+ATTR &quot;BoundaryVisible&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot; write-protected
+ENDGROUP</aTTRIBUTE>
+<aTTRIBUTE name="Language" type="ENUMERATION">System</aTTRIBUTE>
+<aTTRIBUTE name="ExpressionLanguage" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="QueryLanguage" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Process Term" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="BPD Term" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="ProcessType" type="ENUMERATION">None</aTTRIBUTE>
+<aTTRIBUTE name="Status" type="ENUMERATION">None</aTTRIBUTE>
+<rECORD name="Assignments"></rECORD>
+<aTTRIBUTE name="AdHoc" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="AdHocOrdering" type="ENUMERATION">None</aTTRIBUTE>
+<aTTRIBUTE name="AdHocCompletionCondition" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="EnableInstanceCompensation" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Categories (Process)" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation (Process)" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation (Pool)" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Categories (Pool)" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="SuppressJoinFailure" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="RACI/DEMI visualisation" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="IT systems" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Responsible role" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Input/Output" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Products" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Use cases" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Products color" type="STRING">whitesmoke</aTTRIBUTE>
+<aTTRIBUTE name="RACI/DEMI color" type="STRING">whitesmoke</aTTRIBUTE>
+<aTTRIBUTE name="Responsible role color" type="STRING">whitesmoke</aTTRIBUTE>
+<aTTRIBUTE name="Input/Output color" type="STRING">whitesmoke</aTTRIBUTE>
+<aTTRIBUTE name="Use cases color" type="STRING">whitesmoke</aTTRIBUTE>
+<aTTRIBUTE name="IT systems color" type="STRING">whitesmoke</aTTRIBUTE>
+<aTTRIBUTE name="_ToggleModelInfo_" type="PROGRAMCALL">ITEM &quot;_ToggleModelInfo_&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Display modelling information" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Documentation (Model)" type="STRING"></aTTRIBUTE>
+<rECORD name="Properties (BPMN)"></rECORD>
+<aTTRIBUTE name="CreationDate" type="EXPRESSION">EXPR val:&quot;11.08.2015, 14:04&quot;</aTTRIBUTE>
+<aTTRIBUTE name="ModificationDate" type="EXPRESSION">EXPR val:&quot;20.08.2015, 15:51:40&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Language (BPMN)" type="STRING">English</aTTRIBUTE>
+<aTTRIBUTE name="BPMN20 Model Attributes" type="LONGSTRING">NOTEBOOK
+# TODO AVAL sMfbRegistration:&quot;_MFB-Registration_&quot;
+CHAPTER &quot;Description&quot;
+ATTR &quot;Contact person&quot;
+ATTR &quot;Keywords&quot; lines:2
+ATTR &quot;Description&quot; lines:3
+ATTR &quot;Comment&quot; lines:3
+
+GROUP &quot;Copyright&quot;
+ATTR &quot;Copyright info&quot; 
+ATTR &quot;Copyright info position&quot; 
+ENDGROUP
+ATTR &quot;Name&quot; write-protected
+ATTR &quot;Id&quot; write-protected
+
+
+
+#---------------------------------------------
+CHAPTER &quot;Process properties&quot;
+#---------------------------------------------
+GROUP &quot;Process attributes&quot;
+ATTR &quot;Process type&quot; #None, Private, Public 
+ATTR &quot;Executable&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ATTR &quot;Closed&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ENDGROUP
+
+GROUP &quot;Process relevance&quot;
+ATTR &quot;Auditing&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ATTR &quot;Monitoring&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ENDGROUP
+
+CHAPTER &quot;User attributes&quot;
+ATTR &quot;Model type&quot;
+ATTR &quot;State&quot;
+ATTR &quot;Reviewed on&quot;
+ATTR &quot;Reviewed by&quot;
+
+CHAPTER &quot;System attributes&quot;
+ATTR &quot;Author&quot; write-protected
+ATTR &quot;Creation date&quot; write-protected
+ATTR &quot;Last user&quot; write-protected
+# ATTR &quot;Date last changed from&quot; write-protected
+ATTR &quot;Date last changed&quot; write-protected
+ATTR &quot;Number of objects and relations&quot; write-protected
+ATTR &quot;Context of version&quot; write-protected
+
+CHAPTER &quot;People-like view&quot;
+ATTR &quot;Action&quot;
+ATTR &quot;People-like view&quot;
+
+CHAPTER &quot;BAR Display&quot;
+ATTR &quot;BAR Display active&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot;
+AVAL s_Aktiv: &quot;BAR Display active&quot;
+ATTR &quot;Modelling direction&quot; ctrltype: radio enabled: (s_Aktiv = &quot;Yes&quot;)
+ATTR &quot;Modelling_size&quot;
+
+GROUP &quot;Responsible for execution&quot;
+ATTR &quot;Responsible for execution_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_Responsible_for_execution_display: &quot;Responsible for execution_display&quot;
+ATTR &quot;Responsible for execution_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_Responsible_for_execution_display = &quot;Yes&quot;))
+ATTR &quot;Responsible for execution_size&quot;
+ENDGROUP
+
+GROUP &quot;Accountable for approving results&quot;
+ATTR &quot;Accountable for approving results_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_Accountableforapprovingresults_display: &quot;Actor_display&quot;
+ATTR &quot;Accountable for approving results_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_Accountableforapprovingresults_display = &quot;Yes&quot;))
+ATTR &quot;Accountable for approving results_size&quot;
+ENDGROUP
+
+GROUP &quot;Cooperation/participation&quot;
+ATTR &quot;Cooperation/participation_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_Cooperationparticipation_display: &quot;Cooperation/participation_display&quot;
+ATTR &quot;Cooperation/participation_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_Cooperationparticipation_display = &quot;Yes&quot;))
+ATTR &quot;Cooperation/participation_size&quot;
+ENDGROUP
+
+GROUP &quot;To inform&quot;
+ATTR &quot;To inform_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_Toinform_display: &quot;To inform_display&quot;
+ATTR &quot;To inform_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_Toinform_display = &quot;Yes&quot;))
+ATTR &quot;To inform_size&quot;
+ENDGROUP
+
+GROUP &quot;Knowledge Product&quot;
+ATTR &quot;Knowledge Product_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_KnowledgeProduct_display: &quot;Knowledge Product_display&quot;
+ATTR &quot;Knowledge Product_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_KnowledgeProduct_display = &quot;Yes&quot;))
+ATTR &quot;Knowledge Product_size&quot;
+ENDGROUP
+
+GROUP &quot;Documents and Resources&quot;
+ATTR &quot;Documents and Resources_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_DocumentsandResources_display: &quot;Documents and Resources_display&quot;
+ATTR &quot;Documents and Resources_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_DocumentsandResources_display = &quot;Yes&quot;))
+ATTR &quot;Documents and Resources_size&quot;
+ENDGROUP
+
+GROUP &quot;Incoming Data Object&quot;
+ATTR &quot;Incoming Data Object_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_IncomingDataObject_display: &quot;Incoming Data Object_display&quot;
+ATTR &quot;Incoming Data Object_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_IncomingDataObject_display = &quot;Yes&quot;))
+ATTR &quot;Incoming Data Object_size&quot;
+ENDGROUP
+
+GROUP &quot;Outgoing Data Object&quot;
+ATTR &quot;Outgoing Data Object_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_OutgoingDataObject_display: &quot;Outgoing Data Object_display&quot;
+ATTR &quot;Outgoing Data Object_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_OutgoingDataObject_display = &quot;Yes&quot;))
+ATTR &quot;Outgoing Data Object_size&quot;
+ENDGROUP
+
+GROUP &quot;Description&quot;
+ATTR &quot;Description_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_Description_display: &quot;Description_display&quot;
+ATTR &quot;Description_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_Description_display = &quot;Yes&quot;))
+ATTR &quot;Description_size&quot;
+ENDGROUP
+
+CHAPTER &quot;Comment View&quot;
+ATTR &quot;Comment Mode&quot; ctrltype: check checked-value: &quot;No&quot; unchecked-value: &quot;Yes&quot;
+AVAL s_Aktiv: &quot;Comment Mode&quot;
+ATTR &quot;CommentAreaSize&quot;
+ATTR &quot;CommentModellingAreaSize&quot;
+ATTR &quot;CommentModellingDirection&quot;
+
+
+
+
+CHAPTER &quot;Change history&quot;
+ATTR &quot;Change history&quot; lines:30
+
+</aTTRIBUTE>
+<aTTRIBUTE name="_GoToAceHp_" type="PROGRAMCALL">ITEM &quot;_GoToAceHp_&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="__GfxThumb__" type="LONGSTRING">iVBORw0KGgoAAAANSUhEUgAAAQAAAADdCAIAAADbxzt0AAAACXBIWXMAAAsTAAALEwEAmpwYAAARJElEQVR4nO3df3AT14EH8O9mnH/auQ69y5T+0aS9QfK1hnYCgXS8DpPkDmgkG+Lc4RXtpHADZhlIiNTkKJermcDgaWJ+zMlJSkeCZkpmCpHsuWCD10ngepebWukQEujUqBnskqSZXkgn03/qGM7I++6PlYSsX5YleVf2+37+SISs1Xu23vftPr3dfcrHH3989f2r586eA1BXV3f77bc/0vrIHz76A+adsbGxGzduaJrmdEWohtSdP38+Ho+vX78+/dRbv37r+xs2FNnm/MWL9y5dOvt1q6bzFy+OjY05XQuqPX19fS+99NKJEydOnjx58uTJEydOGIYhJuIj8Xiwsd2YiAcbAQCNjSoAwJiYiMfjYiIebITe368DQKM69TUWtbExGO/XATS26+3temOj3t9v9MeNdgBQD8fFxIRIvn/qHQDAKrRRbW/XU0+qhw9bRSc3aW/XGxuD8X4Aen882N6eKm7CONyuN7YbE3EVMCb6AQTjE2JiIh6P9/X1RSIRQZRB6evrW7p06aVLlxRFue222wDU19e7vvrVIpn56Nq1O7/85UqTZ6+Prl27ePEiD4EoiyKEiEajTlfDPgwAZVKEEE7XgcgxdU5XgMhJdeFw2Ok6EFXfggULSjncrQOg6/rs14fIPqV36zwEIqkxACQ1BoCkxgCQ1BgAkhoDMEtGBwdHcOXUKbTuasZBd2eDoQH1cW8ngggHEDQ66t0ej8vpakqPAZglLo/HBY/HAwAICU/yaeEBEPI7Vi3KwgCQ1BgAkhoDQFJjAEhqDABJjQGgmqAozlyaUoeZnDpXtm3btoVCodkuheY0R87Mr9N13Z5LIhcsWGBDKTQX+Xw+ONRCeEkkOU9RFACONEUGgKRm0yDYqSEOzRVODoKJpMWOmaTGPQBJjWMAqgkcAxA5gB0zSY17AJIaxwBUEzgGIHIAO2aSGvcAJDWOAagmcAxA5AB2zCQ17gFIahwDUE1wbAxg25XIXIyMiqtWCylxdTDLDNYIC4fDZa8mxmXIqLhqtZCZpohjAJIaxwBUEzgPQOQAmwIwh7p/6x41ZL+y//KRSKT0UW8W7gHyiEQiTleBSmXdVa5sHAPkV3aPUhtGu7dtioYBXTse8s/vhcjmRgDIXi5/aMg/p25GPM8HwXOr+yd5cA8wH9TCwL2SkSic6yI5BpgnnB24V3gg7iDuAeaPcjvg0e4mdyCmGyLkmf7F+VUeAI4ByCku/5CQdulu7gGoOqydgCNfH1dSNMcAdlNW95T+4shWUcrnKoSYdp2r2Sh3yiYlD0Ly12RVNO/z4mxbFYvOxT2ArZTVPeNGW8JEYhIJEwkTNzMep5+/mXq8akcPEJ22Lfb2Lgaesb/ctJ6eBtMsqQ/+hx2/+M8f3WUKfPGv/+auRQ3T1kRZ3VMkA11dynPPARXseTgGsNMoLmiPDRrmw97jUJffG7twHlihLn07dhEA8K29wUV7oyPL8MAh7cW/D2x7vaQ/Wm/v4nXrOvr790WjxdpB6a0/Yc7st+rtXbxu3d7+/r3FK2AZPrP/udG7hBCffvpn4813KqlJV5fy1FOXgM+EGOvqUnbvLqeNcQ9gJxeWRw+v8iT+Ip4t1Ao3+a3HLe/5Eyamncy1Wr8Q4y0t28+c2dfbu880n8nbChOToz950L3nPABghe77Bh7csevq45sm/73j6krvq8DiZer9XdqR1YGtr82gJVmtX4jxtWt3nj5drAKWb3j37P7u306a+MKCL1p/gV8+qWx9Wb17eezSBT34YWi5OSWrhWS2fiHGAoGXy8sAxwBVUPo8VCQSSfXBo8f8B6/Eh80nOx4w3ZOD7id+kXxN8zGx877Ux39O850r+CVjJBJpbe0QYlyI68B4c3ObEOOf/7wv7+vPnolsOSs2Tk3dileHEiZuvi/8qee9cX/CxFHA58v/PjkV2CvEOHBdiPHm5u8B45/7XLENI5HIt+5RM/dC6gHxm+fy9P3pAOT980YikXTrF+IzYKx4VQvhHqA6io/DfD5f+gWpz9716KHQrb5/pfhVZ/Znn5gEVkUjW/N0HOk37O/vbGnZDowLMS7EuGEMZNUks+hpjzdulVvyb9Tfv3ft2p3pEA4MnCq0YXqTZP7XuPe/rf7rr4+bj7sPXFAf+bk2+XzcxPBdqb1Q81eSNckc4mf+OpmtX4jPitS2CI4BqkbTlhWaUdI0LRqNapqmrO75cE1JrbD/twsBbN4C4IXcI4r0G/b27sts/ab5TLImqbNBR4R4Nxr1HVU+7GkrsfUb8YWbt+B1Ez/b8EnhX/ZWBTJbf6oCVoWnnJQqNC1q1WQNEpOuRwfEBqvEV8U/WTVZOWUvlJjETfNWcVnlAujqUgKBl63W3929i2MAxxWbUUp/hNmt8I/xb3dctn702ott6db/45Zz/3ZmFYDXzZ0a8hxSW2+4fv3l3t7FXm9zRuvXAGSeDerSNN/RntzW/+0tPVnlWq0/XfSWVxYWz0C6As3NrTmtH7knpWpTajJ6vMV94AJwj4p3Yov3BL+2PzAAfW88dHeq9ecdA6Tff/du0dWlpB8XqmdxdgTAwXXAa1B2H7ywAbgszrYpq3uyWv+eh6L7X9MwXUO0mmBO45uuXBMAMsu1Wj+A0oueUQVyauLypft+Ew8sUg6/J7ananIzYwxQxO7dQlEUzgPMGVaDy33eerLliR4Am7ckm2DCvLFrVejguW353mlwm9LZMNIRd3vDUHXj0P8FAksHdiiKEhwRuZfAlFIukkdcmL7opiu7huoPKt4woKqIxQDoT0eubV7m7W5qii4BwoghZgiRe3JRoZoAeOjxMifCKmFHAIQQpXxPUuFUZbVmOkuZVa1kE3G2rfiLXzcBIGHeSJjXD57b9vj9z7745tM5r/KErNYlRPIQw+MB4C98Us+05c6g6CEPgFC66Az+oSE/UPzr29w2nTxGKLet1/qpENaBWvGvaZNTlZO3hmVFHiRMrHlsylRlhZtnmnZWtfJNin9UGrQtryx89o2N1j9ffPPpfAch1imcgKqqsZj1/yUdHcNeb0e+freUcksuOg/rOMSp60hr+hCoq0t56qmhJ58cm3a6btpWm3X8Wt3NLb29i9eu/eHp09PMqla4ybR+tuGTLa8sTD/O95ICA+6KB1olFF19JR4jFFGjp0JYff/hw02Zz2RmILPnuGmOHnnQvec8lq3Au28D0I98vOsrV0fWNXkDb45M/mDTL0Xs8kXs+524exJZ7wB88sKDyo9M/dGG4fjPgY1L3KJh44Hm/25xH3xH/eay2G+ht4jhO7u0n64JtBtTWkm6DlZTBq63tGwpMquaWeesTaqbgdKHd9XtgGdUdLXM8yvCAAQCR4LBHciZ2LNmHCORSMJ0bX5DfD+r877T9dYH4qaJRGRobcb0ITKmKq3/uiKRP35Hu2kicejW5tqr4h8ztrpp4qFhf8LEsakzndaDhx/+oTWjKcT15uZWIa4XmlVN1zlrk4GBamaAbGBfAKzWj8ITe4UOXW7me4DUkV/2TOcMN898h9OnD7S0bEnP6aDAwWVmiVmbWF8FOsLB0/GrYn5eEWZNVQQCR4T4TIix55/fZx3/5E7sKat7Plid3XxXbE5+sfPGT9qy2nF6cy01v/hBtK2MzTFlclHLmtNB5qRmapZXZExG5m4yFweCMpv1PcC003W3pkhzOm8A6qLFsd9fzu3Fs97Bd7Sn7M0z61B4TmfKoDPzRzOdBpo9c7f7x/weA5QyTV1ofiT2+8sAmndm/yjrFLEKN8+0fv3ljA6+JGVsQpaenikfjRAzvhKtQjU0E1zKTE2mrL9UWZuPDg4OnPIGwgBU3Tge8riS36/7fN26iobjWtQdzZnUHO1uckc1Q4t2RhGLxQAAqtrt88WgGmKo7HsryKytra2np0dRFJu7kjrgT4PbmjobtA7gVDyOhtbWelzp7IS2xF+PUbSOuHFlwO235Q6TFf7mM9/c5fH4PSLzfK3s79fzza2mXuP3SHszhapL7wpszkAd8KXk1DaQ7ro8nuRDF+ACUp/znwYHBzO2vQLUn/KeahUhDwa7uzsDgVjeE1HmqcFtinc4GFwSCIRV3Tje6nV78579QsVZfX9bW/I8iKyDotlmHQKNjo4ODBxEHPHhcHhJMNhQ34zOTfGOjl3AyBWcqkfI4wG+lA4GACsvnuQn7vH7PX65+kNPyBq3+ZM7EJ7uWrZ067efFQCXy5X6GEOpwwHPkPV/lwfs1Ypz9kwYqkQNDYKJ7McAkMNsPujPwgCQk9raZvblddUxAFSh0e4mN4BLyHfl8nQbxjsM+Hxh6IbYdeXWFQ5L/krT7Bl5MgAVGlUUNwCfz3cNeELGcbDLPyQCinJ3WRsCty5q8zhxk2oGoEIu62IOnos2RzEAVVD6rWGp1jAAlZqNSyLJNgxARWbvkkiyBwNQvnTrT18SWfy+sGUo5Q61ACKRSImvpCwMQPmsS2EyL4lMX6UJey/Rsr/EeYMBqFTufWGtayxh4yVa6cuUeQA2UwxARVL3pv2O9c/Ma53trwxbfxkYgEqtX3+Z8wBzFwNQNZJ3wHP0viwMAFXHHN0HMgBUNXOu+wcDYL/ZXrB6thVa5hoQuT+qwfpnYQBsVcXbuDui+ILbv1mZcQMys5wFt+3HANhpFBe0xwzDbPUeh3rPvbF3pi6U/c29wUV7o6PLYl/bYZxp9+qlLZRts0KtP+/Ce7WPAbCTC8ujh1Z7En8RPy50J+CNfuvB9t+JxCTCTtc4l7Xgdt8jRvN/dJ4GhIhdvABAf/6j1v+6s3NkWWz4XTQf0wfawzNacNspDEB1lH7STqrRjx4LHByJD5s/6LjfdE++5vanFsr2HhWP3ZfqQYsulO2IhOlKLri91fO9qX3/svc96cfb46FEyQtuO4gBqIJp1wjLdxd416MHQ7f6/pXif/bnu417gYWyHVTKkU/6edT816MMQHVMs+xX0bvAF1rEIOs27jWi9Nafu8x1DWIAbFLwLvD/G29MLZQ98EJb8du414ISF9wutMx1rWEAbFVklVzM8DbuTsnt+5FahyGr9TMAlEeFd4F3VvF1GNILbqfVYICzMAAOqKk2PVNzOsC5GACasRpv0zPCAJDUGACSGgNAUmMASGp1AMLhUs+5Kv2VRHOCMu15LERzTunfUylc2o1kxjEASY0BIKkxACQ1BoCkxgCQ1BgAkhoDQFJjAEhqDABJjQEgqTEAJDUGgKTGAJDUGACSGgNAUmMASGoMAEmNASCpMQAkNQaApMYAkNQYAJIaA0BSYwBIagwASY0BIKkxACQ1BoCkxgCQ1BgAkhoDQFJjAEhqDABJjQEgqTEAJDUGgKTGAJDUGACSGgNAUmMASGoMAEmNASCpMQAkNQaApMYAkNQYAJIaA0BSYwBIagwASY0BIKkxACQ1BoCkxgCQ1BgAkhoDQFJjAEhqDABJjQEgqTEAJDUGgKTGAJDUGACSGgNAUmMASGoMAEmNASCpMQAkNQaApMYAkNQYAJIaA0BSYwBIagwASY0BIKkxACQ1BoCkxgCQ1BgAkhoDQFJjAEhqDABJjQEgqTEAJDUGgKTGAJDUGACSGgNAUmMASGoMAEmNASCpMQAkNQaApMYAkNQYAJIaA0BSYwBIagwAyU0QOW8kqAKAGjQMwwiqqqrqRvpJVVVVAKpuGIYRBJKPg6qq6nrQMIKqbggDgKoCQHBkJJjcBIYYCeq6rgIAdF0HANUQhp5q/IoQwtbAEdUSHgLRPPPn7qaXArE7VPXTWMx65uuGUK809UeX3LFk+L1wDADU4H2xwK+E+BfuAUhq3APQfGXtCgBADT6sRfsCMUD9ur4Erbv+7pS7L4w7hPhn7gFIav8PGG/U1/8MqI8AAAAASUVORK5CYII=</aTTRIBUTE>
+<aTTRIBUTE name="NT Model Attributes" type="LONGSTRING">NOTEBOOK
+CHAPTER &quot;Description&quot;
+#ATTR &quot;Shared&quot;
+ATTR &quot;Model state&quot; enabled:(cond(search (sMfbRegistration, &quot;MFB_VERS&quot;, 0) = -1, 1, 0))
+ATTR &quot;Description&quot;
+ATTR &quot;Show State&quot; ctrltype:check unchecked-value:&quot;No&quot; checked-value:&quot;Yes&quot; 
+ATTR &quot;Last user&quot; write-protected
+ATTR &quot;Date last changed&quot; write-protected
+#CHAPTER &quot;Suggestion for improvement&quot;
+#ATTR &quot;Suggestion for improvement&quot;
+</aTTRIBUTE>
+<aTTRIBUTE name="Model state" type="ENUMERATION">Draft</aTTRIBUTE>
+<aTTRIBUTE name="Keywords" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Description" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Model type" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Show State" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Actor_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="Actor_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Actor_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="ModelingAreaSize" type="ENUMERATION">20</aTTRIBUTE>
+<aTTRIBUTE name="DrawingAreaWidth" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="DrawingAreaHeight" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Reference overview settings" type="LONGSTRING">Responsible for execution|Responsible for execution
+Accountable for approving results|Accountable for approving results
+Cooperation/participation|Cooperation/participation
+To inform|To inform
+Modelling|Modelling
+Knowledge Product|Knowledge Product
+Documents and Resources|Documents and Resources
+#Data Object|Data Object
+Incoming Data Object|Incoming Data Object
+Outgoing Data Object|Outgoing Data Object
+Description|Description</aTTRIBUTE>
+<aTTRIBUTE name="Data Object_color" type="STRING">lightblue</aTTRIBUTE>
+<aTTRIBUTE name="Data Object_display" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Data Object_size" type="ENUMERATION">1</aTTRIBUTE>
+<aTTRIBUTE name="id_bpmndi_diagram" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="id_bpmndi_plane" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="id_bpmndi_collaboration" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="CommentTypeSize" type="ENUMERATION">8</aTTRIBUTE>
+<aTTRIBUTE name="CommentxCoorTextBox" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="CommentyCoorTextBox" type="STRING"></aTTRIBUTE>
+</mODELATTRIBUTES>
+<iNSTANCE id="obj.16232" class="Pool (collapsed)" name="Entrepreneur">
+<aTTRIBUTE name="Position" type="STRING">NODE x:25.25cm y:3cm w:50.5cm h:3cm index:1</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(&quot;&quot;) val:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<rECORD name="Technical Attributes"></rECORD>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="ParticipantType" type="ENUMERATION">Role</aTTRIBUTE>
+<aTTRIBUTE name="Role" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Entity" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="BoundaryVisible" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Process Term" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="ProcessType" type="ENUMERATION">None</aTTRIBUTE>
+<aTTRIBUTE name="Status" type="ENUMERATION">None</aTTRIBUTE>
+<rECORD name="Assignments"></rECORD>
+<rECORD name="Properties"></rECORD>
+<aTTRIBUTE name="AdHoc" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="AdHocOrdering" type="ENUMERATION">None</aTTRIBUTE>
+<aTTRIBUTE name="AdHocCompletionCondition" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="EnableInstanceCompensation" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Categories (Process)" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation (Process)" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="SuppressJoinFailure" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Open questions" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16232&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Color" type="STRING">white</aTTRIBUTE>
+<aTTRIBUTE name="Orientation" type="ENUMERATION">horizontal</aTTRIBUTE>
+<aTTRIBUTE name="Boundary visible" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Auditing" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Monitoring" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Process type" type="ENUMERATION">None</aTTRIBUTE>
+<aTTRIBUTE name="Executable" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Closed" type="ENUMERATION">No</aTTRIBUTE>
+<iNTERREF name="Referenced Organizational Unit"></iNTERREF>
+<iNTERREF name="Referenced process"></iNTERREF>
+<aTTRIBUTE name="Cardinality" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16235" class="Pool" name="Monti Azzurri Consorsium">
+<aTTRIBUTE name="Position" type="STRING">NODE x:0cm y:9cm w:50cm h:15cm index:2</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(&quot;&quot;) val:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<rECORD name="Technical Attributes"></rECORD>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="ParticipantType" type="ENUMERATION">Role</aTTRIBUTE>
+<aTTRIBUTE name="Role" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Entity" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="BoundaryVisible" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Process Term" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="ProcessType" type="ENUMERATION">None</aTTRIBUTE>
+<aTTRIBUTE name="Status" type="ENUMERATION">None</aTTRIBUTE>
+<rECORD name="Assignments"></rECORD>
+<rECORD name="Properties"></rECORD>
+<aTTRIBUTE name="AdHoc" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="AdHocOrdering" type="ENUMERATION">None</aTTRIBUTE>
+<aTTRIBUTE name="AdHocCompletionCondition" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="EnableInstanceCompensation" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Categories (Process)" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation (Process)" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="SuppressJoinFailure" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Open questions" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16235&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Color" type="STRING">white</aTTRIBUTE>
+<aTTRIBUTE name="Orientation" type="ENUMERATION">horizontal</aTTRIBUTE>
+<aTTRIBUTE name="Boundary visible" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Auditing" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Monitoring" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Process type" type="ENUMERATION">None</aTTRIBUTE>
+<aTTRIBUTE name="Executable" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Closed" type="ENUMERATION">No</aTTRIBUTE>
+<iNTERREF name="Referenced Organizational Unit">
+<iREF type="objectreference" tmodeltype="Organizational structure" tmodelname="Org Model Monti Azzurri" tmodelver="" tclassname="Organizational unit" tobjname="Monti Azzurri"></iREF>
+</iNTERREF>
+</iNSTANCE>
+<iNSTANCE id="obj.16238" class="Lane" name="Office SUAP">
+<aTTRIBUTE name="Position" type="STRING">NODE x:3cm y:9cm w:47cm h:15cm index:3</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(&quot;&quot;) val:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<rECORD name="Technical Attributes"></rECORD>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Open questions" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16238&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Color" type="STRING">white</aTTRIBUTE>
+<aTTRIBUTE name="Orientation" type="ENUMERATION">horizontal</aTTRIBUTE>
+<aTTRIBUTE name="Line break" type="ENUMERATION">No</aTTRIBUTE>
+<rECORD name="Properties"></rECORD>
+<aTTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Cardinality" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Referenced Organizational Unit">
+<iREF type="objectreference" tmodeltype="Organizational structure" tmodelname="Org Model Monti Azzurri" tmodelver="" tclassname="Organizational unit" tobjname="SUAP Office"></iREF>
+</iNTERREF>
+<iNTERREF name="Referenced Role"></iNTERREF>
+<iNTERREF name="Referenced Performer"></iNTERREF>
+</iNSTANCE>
+<iNSTANCE id="obj.16241" class="Start Event" name="Start Event-83017">
+<aTTRIBUTE name="Position" type="STRING">NODE x:7cm y:15cm index:4</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Process calendar" type="LONGSTRING">D@Working day@b@32400-43200@U900;1800@45000-59400@U900;1800@Free day@c@@@$cbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbcbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbcbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbcccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbccbbccb</aTTRIBUTE>
+<aTTRIBUTE name="Quantity" type="EXPRESSION">EXPR expr:(0) val:0</aTTRIBUTE>
+<aTTRIBUTE name="Time period" type="ENUMERATION">Per year</aTTRIBUTE>
+<aTTRIBUTE name="Abandon after tolerance waiting time" type="ENUMERATION">no</aTTRIBUTE>
+<aTTRIBUTE name="Tolerance waiting time" type="TIME">00:000:00:00:00</aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-02] Attribute \&quot;Fontcolor\&quot; (Lane) does not exist!  \&quot;fontcolor\&quot; (Start Event)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<rECORD name="Technical Attributes"></rECORD>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Actor"></iNTERREF>
+<rECORD name="Assignments"></rECORD>
+<aTTRIBUTE name="Term" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Trigger" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Result" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Aggregated execution time" type="TIME">00:000:00:00:00</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated waiting time" type="TIME">00:000:00:00:00</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated resting time" type="TIME">00:000:00:00:00</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated transport time" type="TIME">00:000:00:00:00</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated cycle time" type="TIME">00:000:00:00:00</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Info on results" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Cost driver" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Cost driver quantity" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated personnel costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="External documentation" type="PROGRAMCALL">ITEM &quot;&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Prozeßstart</aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Open questions" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Modelling direction" type="EXPRESSION">EXPR val:&quot;vertical&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Implementing control" type="ENUMERATION">no</aTTRIBUTE>
+<aTTRIBUTE name="Show name" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16241&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Type" type="ENUMERATION">Top-level</aTTRIBUTE>
+<aTTRIBUTE name="Message" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Timer" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Conditional" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Signal" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Escalation" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Error" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Compensation" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Parallel" type="ENUMERATION">No</aTTRIBUTE>
+<rECORD name="Properties"></rECORD>
+<aTTRIBUTE name="Auditing" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Monitoring" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Collection" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Object type" type="ENUMERATION">Information</aTTRIBUTE>
+<aTTRIBUTE name="Cardinality" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Details" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Timer type" type="ENUMERATION">Date</aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16244" class="Sub-Process" name="Receive Instance">
+<aTTRIBUTE name="Position" type="STRING">NODE x:11cm y:15cm w:3.36cm h:1.8cm index:5</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Referenced subprocess"></iNTERREF>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-02] Attribute \&quot;Fontcolor\&quot; (Lane) does not exist!  \&quot;fontcolor\&quot; (Sub-Process)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<rECORD name="Technical Attributes"></rECORD>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Actor"></iNTERREF>
+<rECORD name="Assignments"></rECORD>
+<aTTRIBUTE name="Term" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Prozeßaufruf</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Aggregated execution time" type="EXPRESSION">EXPR val:0s</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated costs" type="EXPRESSION">EXPR val:0</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated resting time" type="EXPRESSION">EXPR val:0s</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated personnel costs" type="EXPRESSION">EXPR val:0</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated waiting time" type="EXPRESSION">EXPR val:0s</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated transport time" type="EXPRESSION">EXPR val:0s</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated cycle time" type="EXPRESSION">EXPR val:0s</aTTRIBUTE>
+<aTTRIBUTE name="Open questions" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Performer" type="EXPRESSION">EXPR expr:(cond (avalf (&quot;%o&quot;, &quot;Responsible role&quot;) &lt;&gt; &quot;&quot;, &quot;({\&quot;&quot; + avalf (&quot;%o&quot;, &quot;Responsible role&quot;) + &quot;\&quot; : \&quot;Role\&quot;} &lt;- \&quot;Has role\&quot;)&quot;,&quot;&quot;)) val:error:&quot;[acoexpar-02] Attribute \&quot;Responsible role\&quot; (Sub-Process) does not exist!  \&quot;Performer\&quot; (Sub-Process)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Subprocessname" type="EXPRESSION">EXPR val:&quot;Bezeichnung&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Classification" type="ENUMERATIONLIST"></aTTRIBUTE>
+<aTTRIBUTE name="External documentation" type="PROGRAMCALL">ITEM &quot;&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="__NameGeneration__" type="STRING">NAMEGEN srcattr:&quot;Referenced subprocess&quot; format:&quot;%m&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Type" type="ENUMERATION">Embedded</aTTRIBUTE>
+<aTTRIBUTE name="Global" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16244&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Auditing" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Monitoring" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="For compensation" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Loop type" type="ENUMERATION">Not specified</aTTRIBUTE>
+<aTTRIBUTE name="Sequential execution" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Cardinality" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Referenced data input"></iNTERREF>
+<iNTERREF name="Referenced data output"></iNTERREF>
+<rECORD name="Properties"></rECORD>
+<aTTRIBUTE name="Collection" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Object type" type="ENUMERATION">Information</aTTRIBUTE>
+<aTTRIBUTE name="Loop condition (standard)" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Completion condition" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Completion condition (ad-hoc)" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Suppress Sub-Process" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Actor_" type="EXPRESSION">EXPR expr:(maval(&quot;Actor_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Description_" type="EXPRESSION">EXPR expr:(maval(&quot;Description_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_Modelling_direction_" type="EXPRESSION">EXPR expr:(maval(&quot;Modelling direction&quot;)) val:&quot;vertical&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Modelling_" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="_REFERENCE_OVERVIEW_SETTINGS_" type="EXPRESSION">EXPR expr:(maval(&quot;Reference overview settings&quot;)) val:&quot;Responsible for execution|Responsible for execution\nAccountable for approving results|Accountable for approving results\nCooperation/participation|Cooperation/participation\nTo inform|To inform\nModelling|Modelling\nKnowledge Product|Knowledge Product\nDocuments and Resources|Documents and Resources\n#Data Object|Data Object\nIncoming Data Object|Incoming Data Object\nOutgoing Data Object|Outgoing Data Object\nDescription|Description&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Actor_" type="EXPRESSION">EXPR expr:(maval(&quot;Actor_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Description_" type="EXPRESSION">EXPR expr:(maval(&quot;Description_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Modelling_" type="EXPRESSION">EXPR expr:(maval(&quot;Modelling_size&quot;)) val:&quot;3&quot;</aTTRIBUTE>
+<aTTRIBUTE name="BoolBarDisplayActive" type="EXPRESSION">EXPR expr:(maval(&quot;BAR Display active&quot;)) val:&quot;No&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Knowledge Product_" type="EXPRESSION">EXPR expr:(maval(&quot;Knowledge Product_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Data Object_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Documents and Resources_" type="EXPRESSION">EXPR expr:(maval(&quot;Documents and Resources_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Data Object_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Documents and Resources_" type="EXPRESSION">EXPR expr:(maval(&quot;Documents and Resources_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Knowledge Product_" type="EXPRESSION">EXPR expr:(maval(&quot;Knowledge Product_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<iNTERREF name="Data Object"></iNTERREF>
+<iNTERREF name="Knowledge Product"></iNTERREF>
+<iNTERREF name="Documents and Resources"></iNTERREF>
+<iNTERREF name="Knowledge Intensive"></iNTERREF>
+<aTTRIBUTE name="_disp_Responsible for execution_" type="EXPRESSION">EXPR expr:(maval(&quot;Responsible for execution_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Responsible for execution_" type="EXPRESSION">EXPR expr:(maval(&quot;Responsible for execution_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Accountable for approving results_" type="EXPRESSION">EXPR expr:(maval(&quot;Accountable for approving results_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Accountable for approving results_" type="EXPRESSION">EXPR expr:(maval(&quot;Accountable for approving results_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Cooperation/participation_" type="EXPRESSION">EXPR expr:(maval(&quot;Cooperation/participation_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Cooperation/participation_" type="EXPRESSION">EXPR expr:(maval(&quot;Cooperation/participation_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_To inform_" type="EXPRESSION">EXPR expr:(maval(&quot;To inform_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_To inform_" type="EXPRESSION">EXPR expr:(maval(&quot;To inform_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Outgoing Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Outgoing Data Object_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Outgoing Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Outgoing Data Object_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Incoming Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Incoming Data Object_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Incoming Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Incoming Data Object_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<iNTERREF name="Incoming Data Object"></iNTERREF>
+<iNTERREF name="Outgoing Data Object"></iNTERREF>
+<iNTERREF name="Responsible for execution"></iNTERREF>
+<iNTERREF name="Cooperation/participation"></iNTERREF>
+<iNTERREF name="Accountable for approving results"></iNTERREF>
+<iNTERREF name="To inform"></iNTERREF>
+<iNTERREF name="Referenced Case Plan Model"></iNTERREF>
+</iNSTANCE>
+<iNSTANCE id="obj.16247" class="Sub-Process" name="Assess Application">
+<aTTRIBUTE name="Position" type="STRING">NODE x:15.5cm y:15cm w:3.36cm h:1.8cm index:6</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Referenced subprocess"></iNTERREF>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-02] Attribute \&quot;Fontcolor\&quot; (Lane) does not exist!  \&quot;fontcolor\&quot; (Sub-Process)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<rECORD name="Technical Attributes"></rECORD>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Actor"></iNTERREF>
+<rECORD name="Assignments"></rECORD>
+<aTTRIBUTE name="Term" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING">Orig.Name = Instance Assessment</aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Prozeßaufruf</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Aggregated execution time" type="EXPRESSION">EXPR val:0s</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated costs" type="EXPRESSION">EXPR val:0</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated resting time" type="EXPRESSION">EXPR val:0s</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated personnel costs" type="EXPRESSION">EXPR val:0</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated waiting time" type="EXPRESSION">EXPR val:0s</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated transport time" type="EXPRESSION">EXPR val:0s</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated cycle time" type="EXPRESSION">EXPR val:0s</aTTRIBUTE>
+<aTTRIBUTE name="Open questions" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Performer" type="EXPRESSION">EXPR expr:(cond (avalf (&quot;%o&quot;, &quot;Responsible role&quot;) &lt;&gt; &quot;&quot;, &quot;({\&quot;&quot; + avalf (&quot;%o&quot;, &quot;Responsible role&quot;) + &quot;\&quot; : \&quot;Role\&quot;} &lt;- \&quot;Has role\&quot;)&quot;,&quot;&quot;)) val:error:&quot;[acoexpar-02] Attribute \&quot;Responsible role\&quot; (Sub-Process) does not exist!  \&quot;Performer\&quot; (Sub-Process)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Subprocessname" type="EXPRESSION">EXPR val:&quot;Bezeichnung&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Classification" type="ENUMERATIONLIST"></aTTRIBUTE>
+<aTTRIBUTE name="External documentation" type="PROGRAMCALL">ITEM &quot;&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="__NameGeneration__" type="STRING">NAMEGEN srcattr:&quot;Referenced subprocess&quot; format:&quot;%m&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Type" type="ENUMERATION">Embedded</aTTRIBUTE>
+<aTTRIBUTE name="Global" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16247&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Auditing" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Monitoring" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="For compensation" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Loop type" type="ENUMERATION">Not specified</aTTRIBUTE>
+<aTTRIBUTE name="Sequential execution" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Cardinality" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Referenced data input"></iNTERREF>
+<iNTERREF name="Referenced data output"></iNTERREF>
+<rECORD name="Properties"></rECORD>
+<aTTRIBUTE name="Collection" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Object type" type="ENUMERATION">Information</aTTRIBUTE>
+<aTTRIBUTE name="Loop condition (standard)" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Completion condition" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Completion condition (ad-hoc)" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Suppress Sub-Process" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Actor_" type="EXPRESSION">EXPR expr:(maval(&quot;Actor_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Description_" type="EXPRESSION">EXPR expr:(maval(&quot;Description_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_Modelling_direction_" type="EXPRESSION">EXPR expr:(maval(&quot;Modelling direction&quot;)) val:&quot;vertical&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Modelling_" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="_REFERENCE_OVERVIEW_SETTINGS_" type="EXPRESSION">EXPR expr:(maval(&quot;Reference overview settings&quot;)) val:&quot;Responsible for execution|Responsible for execution\nAccountable for approving results|Accountable for approving results\nCooperation/participation|Cooperation/participation\nTo inform|To inform\nModelling|Modelling\nKnowledge Product|Knowledge Product\nDocuments and Resources|Documents and Resources\n#Data Object|Data Object\nIncoming Data Object|Incoming Data Object\nOutgoing Data Object|Outgoing Data Object\nDescription|Description&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Actor_" type="EXPRESSION">EXPR expr:(maval(&quot;Actor_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Description_" type="EXPRESSION">EXPR expr:(maval(&quot;Description_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Modelling_" type="EXPRESSION">EXPR expr:(maval(&quot;Modelling_size&quot;)) val:&quot;3&quot;</aTTRIBUTE>
+<aTTRIBUTE name="BoolBarDisplayActive" type="EXPRESSION">EXPR expr:(maval(&quot;BAR Display active&quot;)) val:&quot;No&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Knowledge Product_" type="EXPRESSION">EXPR expr:(maval(&quot;Knowledge Product_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Data Object_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Documents and Resources_" type="EXPRESSION">EXPR expr:(maval(&quot;Documents and Resources_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Data Object_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Documents and Resources_" type="EXPRESSION">EXPR expr:(maval(&quot;Documents and Resources_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Knowledge Product_" type="EXPRESSION">EXPR expr:(maval(&quot;Knowledge Product_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<iNTERREF name="Data Object"></iNTERREF>
+<iNTERREF name="Knowledge Product"></iNTERREF>
+<iNTERREF name="Documents and Resources"></iNTERREF>
+<iNTERREF name="Knowledge Intensive"></iNTERREF>
+<aTTRIBUTE name="_disp_Responsible for execution_" type="EXPRESSION">EXPR expr:(maval(&quot;Responsible for execution_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Responsible for execution_" type="EXPRESSION">EXPR expr:(maval(&quot;Responsible for execution_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Accountable for approving results_" type="EXPRESSION">EXPR expr:(maval(&quot;Accountable for approving results_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Accountable for approving results_" type="EXPRESSION">EXPR expr:(maval(&quot;Accountable for approving results_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Cooperation/participation_" type="EXPRESSION">EXPR expr:(maval(&quot;Cooperation/participation_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Cooperation/participation_" type="EXPRESSION">EXPR expr:(maval(&quot;Cooperation/participation_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_To inform_" type="EXPRESSION">EXPR expr:(maval(&quot;To inform_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_To inform_" type="EXPRESSION">EXPR expr:(maval(&quot;To inform_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Outgoing Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Outgoing Data Object_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Outgoing Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Outgoing Data Object_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Incoming Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Incoming Data Object_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Incoming Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Incoming Data Object_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<iNTERREF name="Incoming Data Object"></iNTERREF>
+<iNTERREF name="Outgoing Data Object"></iNTERREF>
+<iNTERREF name="Responsible for execution"></iNTERREF>
+<iNTERREF name="Cooperation/participation"></iNTERREF>
+<iNTERREF name="Accountable for approving results"></iNTERREF>
+<iNTERREF name="To inform"></iNTERREF>
+<iNTERREF name="Referenced Case Plan Model"></iNTERREF>
+</iNSTANCE>
+<iNSTANCE id="obj.16250" class="Sub-Process" name="Manage of 3rd Party Admin">
+<aTTRIBUTE name="Position" type="STRING">NODE x:27cm y:13cm w:3.36cm h:1.8cm index:7</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Referenced subprocess">
+<iREF type="modelreference" tmodeltype="Business process diagram (BPMN 2.0)" tmodelname="TitoloUnico_MontiAzzurrSUB_3" tmodelver=""></iREF>
+</iNTERREF>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-02] Attribute \&quot;Fontcolor\&quot; (Lane) does not exist!  \&quot;fontcolor\&quot; (Sub-Process)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<rECORD name="Technical Attributes"></rECORD>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Actor"></iNTERREF>
+<rECORD name="Assignments"></rECORD>
+<aTTRIBUTE name="Term" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING">Orig.Name = Manage of third party Administration</aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Prozeßaufruf</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Aggregated execution time" type="EXPRESSION">EXPR val:0s</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated costs" type="EXPRESSION">EXPR val:0</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated resting time" type="EXPRESSION">EXPR val:0s</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated personnel costs" type="EXPRESSION">EXPR val:0</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated waiting time" type="EXPRESSION">EXPR val:0s</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated transport time" type="EXPRESSION">EXPR val:0s</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated cycle time" type="EXPRESSION">EXPR val:0s</aTTRIBUTE>
+<aTTRIBUTE name="Open questions" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Performer" type="EXPRESSION">EXPR expr:(cond (avalf (&quot;%o&quot;, &quot;Responsible role&quot;) &lt;&gt; &quot;&quot;, &quot;({\&quot;&quot; + avalf (&quot;%o&quot;, &quot;Responsible role&quot;) + &quot;\&quot; : \&quot;Role\&quot;} &lt;- \&quot;Has role\&quot;)&quot;,&quot;&quot;)) val:error:&quot;[acoexpar-02] Attribute \&quot;Responsible role\&quot; (Sub-Process) does not exist!  \&quot;Performer\&quot; (Sub-Process)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Subprocessname" type="EXPRESSION">EXPR val:&quot;Keine Modellbezeichnung vergeben&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Classification" type="ENUMERATIONLIST"></aTTRIBUTE>
+<aTTRIBUTE name="External documentation" type="PROGRAMCALL">ITEM &quot;&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="__NameGeneration__" type="STRING">NAMEGEN srcattr:&quot;Referenced subprocess&quot; format:&quot;%m&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Type" type="ENUMERATION">Embedded</aTTRIBUTE>
+<aTTRIBUTE name="Global" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16250&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Auditing" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Monitoring" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="For compensation" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Loop type" type="ENUMERATION">Not specified</aTTRIBUTE>
+<aTTRIBUTE name="Sequential execution" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Cardinality" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Referenced data input"></iNTERREF>
+<iNTERREF name="Referenced data output"></iNTERREF>
+<rECORD name="Properties"></rECORD>
+<aTTRIBUTE name="Collection" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Object type" type="ENUMERATION">Information</aTTRIBUTE>
+<aTTRIBUTE name="Loop condition (standard)" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Completion condition" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Completion condition (ad-hoc)" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Suppress Sub-Process" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Actor_" type="EXPRESSION">EXPR expr:(maval(&quot;Actor_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Description_" type="EXPRESSION">EXPR expr:(maval(&quot;Description_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_Modelling_direction_" type="EXPRESSION">EXPR expr:(maval(&quot;Modelling direction&quot;)) val:&quot;vertical&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Modelling_" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="_REFERENCE_OVERVIEW_SETTINGS_" type="EXPRESSION">EXPR expr:(maval(&quot;Reference overview settings&quot;)) val:&quot;Responsible for execution|Responsible for execution\nAccountable for approving results|Accountable for approving results\nCooperation/participation|Cooperation/participation\nTo inform|To inform\nModelling|Modelling\nKnowledge Product|Knowledge Product\nDocuments and Resources|Documents and Resources\n#Data Object|Data Object\nIncoming Data Object|Incoming Data Object\nOutgoing Data Object|Outgoing Data Object\nDescription|Description&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Actor_" type="EXPRESSION">EXPR expr:(maval(&quot;Actor_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Description_" type="EXPRESSION">EXPR expr:(maval(&quot;Description_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Modelling_" type="EXPRESSION">EXPR expr:(maval(&quot;Modelling_size&quot;)) val:&quot;3&quot;</aTTRIBUTE>
+<aTTRIBUTE name="BoolBarDisplayActive" type="EXPRESSION">EXPR expr:(maval(&quot;BAR Display active&quot;)) val:&quot;No&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Knowledge Product_" type="EXPRESSION">EXPR expr:(maval(&quot;Knowledge Product_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Data Object_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Documents and Resources_" type="EXPRESSION">EXPR expr:(maval(&quot;Documents and Resources_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Data Object_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Documents and Resources_" type="EXPRESSION">EXPR expr:(maval(&quot;Documents and Resources_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Knowledge Product_" type="EXPRESSION">EXPR expr:(maval(&quot;Knowledge Product_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<iNTERREF name="Data Object"></iNTERREF>
+<iNTERREF name="Knowledge Product"></iNTERREF>
+<iNTERREF name="Documents and Resources"></iNTERREF>
+<iNTERREF name="Knowledge Intensive"></iNTERREF>
+<aTTRIBUTE name="_disp_Responsible for execution_" type="EXPRESSION">EXPR expr:(maval(&quot;Responsible for execution_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Responsible for execution_" type="EXPRESSION">EXPR expr:(maval(&quot;Responsible for execution_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Accountable for approving results_" type="EXPRESSION">EXPR expr:(maval(&quot;Accountable for approving results_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Accountable for approving results_" type="EXPRESSION">EXPR expr:(maval(&quot;Accountable for approving results_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Cooperation/participation_" type="EXPRESSION">EXPR expr:(maval(&quot;Cooperation/participation_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Cooperation/participation_" type="EXPRESSION">EXPR expr:(maval(&quot;Cooperation/participation_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_To inform_" type="EXPRESSION">EXPR expr:(maval(&quot;To inform_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_To inform_" type="EXPRESSION">EXPR expr:(maval(&quot;To inform_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Outgoing Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Outgoing Data Object_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Outgoing Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Outgoing Data Object_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Incoming Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Incoming Data Object_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Incoming Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Incoming Data Object_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<iNTERREF name="Incoming Data Object"></iNTERREF>
+<iNTERREF name="Outgoing Data Object"></iNTERREF>
+<iNTERREF name="Responsible for execution"></iNTERREF>
+<iNTERREF name="Cooperation/participation"></iNTERREF>
+<iNTERREF name="Accountable for approving results"></iNTERREF>
+<iNTERREF name="To inform"></iNTERREF>
+<iNTERREF name="Referenced Case Plan Model"></iNTERREF>
+</iNSTANCE>
+<iNSTANCE id="obj.16253" class="Sub-Process" name="Manage Service Conference">
+<aTTRIBUTE name="Position" type="STRING">NODE x:27cm y:21.5cm w:3.36cm h:1.8cm index:8</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Referenced subprocess">
+<iREF type="modelreference" tmodeltype="Business process diagram (BPMN 2.0)" tmodelname="TitoloUnico_MonitAzzurrSUB_4" tmodelver=""></iREF>
+</iNTERREF>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-02] Attribute \&quot;Fontcolor\&quot; (Lane) does not exist!  \&quot;fontcolor\&quot; (Sub-Process)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<rECORD name="Technical Attributes"></rECORD>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Actor"></iNTERREF>
+<rECORD name="Assignments"></rECORD>
+<aTTRIBUTE name="Term" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING">Orig.Name = Announces Service Conference</aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Prozeßaufruf</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Aggregated execution time" type="EXPRESSION">EXPR val:0s</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated costs" type="EXPRESSION">EXPR val:0</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated resting time" type="EXPRESSION">EXPR val:0s</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated personnel costs" type="EXPRESSION">EXPR val:0</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated waiting time" type="EXPRESSION">EXPR val:0s</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated transport time" type="EXPRESSION">EXPR val:0s</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated cycle time" type="EXPRESSION">EXPR val:0s</aTTRIBUTE>
+<aTTRIBUTE name="Open questions" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Performer" type="EXPRESSION">EXPR expr:(cond (avalf (&quot;%o&quot;, &quot;Responsible role&quot;) &lt;&gt; &quot;&quot;, &quot;({\&quot;&quot; + avalf (&quot;%o&quot;, &quot;Responsible role&quot;) + &quot;\&quot; : \&quot;Role\&quot;} &lt;- \&quot;Has role\&quot;)&quot;,&quot;&quot;)) val:error:&quot;[acoexpar-02] Attribute \&quot;Responsible role\&quot; (Sub-Process) does not exist!  \&quot;Performer\&quot; (Sub-Process)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Subprocessname" type="EXPRESSION">EXPR val:&quot;Keine Modellbezeichnung vergeben&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Classification" type="ENUMERATIONLIST"></aTTRIBUTE>
+<aTTRIBUTE name="External documentation" type="PROGRAMCALL">ITEM &quot;&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="__NameGeneration__" type="STRING">NAMEGEN srcattr:&quot;Referenced subprocess&quot; format:&quot;%m&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Type" type="ENUMERATION">Embedded</aTTRIBUTE>
+<aTTRIBUTE name="Global" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16253&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Auditing" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Monitoring" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="For compensation" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Loop type" type="ENUMERATION">Not specified</aTTRIBUTE>
+<aTTRIBUTE name="Sequential execution" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Cardinality" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Referenced data input"></iNTERREF>
+<iNTERREF name="Referenced data output"></iNTERREF>
+<rECORD name="Properties"></rECORD>
+<aTTRIBUTE name="Collection" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Object type" type="ENUMERATION">Information</aTTRIBUTE>
+<aTTRIBUTE name="Loop condition (standard)" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Completion condition" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Completion condition (ad-hoc)" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Suppress Sub-Process" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Actor_" type="EXPRESSION">EXPR expr:(maval(&quot;Actor_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Description_" type="EXPRESSION">EXPR expr:(maval(&quot;Description_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_Modelling_direction_" type="EXPRESSION">EXPR expr:(maval(&quot;Modelling direction&quot;)) val:&quot;vertical&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Modelling_" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="_REFERENCE_OVERVIEW_SETTINGS_" type="EXPRESSION">EXPR expr:(maval(&quot;Reference overview settings&quot;)) val:&quot;Responsible for execution|Responsible for execution\nAccountable for approving results|Accountable for approving results\nCooperation/participation|Cooperation/participation\nTo inform|To inform\nModelling|Modelling\nKnowledge Product|Knowledge Product\nDocuments and Resources|Documents and Resources\n#Data Object|Data Object\nIncoming Data Object|Incoming Data Object\nOutgoing Data Object|Outgoing Data Object\nDescription|Description&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Actor_" type="EXPRESSION">EXPR expr:(maval(&quot;Actor_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Description_" type="EXPRESSION">EXPR expr:(maval(&quot;Description_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Modelling_" type="EXPRESSION">EXPR expr:(maval(&quot;Modelling_size&quot;)) val:&quot;3&quot;</aTTRIBUTE>
+<aTTRIBUTE name="BoolBarDisplayActive" type="EXPRESSION">EXPR expr:(maval(&quot;BAR Display active&quot;)) val:&quot;No&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Knowledge Product_" type="EXPRESSION">EXPR expr:(maval(&quot;Knowledge Product_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Data Object_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Documents and Resources_" type="EXPRESSION">EXPR expr:(maval(&quot;Documents and Resources_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Data Object_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Documents and Resources_" type="EXPRESSION">EXPR expr:(maval(&quot;Documents and Resources_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Knowledge Product_" type="EXPRESSION">EXPR expr:(maval(&quot;Knowledge Product_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<iNTERREF name="Data Object"></iNTERREF>
+<iNTERREF name="Knowledge Product"></iNTERREF>
+<iNTERREF name="Documents and Resources"></iNTERREF>
+<iNTERREF name="Knowledge Intensive"></iNTERREF>
+<aTTRIBUTE name="_disp_Responsible for execution_" type="EXPRESSION">EXPR expr:(maval(&quot;Responsible for execution_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Responsible for execution_" type="EXPRESSION">EXPR expr:(maval(&quot;Responsible for execution_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Accountable for approving results_" type="EXPRESSION">EXPR expr:(maval(&quot;Accountable for approving results_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Accountable for approving results_" type="EXPRESSION">EXPR expr:(maval(&quot;Accountable for approving results_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Cooperation/participation_" type="EXPRESSION">EXPR expr:(maval(&quot;Cooperation/participation_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Cooperation/participation_" type="EXPRESSION">EXPR expr:(maval(&quot;Cooperation/participation_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_To inform_" type="EXPRESSION">EXPR expr:(maval(&quot;To inform_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_To inform_" type="EXPRESSION">EXPR expr:(maval(&quot;To inform_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Outgoing Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Outgoing Data Object_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Outgoing Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Outgoing Data Object_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Incoming Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Incoming Data Object_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Incoming Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Incoming Data Object_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<iNTERREF name="Incoming Data Object"></iNTERREF>
+<iNTERREF name="Outgoing Data Object"></iNTERREF>
+<iNTERREF name="Responsible for execution"></iNTERREF>
+<iNTERREF name="Cooperation/participation"></iNTERREF>
+<iNTERREF name="Accountable for approving results"></iNTERREF>
+<iNTERREF name="To inform"></iNTERREF>
+<iNTERREF name="Referenced Case Plan Model"></iNTERREF>
+</iNSTANCE>
+<iNSTANCE id="obj.16256" class="Sub-Process" name="Check Integration">
+<aTTRIBUTE name="Position" type="STRING">NODE x:35.5cm y:13cm w:3.36cm h:1.8cm index:9</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Referenced subprocess"></iNTERREF>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-02] Attribute \&quot;Fontcolor\&quot; (Lane) does not exist!  \&quot;fontcolor\&quot; (Sub-Process)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<rECORD name="Technical Attributes"></rECORD>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Actor"></iNTERREF>
+<rECORD name="Assignments"></rECORD>
+<aTTRIBUTE name="Term" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Prozeßaufruf</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Aggregated execution time" type="EXPRESSION">EXPR val:0s</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated costs" type="EXPRESSION">EXPR val:0</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated resting time" type="EXPRESSION">EXPR val:0s</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated personnel costs" type="EXPRESSION">EXPR val:0</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated waiting time" type="EXPRESSION">EXPR val:0s</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated transport time" type="EXPRESSION">EXPR val:0s</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated cycle time" type="EXPRESSION">EXPR val:0s</aTTRIBUTE>
+<aTTRIBUTE name="Open questions" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Performer" type="EXPRESSION">EXPR expr:(cond (avalf (&quot;%o&quot;, &quot;Responsible role&quot;) &lt;&gt; &quot;&quot;, &quot;({\&quot;&quot; + avalf (&quot;%o&quot;, &quot;Responsible role&quot;) + &quot;\&quot; : \&quot;Role\&quot;} &lt;- \&quot;Has role\&quot;)&quot;,&quot;&quot;)) val:error:&quot;[acoexpar-02] Attribute \&quot;Responsible role\&quot; (Sub-Process) does not exist!  \&quot;Performer\&quot; (Sub-Process)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Subprocessname" type="EXPRESSION">EXPR val:&quot;Bezeichnung&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Classification" type="ENUMERATIONLIST"></aTTRIBUTE>
+<aTTRIBUTE name="External documentation" type="PROGRAMCALL">ITEM &quot;&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="__NameGeneration__" type="STRING">NAMEGEN srcattr:&quot;Referenced subprocess&quot; format:&quot;%m&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Type" type="ENUMERATION">Embedded</aTTRIBUTE>
+<aTTRIBUTE name="Global" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16256&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Auditing" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Monitoring" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="For compensation" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Loop type" type="ENUMERATION">Not specified</aTTRIBUTE>
+<aTTRIBUTE name="Sequential execution" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Cardinality" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Referenced data input"></iNTERREF>
+<iNTERREF name="Referenced data output"></iNTERREF>
+<rECORD name="Properties"></rECORD>
+<aTTRIBUTE name="Collection" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Object type" type="ENUMERATION">Information</aTTRIBUTE>
+<aTTRIBUTE name="Loop condition (standard)" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Completion condition" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Completion condition (ad-hoc)" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Suppress Sub-Process" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Actor_" type="EXPRESSION">EXPR expr:(maval(&quot;Actor_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Description_" type="EXPRESSION">EXPR expr:(maval(&quot;Description_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_Modelling_direction_" type="EXPRESSION">EXPR expr:(maval(&quot;Modelling direction&quot;)) val:&quot;vertical&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Modelling_" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="_REFERENCE_OVERVIEW_SETTINGS_" type="EXPRESSION">EXPR expr:(maval(&quot;Reference overview settings&quot;)) val:&quot;Responsible for execution|Responsible for execution\nAccountable for approving results|Accountable for approving results\nCooperation/participation|Cooperation/participation\nTo inform|To inform\nModelling|Modelling\nKnowledge Product|Knowledge Product\nDocuments and Resources|Documents and Resources\n#Data Object|Data Object\nIncoming Data Object|Incoming Data Object\nOutgoing Data Object|Outgoing Data Object\nDescription|Description&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Actor_" type="EXPRESSION">EXPR expr:(maval(&quot;Actor_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Description_" type="EXPRESSION">EXPR expr:(maval(&quot;Description_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Modelling_" type="EXPRESSION">EXPR expr:(maval(&quot;Modelling_size&quot;)) val:&quot;3&quot;</aTTRIBUTE>
+<aTTRIBUTE name="BoolBarDisplayActive" type="EXPRESSION">EXPR expr:(maval(&quot;BAR Display active&quot;)) val:&quot;No&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Knowledge Product_" type="EXPRESSION">EXPR expr:(maval(&quot;Knowledge Product_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Data Object_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Documents and Resources_" type="EXPRESSION">EXPR expr:(maval(&quot;Documents and Resources_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Data Object_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Documents and Resources_" type="EXPRESSION">EXPR expr:(maval(&quot;Documents and Resources_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Knowledge Product_" type="EXPRESSION">EXPR expr:(maval(&quot;Knowledge Product_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<iNTERREF name="Data Object"></iNTERREF>
+<iNTERREF name="Knowledge Product"></iNTERREF>
+<iNTERREF name="Documents and Resources"></iNTERREF>
+<iNTERREF name="Knowledge Intensive"></iNTERREF>
+<aTTRIBUTE name="_disp_Responsible for execution_" type="EXPRESSION">EXPR expr:(maval(&quot;Responsible for execution_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Responsible for execution_" type="EXPRESSION">EXPR expr:(maval(&quot;Responsible for execution_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Accountable for approving results_" type="EXPRESSION">EXPR expr:(maval(&quot;Accountable for approving results_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Accountable for approving results_" type="EXPRESSION">EXPR expr:(maval(&quot;Accountable for approving results_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Cooperation/participation_" type="EXPRESSION">EXPR expr:(maval(&quot;Cooperation/participation_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Cooperation/participation_" type="EXPRESSION">EXPR expr:(maval(&quot;Cooperation/participation_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_To inform_" type="EXPRESSION">EXPR expr:(maval(&quot;To inform_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_To inform_" type="EXPRESSION">EXPR expr:(maval(&quot;To inform_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Outgoing Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Outgoing Data Object_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Outgoing Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Outgoing Data Object_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Incoming Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Incoming Data Object_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Incoming Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Incoming Data Object_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<iNTERREF name="Incoming Data Object"></iNTERREF>
+<iNTERREF name="Outgoing Data Object"></iNTERREF>
+<iNTERREF name="Responsible for execution"></iNTERREF>
+<iNTERREF name="Cooperation/participation"></iNTERREF>
+<iNTERREF name="Accountable for approving results"></iNTERREF>
+<iNTERREF name="To inform"></iNTERREF>
+<iNTERREF name="Referenced Case Plan Model"></iNTERREF>
+</iNSTANCE>
+<iNSTANCE id="obj.16259" class="Sub-Process" name="Manage Inhibition">
+<aTTRIBUTE name="Position" type="STRING">NODE x:40.5cm y:21.5cm w:3.36cm h:1.95cm index:10</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Referenced subprocess"></iNTERREF>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-02] Attribute \&quot;Fontcolor\&quot; (Lane) does not exist!  \&quot;fontcolor\&quot; (Sub-Process)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<rECORD name="Technical Attributes"></rECORD>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Actor"></iNTERREF>
+<rECORD name="Assignments"></rECORD>
+<aTTRIBUTE name="Term" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING">Orgi.Name = Manage of the Inhibition
+don&apos;t understand what is done; what is meant with &apos;inhibition&apos;?</aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Prozeßaufruf</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Aggregated execution time" type="EXPRESSION">EXPR val:0s</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated costs" type="EXPRESSION">EXPR val:0</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated resting time" type="EXPRESSION">EXPR val:0s</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated personnel costs" type="EXPRESSION">EXPR val:0</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated waiting time" type="EXPRESSION">EXPR val:0s</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated transport time" type="EXPRESSION">EXPR val:0s</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated cycle time" type="EXPRESSION">EXPR val:0s</aTTRIBUTE>
+<aTTRIBUTE name="Open questions" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Performer" type="EXPRESSION">EXPR expr:(cond (avalf (&quot;%o&quot;, &quot;Responsible role&quot;) &lt;&gt; &quot;&quot;, &quot;({\&quot;&quot; + avalf (&quot;%o&quot;, &quot;Responsible role&quot;) + &quot;\&quot; : \&quot;Role\&quot;} &lt;- \&quot;Has role\&quot;)&quot;,&quot;&quot;)) val:error:&quot;[acoexpar-02] Attribute \&quot;Responsible role\&quot; (Sub-Process) does not exist!  \&quot;Performer\&quot; (Sub-Process)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Subprocessname" type="EXPRESSION">EXPR val:&quot;Bezeichnung&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Classification" type="ENUMERATIONLIST"></aTTRIBUTE>
+<aTTRIBUTE name="External documentation" type="PROGRAMCALL">ITEM &quot;&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="__NameGeneration__" type="STRING">NAMEGEN srcattr:&quot;Referenced subprocess&quot; format:&quot;%m&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Type" type="ENUMERATION">Embedded</aTTRIBUTE>
+<aTTRIBUTE name="Global" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16259&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Auditing" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Monitoring" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="For compensation" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Loop type" type="ENUMERATION">Not specified</aTTRIBUTE>
+<aTTRIBUTE name="Sequential execution" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Cardinality" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Referenced data input"></iNTERREF>
+<iNTERREF name="Referenced data output"></iNTERREF>
+<rECORD name="Properties"></rECORD>
+<aTTRIBUTE name="Collection" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Object type" type="ENUMERATION">Information</aTTRIBUTE>
+<aTTRIBUTE name="Loop condition (standard)" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Completion condition" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Completion condition (ad-hoc)" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Suppress Sub-Process" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Actor_" type="EXPRESSION">EXPR expr:(maval(&quot;Actor_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Description_" type="EXPRESSION">EXPR expr:(maval(&quot;Description_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_Modelling_direction_" type="EXPRESSION">EXPR expr:(maval(&quot;Modelling direction&quot;)) val:&quot;vertical&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Modelling_" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="_REFERENCE_OVERVIEW_SETTINGS_" type="EXPRESSION">EXPR expr:(maval(&quot;Reference overview settings&quot;)) val:&quot;Responsible for execution|Responsible for execution\nAccountable for approving results|Accountable for approving results\nCooperation/participation|Cooperation/participation\nTo inform|To inform\nModelling|Modelling\nKnowledge Product|Knowledge Product\nDocuments and Resources|Documents and Resources\n#Data Object|Data Object\nIncoming Data Object|Incoming Data Object\nOutgoing Data Object|Outgoing Data Object\nDescription|Description&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Actor_" type="EXPRESSION">EXPR expr:(maval(&quot;Actor_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Description_" type="EXPRESSION">EXPR expr:(maval(&quot;Description_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Modelling_" type="EXPRESSION">EXPR expr:(maval(&quot;Modelling_size&quot;)) val:&quot;3&quot;</aTTRIBUTE>
+<aTTRIBUTE name="BoolBarDisplayActive" type="EXPRESSION">EXPR expr:(maval(&quot;BAR Display active&quot;)) val:&quot;No&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Knowledge Product_" type="EXPRESSION">EXPR expr:(maval(&quot;Knowledge Product_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Data Object_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Documents and Resources_" type="EXPRESSION">EXPR expr:(maval(&quot;Documents and Resources_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Data Object_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Documents and Resources_" type="EXPRESSION">EXPR expr:(maval(&quot;Documents and Resources_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Knowledge Product_" type="EXPRESSION">EXPR expr:(maval(&quot;Knowledge Product_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<iNTERREF name="Data Object"></iNTERREF>
+<iNTERREF name="Knowledge Product"></iNTERREF>
+<iNTERREF name="Documents and Resources"></iNTERREF>
+<iNTERREF name="Knowledge Intensive"></iNTERREF>
+<aTTRIBUTE name="_disp_Responsible for execution_" type="EXPRESSION">EXPR expr:(maval(&quot;Responsible for execution_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Responsible for execution_" type="EXPRESSION">EXPR expr:(maval(&quot;Responsible for execution_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Accountable for approving results_" type="EXPRESSION">EXPR expr:(maval(&quot;Accountable for approving results_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Accountable for approving results_" type="EXPRESSION">EXPR expr:(maval(&quot;Accountable for approving results_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Cooperation/participation_" type="EXPRESSION">EXPR expr:(maval(&quot;Cooperation/participation_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Cooperation/participation_" type="EXPRESSION">EXPR expr:(maval(&quot;Cooperation/participation_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_To inform_" type="EXPRESSION">EXPR expr:(maval(&quot;To inform_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_To inform_" type="EXPRESSION">EXPR expr:(maval(&quot;To inform_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Outgoing Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Outgoing Data Object_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Outgoing Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Outgoing Data Object_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Incoming Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Incoming Data Object_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Incoming Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Incoming Data Object_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<iNTERREF name="Incoming Data Object"></iNTERREF>
+<iNTERREF name="Outgoing Data Object"></iNTERREF>
+<iNTERREF name="Responsible for execution"></iNTERREF>
+<iNTERREF name="Cooperation/participation"></iNTERREF>
+<iNTERREF name="Accountable for approving results"></iNTERREF>
+<iNTERREF name="To inform"></iNTERREF>
+<iNTERREF name="Referenced Case Plan Model"></iNTERREF>
+</iNSTANCE>
+<iNSTANCE id="obj.16262" class="Task" name="Send Authorization Document">
+<aTTRIBUTE name="Position" type="STRING">NODE x:45cm y:13cm w:3.36cm h:1.8cm index:11</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Performer" type="EXPRESSION">EXPR expr:(&quot;&quot;) val:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Execution time" type="TIME">00:000:00:00:00</aTTRIBUTE>
+<aTTRIBUTE name="Waiting time" type="TIME">00:000:00:00:00</aTTRIBUTE>
+<aTTRIBUTE name="Resting time" type="TIME">00:000:00:00:00</aTTRIBUTE>
+<aTTRIBUTE name="Transport time" type="TIME">00:000:00:00:00</aTTRIBUTE>
+<aTTRIBUTE name="Priority" type="INTEGER">10</aTTRIBUTE>
+<aTTRIBUTE name="Done by" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Continuous execution" type="ENUMERATION">no</aTTRIBUTE>
+<aTTRIBUTE name="Max. resource waiting time" type="TIME">00:000:00:05:00</aTTRIBUTE>
+<aTTRIBUTE name="Cooperative" type="ENUMERATION">no</aTTRIBUTE>
+<aTTRIBUTE name="Cooperation mode" type="ENUMERATION">synchron</aTTRIBUTE>
+<aTTRIBUTE name="Average number of participants" type="INTEGER">1</aTTRIBUTE>
+<aTTRIBUTE name="Min. quota of presence" type="INTEGER">100</aTTRIBUTE>
+<aTTRIBUTE name="Max. start period" type="TIME">00:001:00:00:00</aTTRIBUTE>
+<aTTRIBUTE name="Execution interruptable" type="ENUMERATION">yes</aTTRIBUTE>
+<aTTRIBUTE name="Task stack" type="ENUMERATION">personal</aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-02] Attribute \&quot;Fontcolor\&quot; (Lane) does not exist!  \&quot;fontcolor\&quot; (Task)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<rECORD name="Technical Attributes"></rECORD>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Actor"></iNTERREF>
+<rECORD name="Assignments"></rECORD>
+<aTTRIBUTE name="Term" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Status" type="ENUMERATION">None</aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="External documentation" type="PROGRAMCALL">ITEM &quot;&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Info on results" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Number" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated execution time" type="TIME">00:000:00:00:00</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated waiting time" type="TIME">00:000:00:00:00</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated resting time" type="TIME">00:000:00:00:00</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated transport time" type="TIME">00:000:00:00:00</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Aggregated personnel costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Classification" type="ENUMERATIONLIST"></aTTRIBUTE>
+<aTTRIBUTE name="EDP transaction costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="EDP batch costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Printing costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Postal costs" type="DOUBLE">0</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Aktivität</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Open questions" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Type" type="ENUMERATION">Standard</aTTRIBUTE>
+<iNTERREF name="referenced subprocess"></iNTERREF>
+<aTTRIBUTE name="Display responsible role" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Subprocessname" type="EXPRESSION">EXPR val:&quot;Bezeichnung&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Modelling direction" type="EXPRESSION">EXPR val:&quot;vertical&quot;</aTTRIBUTE>
+<rECORD name="Properties"></rECORD>
+<aTTRIBUTE name="Show name" type="ENUMERATION">center</aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16262&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Task type" type="ENUMERATION">Send</aTTRIBUTE>
+<aTTRIBUTE name="Global task" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Auditing" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Monitoring" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="For compensation" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Loop type" type="ENUMERATION">Not specified</aTTRIBUTE>
+<iNTERREF name="Call activity"></iNTERREF>
+<aTTRIBUTE name="Sequential execution" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Cardinality" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Referenced data input"></iNTERREF>
+<iNTERREF name="Referenced data output"></iNTERREF>
+<aTTRIBUTE name="Instantiate" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Collection" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Object type" type="ENUMERATION">Information</aTTRIBUTE>
+<aTTRIBUTE name="Completion condition" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Loop condition (standard)" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Referenced message"></iNTERREF>
+<aTTRIBUTE name="People-like_view_Expression" type="EXPRESSION">EXPR expr:(maval(&quot;People-like view&quot;)) val:&quot;No&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Action" type="ENUMERATION">Fill in</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Actor_" type="EXPRESSION">EXPR expr:(maval(&quot;Actor_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Description_" type="EXPRESSION">EXPR expr:(maval(&quot;Description_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_Modelling_direction_" type="EXPRESSION">EXPR expr:(maval(&quot;Modelling direction&quot;)) val:&quot;vertical&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Modelling_" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="_REFERENCE_OVERVIEW_SETTINGS_" type="EXPRESSION">EXPR expr:(maval(&quot;Reference overview settings&quot;)) val:&quot;Responsible for execution|Responsible for execution\nAccountable for approving results|Accountable for approving results\nCooperation/participation|Cooperation/participation\nTo inform|To inform\nModelling|Modelling\nKnowledge Product|Knowledge Product\nDocuments and Resources|Documents and Resources\n#Data Object|Data Object\nIncoming Data Object|Incoming Data Object\nOutgoing Data Object|Outgoing Data Object\nDescription|Description&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Actor_" type="EXPRESSION">EXPR expr:(maval(&quot;Actor_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Description_" type="EXPRESSION">EXPR expr:(maval(&quot;Description_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Modelling_" type="EXPRESSION">EXPR expr:(maval(&quot;Modelling_size&quot;)) val:&quot;3&quot;</aTTRIBUTE>
+<aTTRIBUTE name="BoolBarDisplayActive" type="EXPRESSION">EXPR expr:(maval(&quot;BAR Display active&quot;)) val:&quot;No&quot;</aTTRIBUTE>
+<iNTERREF name="Data Object"></iNTERREF>
+<iNTERREF name="Knowledge Product"></iNTERREF>
+<iNTERREF name="Documents and Resources"></iNTERREF>
+<aTTRIBUTE name="_disp_Knowledge Product_" type="EXPRESSION">EXPR expr:(maval(&quot;Knowledge Product_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Data Object_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Documents and Resources_" type="EXPRESSION">EXPR expr:(maval(&quot;Documents and Resources_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Data Object_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Documents and Resources_" type="EXPRESSION">EXPR expr:(maval(&quot;Documents and Resources_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Knowledge Product_" type="EXPRESSION">EXPR expr:(maval(&quot;Knowledge Product_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Responsible for execution_" type="EXPRESSION">EXPR expr:(maval(&quot;Responsible for execution_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Responsible for execution_" type="EXPRESSION">EXPR expr:(maval(&quot;Responsible for execution_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Accountable for approving results_" type="EXPRESSION">EXPR expr:(maval(&quot;Accountable for approving results_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Accountable for approving results_" type="EXPRESSION">EXPR expr:(maval(&quot;Accountable for approving results_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Cooperation/participation_" type="EXPRESSION">EXPR expr:(maval(&quot;Cooperation/participation_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Cooperation/participation_" type="EXPRESSION">EXPR expr:(maval(&quot;Cooperation/participation_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_To inform_" type="EXPRESSION">EXPR expr:(maval(&quot;To inform_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_To inform_" type="EXPRESSION">EXPR expr:(maval(&quot;To inform_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<iNTERREF name="Responsible for execution"></iNTERREF>
+<iNTERREF name="To inform"></iNTERREF>
+<iNTERREF name="Cooperation/participation"></iNTERREF>
+<iNTERREF name="Accountable for approving results"></iNTERREF>
+<iNTERREF name="Incoming Data Object"></iNTERREF>
+<iNTERREF name="Outgoing Data Object"></iNTERREF>
+<aTTRIBUTE name="_size_Outgoing Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Outgoing Data Object_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Outgoing Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Outgoing Data Object_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_size_Incoming Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Incoming Data Object_size&quot;)) val:&quot;1&quot;</aTTRIBUTE>
+<aTTRIBUTE name="_disp_Incoming Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Incoming Data Object_display&quot;)) val:&quot;Yes&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Commentboxcomment" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="CommentAreaSizeExp" type="EXPRESSION">EXPR expr:(maval(&quot;CommentAreaSize&quot;)) val:&quot;2&quot;</aTTRIBUTE>
+<aTTRIBUTE name="CommentBool" type="ENUMERATION">0</aTTRIBUTE>
+<aTTRIBUTE name="CommentBox" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="CommentInfo" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="CommentMode" type="EXPRESSION">EXPR expr:(maval(&quot;Comment Mode&quot;)) val:&quot;No&quot;</aTTRIBUTE>
+<rECORD name="CommentTable"></rECORD>
+<aTTRIBUTE name="WriteComment" type="PROGRAMCALL">ITEM &quot;Add Comment&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="ClearComment" type="PROGRAMCALL">ITEM &quot;Clear Comment&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="CommentModellingAreaSizeExp" type="EXPRESSION">EXPR expr:(maval(&quot;CommentModellingAreaSize&quot;)) val:&quot;3&quot;</aTTRIBUTE>
+<aTTRIBUTE name="BoolCommentModeActive" type="EXPRESSION">EXPR expr:(maval(&quot;Comment Mode&quot;)) val:&quot;No&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Comment Model Direction" type="EXPRESSION">EXPR expr:(maval(&quot;CommentModellingDirection&quot;)) val:&quot;vertical&quot;</aTTRIBUTE>
+<iNTERREF name="Decision"></iNTERREF>
+<iNTERREF name="Referenced documents"></iNTERREF>
+<aTTRIBUTE name="Left border" type="EXPRESSION">EXPR
+ val:43.32</aTTRIBUTE>
+<iNTERREF name="Referenced Planning Table"></iNTERREF>
+<aTTRIBUTE name="Right border" type="EXPRESSION">EXPR
+ val:46.68</aTTRIBUTE>
+<aTTRIBUTE name="Show or Hide" type="ENUMERATION">Shown</aTTRIBUTE>
+<aTTRIBUTE name="Top border" type="EXPRESSION">EXPR
+ val:12.1</aTTRIBUTE>
+<aTTRIBUTE name="Bottom border" type="EXPRESSION">EXPR
+ val:13.9</aTTRIBUTE>
+<aTTRIBUTE name="X" type="EXPRESSION">EXPR
+ val:45</aTTRIBUTE>
+<aTTRIBUTE name="Y" type="EXPRESSION">EXPR
+ val:13</aTTRIBUTE>
+<aTTRIBUTE name="Change Visibility" type="PROGRAMCALL">ITEM &quot;Change Visibility&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Planning Table" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Bounding box" type="EXPRESSION">EXPR
+ val:&quot;[12.1,13.9,43.32,46.68,45,13]&quot;</aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16265" class="Exclusive Gateway" name="reject application?">
+<aTTRIBUTE name="Position" type="STRING">NODE x:19cm y:15cm index:12</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Variable type" type="ENUMERATION">enumeration</aTTRIBUTE>
+<aTTRIBUTE name="Variable scope" type="ENUMERATION">global</aTTRIBUTE>
+<aTTRIBUTE name="Variable name" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Variable value" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-02] Attribute \&quot;Fontcolor\&quot; (Lane) does not exist!  \&quot;fontcolor\&quot; (Exclusive Gateway)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<rECORD name="Technical Attributes"></rECORD>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Actor"></iNTERREF>
+<rECORD name="Assignments"></rECORD>
+<aTTRIBUTE name="Term" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING">Orig.Name = is Rejected?</aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Entscheidung</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Open questions" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Sum" type="EXPRESSION">EXPR
+ val:0</aTTRIBUTE>
+<aTTRIBUTE name="Type" type="ENUMERATION">Data-based (without marker)</aTTRIBUTE>
+<aTTRIBUTE name="Show name" type="ENUMERATION">below</aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16265&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Constraints" type="ENUMERATION">Unspecified</aTTRIBUTE>
+<rECORD name="Properties"></rECORD>
+<aTTRIBUTE name="Cardinality" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16268" class="Intermediate Event (boundary)" name="Intermediate Event (boundary)-83066">
+<aTTRIBUTE name="Position" type="STRING">NODE x:28.5cm y:14cm index:16</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(&quot;&quot;) val:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<rECORD name="Technical Attributes"></rECORD>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Actor"></iNTERREF>
+<rECORD name="Assignments"></rECORD>
+<aTTRIBUTE name="Term" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR expr:(&quot;&quot;) val:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING">first implementation: display events as buttons to trigger change of flow</aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING">further development:
+1) enhance BPMN meta model properties for events &gt; trigger/description
+2) display time gone for timer trigger
+
+</aTTRIBUTE>
+<aTTRIBUTE name="External documentation" type="PROGRAMCALL">ITEM &quot;&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Open questions" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Auslöser</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Referenced trigger"></iNTERREF>
+<aTTRIBUTE name="Modelling direction" type="EXPRESSION">EXPR expr:(&quot;&quot;) val:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Type" type="ENUMERATION">interrupting</aTTRIBUTE>
+<aTTRIBUTE name="Show name" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16268&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Message" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Timer" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Conditional" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Signal" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Escalation" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Error" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Compensation" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Parallel" type="ENUMERATION">No</aTTRIBUTE>
+<iNTERREF name="Referenced message"></iNTERREF>
+<aTTRIBUTE name="Cancel" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="cancelActivity" type="ENUMERATION">No</aTTRIBUTE>
+<rECORD name="Properties"></rECORD>
+<iNTERREF name="Attached to">
+<iREF type="objectreference" tmodeltype="Business process diagram (BPMN 2.0)" tmodelname="TitoloUnico_MontiAzzurrSUB" tmodelver="" tclassname="Sub-Process" tobjname="Manage of 3rd Party Admin"></iREF>
+</iNTERREF>
+<aTTRIBUTE name="Auditing" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Monitoring" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Cancel activity" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Collection" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Object type" type="ENUMERATION">Information</aTTRIBUTE>
+<aTTRIBUTE name="Cardinality" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Referenced activity"></iNTERREF>
+<aTTRIBUTE name="Details" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Timer type" type="ENUMERATION">Date</aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16271" class="Intermediate Event (boundary)" name="Intermediate Event (boundary)-83071">
+<aTTRIBUTE name="Position" type="STRING">NODE x:37cm y:14cm index:17</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(&quot;&quot;) val:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<rECORD name="Technical Attributes"></rECORD>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Actor"></iNTERREF>
+<rECORD name="Assignments"></rECORD>
+<aTTRIBUTE name="Term" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR expr:(&quot;&quot;) val:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="External documentation" type="PROGRAMCALL">ITEM &quot;&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Open questions" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Auslöser</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Referenced trigger"></iNTERREF>
+<aTTRIBUTE name="Modelling direction" type="EXPRESSION">EXPR expr:(&quot;&quot;) val:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Type" type="ENUMERATION">interrupting</aTTRIBUTE>
+<aTTRIBUTE name="Show name" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16271&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Message" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Timer" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Conditional" type="ENUMERATION">Yes</aTTRIBUTE>
+<aTTRIBUTE name="Signal" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Escalation" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Error" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Compensation" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Parallel" type="ENUMERATION">No</aTTRIBUTE>
+<iNTERREF name="Referenced message"></iNTERREF>
+<aTTRIBUTE name="Cancel" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="cancelActivity" type="ENUMERATION">No</aTTRIBUTE>
+<rECORD name="Properties"></rECORD>
+<iNTERREF name="Attached to">
+<iREF type="objectreference" tmodeltype="Business process diagram (BPMN 2.0)" tmodelname="TitoloUnico_MontiAzzurrSUB" tmodelver="" tclassname="Sub-Process" tobjname="Check Integration"></iREF>
+</iNTERREF>
+<aTTRIBUTE name="Auditing" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Monitoring" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Cancel activity" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Collection" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Object type" type="ENUMERATION">Information</aTTRIBUTE>
+<aTTRIBUTE name="Cardinality" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Referenced activity"></iNTERREF>
+<aTTRIBUTE name="Details" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Timer type" type="ENUMERATION">Date</aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16274" class="Exclusive Gateway" name="integration necessary?">
+<aTTRIBUTE name="Position" type="STRING">NODE x:31.5cm y:13cm index:18</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Variable type" type="ENUMERATION">enumeration</aTTRIBUTE>
+<aTTRIBUTE name="Variable scope" type="ENUMERATION">global</aTTRIBUTE>
+<aTTRIBUTE name="Variable name" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Variable value" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-02] Attribute \&quot;Fontcolor\&quot; (Lane) does not exist!  \&quot;fontcolor\&quot; (Exclusive Gateway)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<rECORD name="Technical Attributes"></rECORD>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Actor"></iNTERREF>
+<rECORD name="Assignments"></rECORD>
+<aTTRIBUTE name="Term" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Entscheidung</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Open questions" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Sum" type="EXPRESSION">EXPR
+ val:0</aTTRIBUTE>
+<aTTRIBUTE name="Type" type="ENUMERATION">Data-based (without marker)</aTTRIBUTE>
+<aTTRIBUTE name="Show name" type="ENUMERATION">below</aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16274&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Constraints" type="ENUMERATION">Unspecified</aTTRIBUTE>
+<rECORD name="Properties"></rECORD>
+<aTTRIBUTE name="Cardinality" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16277" class="End Event" name="End Event-83081">
+<aTTRIBUTE name="Position" type="STRING">NODE x:49cm y:13cm index:19</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Type" type="ENUMERATION">local</aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-02] Attribute \&quot;Fontcolor\&quot; (Lane) does not exist!  \&quot;fontcolor\&quot; (End Event)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<rECORD name="Technical Attributes"></rECORD>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Actor"></iNTERREF>
+<aTTRIBUTE name="Representation" type="ENUMERATION">without name</aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Ende</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Show name" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Open questions" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16277&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Message" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Signal" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Escalation" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Error" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Compensation" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Terminate" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Cancel" type="ENUMERATION">No</aTTRIBUTE>
+<rECORD name="Properties"></rECORD>
+<aTTRIBUTE name="Auditing" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Monitoring" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Collection" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Object type" type="ENUMERATION">Information</aTTRIBUTE>
+<aTTRIBUTE name="Cardinality" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Details" type="LONGSTRING"></aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16280" class="Exclusive Gateway" name="manage conf directly?">
+<aTTRIBUTE name="Position" type="STRING">NODE x:22.5cm y:15cm index:21</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Variable type" type="ENUMERATION">enumeration</aTTRIBUTE>
+<aTTRIBUTE name="Variable scope" type="ENUMERATION">global</aTTRIBUTE>
+<aTTRIBUTE name="Variable name" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Variable value" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-02] Attribute \&quot;Fontcolor\&quot; (Lane) does not exist!  \&quot;fontcolor\&quot; (Exclusive Gateway)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<rECORD name="Technical Attributes"></rECORD>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Actor"></iNTERREF>
+<rECORD name="Assignments"></rECORD>
+<aTTRIBUTE name="Term" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Entscheidung</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Open questions" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Sum" type="EXPRESSION">EXPR
+ val:0</aTTRIBUTE>
+<aTTRIBUTE name="Type" type="ENUMERATION">Data-based (without marker)</aTTRIBUTE>
+<aTTRIBUTE name="Show name" type="ENUMERATION">below</aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16280&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Constraints" type="ENUMERATION">Unspecified</aTTRIBUTE>
+<rECORD name="Properties"></rECORD>
+<aTTRIBUTE name="Cardinality" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16283" class="Exclusive Gateway" name="Exclusive Gateway-83095">
+<aTTRIBUTE name="Position" type="STRING">NODE x:22.5cm y:19cm index:24</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Variable type" type="ENUMERATION">enumeration</aTTRIBUTE>
+<aTTRIBUTE name="Variable scope" type="ENUMERATION">global</aTTRIBUTE>
+<aTTRIBUTE name="Variable name" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Variable value" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-02] Attribute \&quot;Fontcolor\&quot; (Lane) does not exist!  \&quot;fontcolor\&quot; (Exclusive Gateway)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<rECORD name="Technical Attributes"></rECORD>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Actor"></iNTERREF>
+<rECORD name="Assignments"></rECORD>
+<aTTRIBUTE name="Term" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Entscheidung</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Open questions" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Sum" type="EXPRESSION">EXPR
+ val:0</aTTRIBUTE>
+<aTTRIBUTE name="Type" type="ENUMERATION">Data-based (without marker)</aTTRIBUTE>
+<aTTRIBUTE name="Show name" type="ENUMERATION">do not show</aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16283&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Constraints" type="ENUMERATION">Unspecified</aTTRIBUTE>
+<rECORD name="Properties"></rECORD>
+<aTTRIBUTE name="Cardinality" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16286" class="Exclusive Gateway" name="is decision taken?">
+<aTTRIBUTE name="Position" type="STRING">NODE x:40.5cm y:13cm index:32</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Variable type" type="ENUMERATION">enumeration</aTTRIBUTE>
+<aTTRIBUTE name="Variable scope" type="ENUMERATION">global</aTTRIBUTE>
+<aTTRIBUTE name="Variable name" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Variable value" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-02] Attribute \&quot;Fontcolor\&quot; (Lane) does not exist!  \&quot;fontcolor\&quot; (Exclusive Gateway)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<rECORD name="Technical Attributes"></rECORD>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<iNTERREF name="Actor"></iNTERREF>
+<rECORD name="Assignments"></rECORD>
+<aTTRIBUTE name="Term" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Order" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Entscheidung</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Open questions" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Sum" type="EXPRESSION">EXPR
+ val:0</aTTRIBUTE>
+<aTTRIBUTE name="Type" type="ENUMERATION">Data-based (without marker)</aTTRIBUTE>
+<aTTRIBUTE name="Show name" type="ENUMERATION">below</aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16286&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Constraints" type="ENUMERATION">Unspecified</aTTRIBUTE>
+<rECORD name="Properties"></rECORD>
+<aTTRIBUTE name="Cardinality" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<iNSTANCE id="obj.16289" class="Data Object" name="Titolo Unico">
+<aTTRIBUTE name="Position" type="STRING">NODE x:45cm y:16.5cm index:40</aTTRIBUTE>
+<aTTRIBUTE name="External tool coupling" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(&quot;&quot;) val:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<rECORD name="Technical Attributes"></rECORD>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Collection" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Open questions" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Data type" type="ENUMERATION">Data Output</aTTRIBUTE>
+<iNTERREF name="Referenced input data (optional)"></iNTERREF>
+<iNTERREF name="Referenced input data (while executing)"></iNTERREF>
+<aTTRIBUTE name="Collection (input)" type="ENUMERATION">No</aTTRIBUTE>
+<iNTERREF name="Referenced output data (optional)">
+<iREF type="objectreference" tmodeltype="Document and Knowledge model" tmodelname="Document and Knowledge model TitoloUnico" tmodelver="" tclassname="Document" tobjname="Titolo Unico Authorization Document"></iREF>
+</iNTERREF>
+<iNTERREF name="Referenced output data (while executing)"></iNTERREF>
+<aTTRIBUTE name="Collection (output)" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Capacity" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Unlimited" type="ENUMERATION">No</aTTRIBUTE>
+<iNTERREF name="Referenced data store (global)"></iNTERREF>
+<aTTRIBUTE name="Auditing" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Monitoring" type="ENUMERATION">No</aTTRIBUTE>
+<rECORD name="Properties"></rECORD>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16289&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Cardinality" type="STRING"></aTTRIBUTE>
+</iNSTANCE>
+<cONNECTOR id="con.16292" class="Message Flow">
+<fROM instance="Entrepreneur" class="Pool (collapsed)"></fROM>
+<tO instance="Start Event-83017" class="Start Event"></tO>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 1 x1:7cm y1:5cm index:38</aTTRIBUTE>
+<aTTRIBUTE name="Message Name" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="ParticipantType (from)" type="ENUMERATION">Role</aTTRIBUTE>
+<aTTRIBUTE name="Role (from)" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Entity (from)" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="ParticipantType (to)" type="ENUMERATION">Role</aTTRIBUTE>
+<aTTRIBUTE name="Role (to)" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Entity (to)" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Name" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Message Properties" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;Start Event&quot;</aTTRIBUTE>
+<aTTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Pool (collapsed)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Number" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Show Name" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Show Number" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Representation" type="ENUMERATION">above/below</aTTRIBUTE>
+<aTTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Description" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Show name" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Doku" type="STRING">NOTEBOOK
+
+#-----------------------
+CHAPTER &quot;Description&quot;
+#-----------------------
+ATTR &quot;Name&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+ATTR &quot;Id&quot; </aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16292&quot;</aTTRIBUTE>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16293" class="Is inside">
+<fROM instance="Office SUAP" class="Lane"></fROM>
+<tO instance="Monti Azzurri Consorsium" class="Pool"></tO>
+<aTTRIBUTE name="AutoConnect" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16294" class="Is inside">
+<fROM instance="Start Event-83017" class="Start Event"></fROM>
+<tO instance="Monti Azzurri Consorsium" class="Pool"></tO>
+<aTTRIBUTE name="AutoConnect" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16295" class="Is inside">
+<fROM instance="Start Event-83017" class="Start Event"></fROM>
+<tO instance="Office SUAP" class="Lane"></tO>
+<aTTRIBUTE name="AutoConnect" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16296" class="Subsequent">
+<fROM instance="Start Event-83017" class="Start Event"></fROM>
+<tO instance="Receive Instance" class="Sub-Process"></tO>
+<aTTRIBUTE name="Transition condition" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Transition probability" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualized values" type="ENUMERATION">Denomination</aTTRIBUTE>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 0 index:13</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">1</aTTRIBUTE>
+<aTTRIBUTE name="Representation" type="ENUMERATION">above/below</aTTRIBUTE>
+<aTTRIBUTE name="Font colour" type="ENUMERATION">black</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Info zur Übergangsbedingung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Nachfolger</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Denomination" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Description" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Auditing" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Monitoring" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Default" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Immediate" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Category" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16296&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Color" type="STRING">black</aTTRIBUTE>
+<aTTRIBUTE name="Doku" type="STRING">NOTEBOOK
+
+#-----------------------
+LANG &quot;en&quot;
+#-----------------------
+CHAPTER &quot;Description&quot;
+ATTR &quot;Denomination&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+
+
+CHAPTER &quot;Details (BPMN)&quot;
+
+ATTR &quot;Auditing&quot; 
+ATTR &quot;Monitoring&quot; 
+
+ATTR &quot;Default&quot; 
+ATTR &quot;Immediate&quot; 
+ATTR &quot;Category&quot;
+ATTR &quot;Id&quot; 
+
+
+CHAPTER &quot;Details (Simulation)&quot;
+
+ATTR &quot;Transition condition&quot; dialog:transcond
+
+ATTR &quot;Transition probability&quot;
+
+</aTTRIBUTE>
+<aTTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;Sub-Process&quot;</aTTRIBUTE>
+<aTTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Start Event&quot;</aTTRIBUTE>
+<aTTRIBUTE name="ModelTypeExp" type="EXPRESSION">EXPR val:&quot;Business process diagram (BPMN 2.0)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16297" class="Is inside">
+<fROM instance="Receive Instance" class="Sub-Process"></fROM>
+<tO instance="Monti Azzurri Consorsium" class="Pool"></tO>
+<aTTRIBUTE name="AutoConnect" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16298" class="Is inside">
+<fROM instance="Receive Instance" class="Sub-Process"></fROM>
+<tO instance="Office SUAP" class="Lane"></tO>
+<aTTRIBUTE name="AutoConnect" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16299" class="Subsequent">
+<fROM instance="Receive Instance" class="Sub-Process"></fROM>
+<tO instance="Assess Application" class="Sub-Process"></tO>
+<aTTRIBUTE name="Transition condition" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Transition probability" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualized values" type="ENUMERATION">Denomination</aTTRIBUTE>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 0 index:14</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">2</aTTRIBUTE>
+<aTTRIBUTE name="Representation" type="ENUMERATION">above/below</aTTRIBUTE>
+<aTTRIBUTE name="Font colour" type="ENUMERATION">black</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Info zur Übergangsbedingung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Nachfolger</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Denomination" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Description" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Auditing" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Monitoring" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Default" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Immediate" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Category" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16299&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Color" type="STRING">black</aTTRIBUTE>
+<aTTRIBUTE name="Doku" type="STRING">NOTEBOOK
+
+#-----------------------
+LANG &quot;en&quot;
+#-----------------------
+CHAPTER &quot;Description&quot;
+ATTR &quot;Denomination&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+
+
+CHAPTER &quot;Details (BPMN)&quot;
+
+ATTR &quot;Auditing&quot; 
+ATTR &quot;Monitoring&quot; 
+
+ATTR &quot;Default&quot; 
+ATTR &quot;Immediate&quot; 
+ATTR &quot;Category&quot;
+ATTR &quot;Id&quot; 
+
+
+CHAPTER &quot;Details (Simulation)&quot;
+
+ATTR &quot;Transition condition&quot; dialog:transcond
+
+ATTR &quot;Transition probability&quot;
+
+</aTTRIBUTE>
+<aTTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;Sub-Process&quot;</aTTRIBUTE>
+<aTTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Sub-Process&quot;</aTTRIBUTE>
+<aTTRIBUTE name="ModelTypeExp" type="EXPRESSION">EXPR val:&quot;Business process diagram (BPMN 2.0)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16300" class="Is inside">
+<fROM instance="Assess Application" class="Sub-Process"></fROM>
+<tO instance="Monti Azzurri Consorsium" class="Pool"></tO>
+<aTTRIBUTE name="AutoConnect" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16301" class="Is inside">
+<fROM instance="Assess Application" class="Sub-Process"></fROM>
+<tO instance="Office SUAP" class="Lane"></tO>
+<aTTRIBUTE name="AutoConnect" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16302" class="Subsequent">
+<fROM instance="Assess Application" class="Sub-Process"></fROM>
+<tO instance="reject application?" class="Exclusive Gateway"></tO>
+<aTTRIBUTE name="Transition condition" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Transition probability" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualized values" type="ENUMERATION">Denomination</aTTRIBUTE>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 0 index:15</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">3</aTTRIBUTE>
+<aTTRIBUTE name="Representation" type="ENUMERATION">above/below</aTTRIBUTE>
+<aTTRIBUTE name="Font colour" type="ENUMERATION">black</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Info zur Übergangsbedingung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Nachfolger</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Denomination" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Description" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Auditing" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Monitoring" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Default" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Immediate" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Category" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16302&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Color" type="STRING">black</aTTRIBUTE>
+<aTTRIBUTE name="Doku" type="STRING">NOTEBOOK
+
+#-----------------------
+LANG &quot;en&quot;
+#-----------------------
+CHAPTER &quot;Description&quot;
+ATTR &quot;Denomination&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+
+
+CHAPTER &quot;Details (BPMN)&quot;
+
+ATTR &quot;Auditing&quot; 
+ATTR &quot;Monitoring&quot; 
+
+ATTR &quot;Default&quot; 
+ATTR &quot;Immediate&quot; 
+ATTR &quot;Category&quot;
+ATTR &quot;Id&quot; 
+
+
+CHAPTER &quot;Details (Simulation)&quot;
+
+ATTR &quot;Transition condition&quot; dialog:transcond
+
+ATTR &quot;Transition probability&quot;
+
+</aTTRIBUTE>
+<aTTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;Exclusive Gateway&quot;</aTTRIBUTE>
+<aTTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Sub-Process&quot;</aTTRIBUTE>
+<aTTRIBUTE name="ModelTypeExp" type="EXPRESSION">EXPR val:&quot;Business process diagram (BPMN 2.0)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16303" class="Is inside">
+<fROM instance="Manage of 3rd Party Admin" class="Sub-Process"></fROM>
+<tO instance="Monti Azzurri Consorsium" class="Pool"></tO>
+<aTTRIBUTE name="AutoConnect" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16304" class="Is inside">
+<fROM instance="Manage of 3rd Party Admin" class="Sub-Process"></fROM>
+<tO instance="Office SUAP" class="Lane"></tO>
+<aTTRIBUTE name="AutoConnect" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16305" class="Subsequent">
+<fROM instance="Manage of 3rd Party Admin" class="Sub-Process"></fROM>
+<tO instance="integration necessary?" class="Exclusive Gateway"></tO>
+<aTTRIBUTE name="Transition condition" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Transition probability" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualized values" type="ENUMERATION">Denomination</aTTRIBUTE>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 0 index:29</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">11</aTTRIBUTE>
+<aTTRIBUTE name="Representation" type="ENUMERATION">above/below</aTTRIBUTE>
+<aTTRIBUTE name="Font colour" type="ENUMERATION">black</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Info zur Übergangsbedingung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Nachfolger</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Denomination" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Description" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Auditing" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Monitoring" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Default" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Immediate" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Category" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16305&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Color" type="STRING">black</aTTRIBUTE>
+<aTTRIBUTE name="Doku" type="STRING">NOTEBOOK
+
+#-----------------------
+LANG &quot;en&quot;
+#-----------------------
+CHAPTER &quot;Description&quot;
+ATTR &quot;Denomination&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+
+
+CHAPTER &quot;Details (BPMN)&quot;
+
+ATTR &quot;Auditing&quot; 
+ATTR &quot;Monitoring&quot; 
+
+ATTR &quot;Default&quot; 
+ATTR &quot;Immediate&quot; 
+ATTR &quot;Category&quot;
+ATTR &quot;Id&quot; 
+
+
+CHAPTER &quot;Details (Simulation)&quot;
+
+ATTR &quot;Transition condition&quot; dialog:transcond
+
+ATTR &quot;Transition probability&quot;
+
+</aTTRIBUTE>
+<aTTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;Exclusive Gateway&quot;</aTTRIBUTE>
+<aTTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Sub-Process&quot;</aTTRIBUTE>
+<aTTRIBUTE name="ModelTypeExp" type="EXPRESSION">EXPR val:&quot;Business process diagram (BPMN 2.0)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16306" class="Is inside">
+<fROM instance="Manage Service Conference" class="Sub-Process"></fROM>
+<tO instance="Monti Azzurri Consorsium" class="Pool"></tO>
+<aTTRIBUTE name="AutoConnect" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16307" class="Is inside">
+<fROM instance="Manage Service Conference" class="Sub-Process"></fROM>
+<tO instance="Office SUAP" class="Lane"></tO>
+<aTTRIBUTE name="AutoConnect" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16308" class="Subsequent">
+<fROM instance="Manage Service Conference" class="Sub-Process"></fROM>
+<tO instance="integration necessary?" class="Exclusive Gateway"></tO>
+<aTTRIBUTE name="Transition condition" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Transition probability" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualized values" type="ENUMERATION">Denomination</aTTRIBUTE>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 1 x1:31.5cm y1:21.5cm index:28</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">10</aTTRIBUTE>
+<aTTRIBUTE name="Representation" type="ENUMERATION">above/below</aTTRIBUTE>
+<aTTRIBUTE name="Font colour" type="ENUMERATION">black</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Info zur Übergangsbedingung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Nachfolger</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Denomination" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Description" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Auditing" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Monitoring" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Default" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Immediate" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Category" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16308&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Color" type="STRING">black</aTTRIBUTE>
+<aTTRIBUTE name="Doku" type="STRING">NOTEBOOK
+
+#-----------------------
+LANG &quot;en&quot;
+#-----------------------
+CHAPTER &quot;Description&quot;
+ATTR &quot;Denomination&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+
+
+CHAPTER &quot;Details (BPMN)&quot;
+
+ATTR &quot;Auditing&quot; 
+ATTR &quot;Monitoring&quot; 
+
+ATTR &quot;Default&quot; 
+ATTR &quot;Immediate&quot; 
+ATTR &quot;Category&quot;
+ATTR &quot;Id&quot; 
+
+
+CHAPTER &quot;Details (Simulation)&quot;
+
+ATTR &quot;Transition condition&quot; dialog:transcond
+
+ATTR &quot;Transition probability&quot;
+
+</aTTRIBUTE>
+<aTTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;Exclusive Gateway&quot;</aTTRIBUTE>
+<aTTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Sub-Process&quot;</aTTRIBUTE>
+<aTTRIBUTE name="ModelTypeExp" type="EXPRESSION">EXPR val:&quot;Business process diagram (BPMN 2.0)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16309" class="Is inside">
+<fROM instance="Check Integration" class="Sub-Process"></fROM>
+<tO instance="Monti Azzurri Consorsium" class="Pool"></tO>
+<aTTRIBUTE name="AutoConnect" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16310" class="Is inside">
+<fROM instance="Check Integration" class="Sub-Process"></fROM>
+<tO instance="Office SUAP" class="Lane"></tO>
+<aTTRIBUTE name="AutoConnect" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16311" class="Subsequent">
+<fROM instance="Check Integration" class="Sub-Process"></fROM>
+<tO instance="is decision taken?" class="Exclusive Gateway"></tO>
+<aTTRIBUTE name="Transition condition" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Transition probability" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualized values" type="ENUMERATION">Denomination</aTTRIBUTE>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 0 index:33</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">14</aTTRIBUTE>
+<aTTRIBUTE name="Representation" type="ENUMERATION">above/below</aTTRIBUTE>
+<aTTRIBUTE name="Font colour" type="ENUMERATION">black</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Info zur Übergangsbedingung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Nachfolger</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Denomination" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Description" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Auditing" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Monitoring" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Default" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Immediate" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Category" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16311&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Color" type="STRING">black</aTTRIBUTE>
+<aTTRIBUTE name="Doku" type="STRING">NOTEBOOK
+
+#-----------------------
+LANG &quot;en&quot;
+#-----------------------
+CHAPTER &quot;Description&quot;
+ATTR &quot;Denomination&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+
+
+CHAPTER &quot;Details (BPMN)&quot;
+
+ATTR &quot;Auditing&quot; 
+ATTR &quot;Monitoring&quot; 
+
+ATTR &quot;Default&quot; 
+ATTR &quot;Immediate&quot; 
+ATTR &quot;Category&quot;
+ATTR &quot;Id&quot; 
+
+
+CHAPTER &quot;Details (Simulation)&quot;
+
+ATTR &quot;Transition condition&quot; dialog:transcond
+
+ATTR &quot;Transition probability&quot;
+
+</aTTRIBUTE>
+<aTTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;Exclusive Gateway&quot;</aTTRIBUTE>
+<aTTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Sub-Process&quot;</aTTRIBUTE>
+<aTTRIBUTE name="ModelTypeExp" type="EXPRESSION">EXPR val:&quot;Business process diagram (BPMN 2.0)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16312" class="Is inside">
+<fROM instance="Manage Inhibition" class="Sub-Process"></fROM>
+<tO instance="Monti Azzurri Consorsium" class="Pool"></tO>
+<aTTRIBUTE name="AutoConnect" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16313" class="Is inside">
+<fROM instance="Manage Inhibition" class="Sub-Process"></fROM>
+<tO instance="Office SUAP" class="Lane"></tO>
+<aTTRIBUTE name="AutoConnect" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16314" class="Subsequent">
+<fROM instance="Manage Inhibition" class="Sub-Process"></fROM>
+<tO instance="End Event-83081" class="End Event"></tO>
+<aTTRIBUTE name="Transition condition" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Transition probability" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualized values" type="ENUMERATION">Denomination</aTTRIBUTE>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 1 x1:49cm y1:21.5cm index:36</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">17</aTTRIBUTE>
+<aTTRIBUTE name="Representation" type="ENUMERATION">above/below</aTTRIBUTE>
+<aTTRIBUTE name="Font colour" type="ENUMERATION">black</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Info zur Übergangsbedingung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Nachfolger</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Denomination" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Description" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Auditing" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Monitoring" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Default" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Immediate" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Category" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16314&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Color" type="STRING">black</aTTRIBUTE>
+<aTTRIBUTE name="Doku" type="STRING">NOTEBOOK
+
+#-----------------------
+LANG &quot;en&quot;
+#-----------------------
+CHAPTER &quot;Description&quot;
+ATTR &quot;Denomination&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+
+
+CHAPTER &quot;Details (BPMN)&quot;
+
+ATTR &quot;Auditing&quot; 
+ATTR &quot;Monitoring&quot; 
+
+ATTR &quot;Default&quot; 
+ATTR &quot;Immediate&quot; 
+ATTR &quot;Category&quot;
+ATTR &quot;Id&quot; 
+
+
+CHAPTER &quot;Details (Simulation)&quot;
+
+ATTR &quot;Transition condition&quot; dialog:transcond
+
+ATTR &quot;Transition probability&quot;
+
+</aTTRIBUTE>
+<aTTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;End Event&quot;</aTTRIBUTE>
+<aTTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Sub-Process&quot;</aTTRIBUTE>
+<aTTRIBUTE name="ModelTypeExp" type="EXPRESSION">EXPR val:&quot;Business process diagram (BPMN 2.0)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16315" class="Is inside">
+<fROM instance="Send Authorization Document" class="Task"></fROM>
+<tO instance="Monti Azzurri Consorsium" class="Pool"></tO>
+<aTTRIBUTE name="AutoConnect" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16316" class="Is inside">
+<fROM instance="Send Authorization Document" class="Task"></fROM>
+<tO instance="Office SUAP" class="Lane"></tO>
+<aTTRIBUTE name="AutoConnect" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16317" class="Message Flow">
+<fROM instance="Send Authorization Document" class="Task"></fROM>
+<tO instance="Entrepreneur" class="Pool (collapsed)"></tO>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 1 x1:45cm y1:5cm index:39</aTTRIBUTE>
+<aTTRIBUTE name="Message Name" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="ParticipantType (from)" type="ENUMERATION">Role</aTTRIBUTE>
+<aTTRIBUTE name="Role (from)" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Entity (from)" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="ParticipantType (to)" type="ENUMERATION">Role</aTTRIBUTE>
+<aTTRIBUTE name="Role (to)" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Entity (to)" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Categories" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Documentation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Name" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Message Properties" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;Pool (collapsed)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Task&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Number" type="INTEGER">0</aTTRIBUTE>
+<aTTRIBUTE name="Show Name" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Show Number" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Representation" type="ENUMERATION">above/below</aTTRIBUTE>
+<aTTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Description" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Show name" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Doku" type="STRING">NOTEBOOK
+
+#-----------------------
+CHAPTER &quot;Description&quot;
+#-----------------------
+ATTR &quot;Name&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+ATTR &quot;Id&quot; </aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16317&quot;</aTTRIBUTE>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16318" class="Subsequent">
+<fROM instance="Send Authorization Document" class="Task"></fROM>
+<tO instance="End Event-83081" class="End Event"></tO>
+<aTTRIBUTE name="Transition condition" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Transition probability" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualized values" type="ENUMERATION">Denomination</aTTRIBUTE>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 0 index:42</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">19</aTTRIBUTE>
+<aTTRIBUTE name="Representation" type="ENUMERATION">above/below</aTTRIBUTE>
+<aTTRIBUTE name="Font colour" type="ENUMERATION">black</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Info zur Übergangsbedingung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Nachfolger</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Denomination" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Description" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Auditing" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Monitoring" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Default" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Immediate" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Category" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16318&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Color" type="STRING">black</aTTRIBUTE>
+<aTTRIBUTE name="Doku" type="STRING">NOTEBOOK
+
+#-----------------------
+LANG &quot;en&quot;
+#-----------------------
+CHAPTER &quot;Description&quot;
+ATTR &quot;Denomination&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+
+
+CHAPTER &quot;Details (BPMN)&quot;
+
+ATTR &quot;Auditing&quot; 
+ATTR &quot;Monitoring&quot; 
+
+ATTR &quot;Default&quot; 
+ATTR &quot;Immediate&quot; 
+ATTR &quot;Category&quot;
+ATTR &quot;Id&quot; 
+
+
+CHAPTER &quot;Details (Simulation)&quot;
+
+ATTR &quot;Transition condition&quot; dialog:transcond
+
+ATTR &quot;Transition probability&quot;
+
+</aTTRIBUTE>
+<aTTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;End Event&quot;</aTTRIBUTE>
+<aTTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Task&quot;</aTTRIBUTE>
+<aTTRIBUTE name="ModelTypeExp" type="EXPRESSION">EXPR val:&quot;Business process diagram (BPMN 2.0)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16319" class="Is inside">
+<fROM instance="reject application?" class="Exclusive Gateway"></fROM>
+<tO instance="Monti Azzurri Consorsium" class="Pool"></tO>
+<aTTRIBUTE name="AutoConnect" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16320" class="Is inside">
+<fROM instance="reject application?" class="Exclusive Gateway"></fROM>
+<tO instance="Office SUAP" class="Lane"></tO>
+<aTTRIBUTE name="AutoConnect" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16321" class="Subsequent">
+<fROM instance="reject application?" class="Exclusive Gateway"></fROM>
+<tO instance="End Event-83081" class="End Event"></tO>
+<aTTRIBUTE name="Transition condition" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Transition probability" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualized values" type="ENUMERATION">Denomination</aTTRIBUTE>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 2 x1:19cm y1:10cm x2:49cm y2:10cm index:20</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">4</aTTRIBUTE>
+<aTTRIBUTE name="Representation" type="ENUMERATION">above/below</aTTRIBUTE>
+<aTTRIBUTE name="Font colour" type="ENUMERATION">black</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Info zur Übergangsbedingung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Nachfolger</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Denomination" type="STRING">yes</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Auditing" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Monitoring" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Default" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Immediate" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Category" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16321&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Color" type="STRING">black</aTTRIBUTE>
+<aTTRIBUTE name="Doku" type="STRING">NOTEBOOK
+
+#-----------------------
+LANG &quot;en&quot;
+#-----------------------
+CHAPTER &quot;Description&quot;
+ATTR &quot;Denomination&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+
+
+CHAPTER &quot;Details (BPMN)&quot;
+
+ATTR &quot;Auditing&quot; 
+ATTR &quot;Monitoring&quot; 
+
+ATTR &quot;Default&quot; 
+ATTR &quot;Immediate&quot; 
+ATTR &quot;Category&quot;
+ATTR &quot;Id&quot; 
+
+
+CHAPTER &quot;Details (Simulation)&quot;
+
+ATTR &quot;Transition condition&quot; dialog:transcond
+
+ATTR &quot;Transition probability&quot;
+
+</aTTRIBUTE>
+<aTTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;End Event&quot;</aTTRIBUTE>
+<aTTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Exclusive Gateway&quot;</aTTRIBUTE>
+<aTTRIBUTE name="ModelTypeExp" type="EXPRESSION">EXPR val:&quot;Business process diagram (BPMN 2.0)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16322" class="Subsequent">
+<fROM instance="reject application?" class="Exclusive Gateway"></fROM>
+<tO instance="manage conf directly?" class="Exclusive Gateway"></tO>
+<aTTRIBUTE name="Transition condition" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Transition probability" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualized values" type="ENUMERATION">Denomination</aTTRIBUTE>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 0 index:22</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">5</aTTRIBUTE>
+<aTTRIBUTE name="Representation" type="ENUMERATION">above/below</aTTRIBUTE>
+<aTTRIBUTE name="Font colour" type="ENUMERATION">black</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Info zur Übergangsbedingung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Nachfolger</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Denomination" type="STRING">no</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Auditing" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Monitoring" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Default" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Immediate" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Category" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16322&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Color" type="STRING">black</aTTRIBUTE>
+<aTTRIBUTE name="Doku" type="STRING">NOTEBOOK
+
+#-----------------------
+LANG &quot;en&quot;
+#-----------------------
+CHAPTER &quot;Description&quot;
+ATTR &quot;Denomination&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+
+
+CHAPTER &quot;Details (BPMN)&quot;
+
+ATTR &quot;Auditing&quot; 
+ATTR &quot;Monitoring&quot; 
+
+ATTR &quot;Default&quot; 
+ATTR &quot;Immediate&quot; 
+ATTR &quot;Category&quot;
+ATTR &quot;Id&quot; 
+
+
+CHAPTER &quot;Details (Simulation)&quot;
+
+ATTR &quot;Transition condition&quot; dialog:transcond
+
+ATTR &quot;Transition probability&quot;
+
+</aTTRIBUTE>
+<aTTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;Exclusive Gateway&quot;</aTTRIBUTE>
+<aTTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Exclusive Gateway&quot;</aTTRIBUTE>
+<aTTRIBUTE name="ModelTypeExp" type="EXPRESSION">EXPR val:&quot;Business process diagram (BPMN 2.0)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16323" class="Is inside">
+<fROM instance="Intermediate Event (boundary)-83066" class="Intermediate Event (boundary)"></fROM>
+<tO instance="Monti Azzurri Consorsium" class="Pool"></tO>
+<aTTRIBUTE name="AutoConnect" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16324" class="Is inside">
+<fROM instance="Intermediate Event (boundary)-83066" class="Intermediate Event (boundary)"></fROM>
+<tO instance="Office SUAP" class="Lane"></tO>
+<aTTRIBUTE name="AutoConnect" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16325" class="Subsequent">
+<fROM instance="Intermediate Event (boundary)-83066" class="Intermediate Event (boundary)"></fROM>
+<tO instance="Exclusive Gateway-83095" class="Exclusive Gateway"></tO>
+<aTTRIBUTE name="Transition condition" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Transition probability" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualized values" type="ENUMERATION">Denomination</aTTRIBUTE>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 1 x1:28.5cm y1:19cm index:26</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">8</aTTRIBUTE>
+<aTTRIBUTE name="Representation" type="ENUMERATION">above/below</aTTRIBUTE>
+<aTTRIBUTE name="Font colour" type="ENUMERATION">black</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Info zur Übergangsbedingung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Nachfolger</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Denomination" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Description" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Auditing" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Monitoring" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Default" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Immediate" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Category" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16325&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Color" type="STRING">black</aTTRIBUTE>
+<aTTRIBUTE name="Doku" type="STRING">NOTEBOOK
+
+#-----------------------
+LANG &quot;en&quot;
+#-----------------------
+CHAPTER &quot;Description&quot;
+ATTR &quot;Denomination&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+
+
+CHAPTER &quot;Details (BPMN)&quot;
+
+ATTR &quot;Auditing&quot; 
+ATTR &quot;Monitoring&quot; 
+
+ATTR &quot;Default&quot; 
+ATTR &quot;Immediate&quot; 
+ATTR &quot;Category&quot;
+ATTR &quot;Id&quot; 
+
+
+CHAPTER &quot;Details (Simulation)&quot;
+
+ATTR &quot;Transition condition&quot; dialog:transcond
+
+ATTR &quot;Transition probability&quot;
+
+</aTTRIBUTE>
+<aTTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;Exclusive Gateway&quot;</aTTRIBUTE>
+<aTTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Intermediate Event (boundary)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="ModelTypeExp" type="EXPRESSION">EXPR val:&quot;Business process diagram (BPMN 2.0)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16326" class="Is inside">
+<fROM instance="Intermediate Event (boundary)-83071" class="Intermediate Event (boundary)"></fROM>
+<tO instance="Monti Azzurri Consorsium" class="Pool"></tO>
+<aTTRIBUTE name="AutoConnect" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16327" class="Is inside">
+<fROM instance="Intermediate Event (boundary)-83071" class="Intermediate Event (boundary)"></fROM>
+<tO instance="Office SUAP" class="Lane"></tO>
+<aTTRIBUTE name="AutoConnect" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16328" class="Subsequent">
+<fROM instance="Intermediate Event (boundary)-83071" class="Intermediate Event (boundary)"></fROM>
+<tO instance="Exclusive Gateway-83095" class="Exclusive Gateway"></tO>
+<aTTRIBUTE name="Transition condition" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Transition probability" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualized values" type="ENUMERATION">Denomination</aTTRIBUTE>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 1 x1:37cm y1:19cm index:30</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">12</aTTRIBUTE>
+<aTTRIBUTE name="Representation" type="ENUMERATION">above/below</aTTRIBUTE>
+<aTTRIBUTE name="Font colour" type="ENUMERATION">black</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Info zur Übergangsbedingung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Nachfolger</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Denomination" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Description" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Auditing" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Monitoring" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Default" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Immediate" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Category" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16328&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Color" type="STRING">black</aTTRIBUTE>
+<aTTRIBUTE name="Doku" type="STRING">NOTEBOOK
+
+#-----------------------
+LANG &quot;en&quot;
+#-----------------------
+CHAPTER &quot;Description&quot;
+ATTR &quot;Denomination&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+
+
+CHAPTER &quot;Details (BPMN)&quot;
+
+ATTR &quot;Auditing&quot; 
+ATTR &quot;Monitoring&quot; 
+
+ATTR &quot;Default&quot; 
+ATTR &quot;Immediate&quot; 
+ATTR &quot;Category&quot;
+ATTR &quot;Id&quot; 
+
+
+CHAPTER &quot;Details (Simulation)&quot;
+
+ATTR &quot;Transition condition&quot; dialog:transcond
+
+ATTR &quot;Transition probability&quot;
+
+</aTTRIBUTE>
+<aTTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;Exclusive Gateway&quot;</aTTRIBUTE>
+<aTTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Intermediate Event (boundary)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="ModelTypeExp" type="EXPRESSION">EXPR val:&quot;Business process diagram (BPMN 2.0)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16329" class="Is inside">
+<fROM instance="integration necessary?" class="Exclusive Gateway"></fROM>
+<tO instance="Monti Azzurri Consorsium" class="Pool"></tO>
+<aTTRIBUTE name="AutoConnect" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16330" class="Is inside">
+<fROM instance="integration necessary?" class="Exclusive Gateway"></fROM>
+<tO instance="Office SUAP" class="Lane"></tO>
+<aTTRIBUTE name="AutoConnect" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16331" class="Subsequent">
+<fROM instance="integration necessary?" class="Exclusive Gateway"></fROM>
+<tO instance="Check Integration" class="Sub-Process"></tO>
+<aTTRIBUTE name="Transition condition" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Transition probability" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualized values" type="ENUMERATION">Denomination</aTTRIBUTE>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 0 index:31</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">13</aTTRIBUTE>
+<aTTRIBUTE name="Representation" type="ENUMERATION">above/below</aTTRIBUTE>
+<aTTRIBUTE name="Font colour" type="ENUMERATION">black</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Info zur Übergangsbedingung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Nachfolger</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Denomination" type="STRING">yes</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Auditing" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Monitoring" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Default" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Immediate" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Category" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16331&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Color" type="STRING">black</aTTRIBUTE>
+<aTTRIBUTE name="Doku" type="STRING">NOTEBOOK
+
+#-----------------------
+LANG &quot;en&quot;
+#-----------------------
+CHAPTER &quot;Description&quot;
+ATTR &quot;Denomination&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+
+
+CHAPTER &quot;Details (BPMN)&quot;
+
+ATTR &quot;Auditing&quot; 
+ATTR &quot;Monitoring&quot; 
+
+ATTR &quot;Default&quot; 
+ATTR &quot;Immediate&quot; 
+ATTR &quot;Category&quot;
+ATTR &quot;Id&quot; 
+
+
+CHAPTER &quot;Details (Simulation)&quot;
+
+ATTR &quot;Transition condition&quot; dialog:transcond
+
+ATTR &quot;Transition probability&quot;
+
+</aTTRIBUTE>
+<aTTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;Sub-Process&quot;</aTTRIBUTE>
+<aTTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Exclusive Gateway&quot;</aTTRIBUTE>
+<aTTRIBUTE name="ModelTypeExp" type="EXPRESSION">EXPR val:&quot;Business process diagram (BPMN 2.0)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16332" class="Subsequent">
+<fROM instance="integration necessary?" class="Exclusive Gateway"></fROM>
+<tO instance="is decision taken?" class="Exclusive Gateway"></tO>
+<aTTRIBUTE name="Transition condition" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Transition probability" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualized values" type="ENUMERATION">Denomination</aTTRIBUTE>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 2 x1:31.5cm y1:11cm x2:40.5cm y2:11cm index:37</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">18</aTTRIBUTE>
+<aTTRIBUTE name="Representation" type="ENUMERATION">above/below</aTTRIBUTE>
+<aTTRIBUTE name="Font colour" type="ENUMERATION">black</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Info zur Übergangsbedingung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Nachfolger</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Denomination" type="STRING">no</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Auditing" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Monitoring" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Default" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Immediate" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Category" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16332&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Color" type="STRING">black</aTTRIBUTE>
+<aTTRIBUTE name="Doku" type="STRING">NOTEBOOK
+
+#-----------------------
+LANG &quot;en&quot;
+#-----------------------
+CHAPTER &quot;Description&quot;
+ATTR &quot;Denomination&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+
+
+CHAPTER &quot;Details (BPMN)&quot;
+
+ATTR &quot;Auditing&quot; 
+ATTR &quot;Monitoring&quot; 
+
+ATTR &quot;Default&quot; 
+ATTR &quot;Immediate&quot; 
+ATTR &quot;Category&quot;
+ATTR &quot;Id&quot; 
+
+
+CHAPTER &quot;Details (Simulation)&quot;
+
+ATTR &quot;Transition condition&quot; dialog:transcond
+
+ATTR &quot;Transition probability&quot;
+
+</aTTRIBUTE>
+<aTTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;Exclusive Gateway&quot;</aTTRIBUTE>
+<aTTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Exclusive Gateway&quot;</aTTRIBUTE>
+<aTTRIBUTE name="ModelTypeExp" type="EXPRESSION">EXPR val:&quot;Business process diagram (BPMN 2.0)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16333" class="Is inside">
+<fROM instance="End Event-83081" class="End Event"></fROM>
+<tO instance="Office SUAP" class="Lane"></tO>
+<aTTRIBUTE name="AutoConnect" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16334" class="Is inside">
+<fROM instance="End Event-83081" class="End Event"></fROM>
+<tO instance="Monti Azzurri Consorsium" class="Pool"></tO>
+<aTTRIBUTE name="AutoConnect" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16335" class="Is inside">
+<fROM instance="manage conf directly?" class="Exclusive Gateway"></fROM>
+<tO instance="Monti Azzurri Consorsium" class="Pool"></tO>
+<aTTRIBUTE name="AutoConnect" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16336" class="Is inside">
+<fROM instance="manage conf directly?" class="Exclusive Gateway"></fROM>
+<tO instance="Office SUAP" class="Lane"></tO>
+<aTTRIBUTE name="AutoConnect" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16337" class="Subsequent">
+<fROM instance="manage conf directly?" class="Exclusive Gateway"></fROM>
+<tO instance="Manage of 3rd Party Admin" class="Sub-Process"></tO>
+<aTTRIBUTE name="Transition condition" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Transition probability" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualized values" type="ENUMERATION">Denomination</aTTRIBUTE>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 1 x1:22.5cm y1:13cm index:23</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">6</aTTRIBUTE>
+<aTTRIBUTE name="Representation" type="ENUMERATION">above/below</aTTRIBUTE>
+<aTTRIBUTE name="Font colour" type="ENUMERATION">black</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Info zur Übergangsbedingung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Nachfolger</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Denomination" type="STRING">no</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Auditing" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Monitoring" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Default" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Immediate" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Category" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16337&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Color" type="STRING">black</aTTRIBUTE>
+<aTTRIBUTE name="Doku" type="STRING">NOTEBOOK
+
+#-----------------------
+LANG &quot;en&quot;
+#-----------------------
+CHAPTER &quot;Description&quot;
+ATTR &quot;Denomination&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+
+
+CHAPTER &quot;Details (BPMN)&quot;
+
+ATTR &quot;Auditing&quot; 
+ATTR &quot;Monitoring&quot; 
+
+ATTR &quot;Default&quot; 
+ATTR &quot;Immediate&quot; 
+ATTR &quot;Category&quot;
+ATTR &quot;Id&quot; 
+
+
+CHAPTER &quot;Details (Simulation)&quot;
+
+ATTR &quot;Transition condition&quot; dialog:transcond
+
+ATTR &quot;Transition probability&quot;
+
+</aTTRIBUTE>
+<aTTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;Sub-Process&quot;</aTTRIBUTE>
+<aTTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Exclusive Gateway&quot;</aTTRIBUTE>
+<aTTRIBUTE name="ModelTypeExp" type="EXPRESSION">EXPR val:&quot;Business process diagram (BPMN 2.0)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16338" class="Subsequent">
+<fROM instance="manage conf directly?" class="Exclusive Gateway"></fROM>
+<tO instance="Exclusive Gateway-83095" class="Exclusive Gateway"></tO>
+<aTTRIBUTE name="Transition condition" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Transition probability" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualized values" type="ENUMERATION">Denomination</aTTRIBUTE>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 0 index:25</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">7</aTTRIBUTE>
+<aTTRIBUTE name="Representation" type="ENUMERATION">above/below</aTTRIBUTE>
+<aTTRIBUTE name="Font colour" type="ENUMERATION">black</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Info zur Übergangsbedingung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Nachfolger</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Denomination" type="STRING">yes</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Auditing" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Monitoring" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Default" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Immediate" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Category" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16338&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Color" type="STRING">black</aTTRIBUTE>
+<aTTRIBUTE name="Doku" type="STRING">NOTEBOOK
+
+#-----------------------
+LANG &quot;en&quot;
+#-----------------------
+CHAPTER &quot;Description&quot;
+ATTR &quot;Denomination&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+
+
+CHAPTER &quot;Details (BPMN)&quot;
+
+ATTR &quot;Auditing&quot; 
+ATTR &quot;Monitoring&quot; 
+
+ATTR &quot;Default&quot; 
+ATTR &quot;Immediate&quot; 
+ATTR &quot;Category&quot;
+ATTR &quot;Id&quot; 
+
+
+CHAPTER &quot;Details (Simulation)&quot;
+
+ATTR &quot;Transition condition&quot; dialog:transcond
+
+ATTR &quot;Transition probability&quot;
+
+</aTTRIBUTE>
+<aTTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;Exclusive Gateway&quot;</aTTRIBUTE>
+<aTTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Exclusive Gateway&quot;</aTTRIBUTE>
+<aTTRIBUTE name="ModelTypeExp" type="EXPRESSION">EXPR val:&quot;Business process diagram (BPMN 2.0)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16339" class="Is inside">
+<fROM instance="Exclusive Gateway-83095" class="Exclusive Gateway"></fROM>
+<tO instance="Monti Azzurri Consorsium" class="Pool"></tO>
+<aTTRIBUTE name="AutoConnect" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16340" class="Is inside">
+<fROM instance="Exclusive Gateway-83095" class="Exclusive Gateway"></fROM>
+<tO instance="Office SUAP" class="Lane"></tO>
+<aTTRIBUTE name="AutoConnect" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16341" class="Subsequent">
+<fROM instance="Exclusive Gateway-83095" class="Exclusive Gateway"></fROM>
+<tO instance="Manage Service Conference" class="Sub-Process"></tO>
+<aTTRIBUTE name="Transition condition" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Transition probability" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualized values" type="ENUMERATION">Denomination</aTTRIBUTE>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 1 x1:22.5cm y1:21.5cm index:27</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">9</aTTRIBUTE>
+<aTTRIBUTE name="Representation" type="ENUMERATION">above/below</aTTRIBUTE>
+<aTTRIBUTE name="Font colour" type="ENUMERATION">black</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Info zur Übergangsbedingung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Nachfolger</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Denomination" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Description" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Auditing" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Monitoring" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Default" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Immediate" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Category" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16341&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Color" type="STRING">black</aTTRIBUTE>
+<aTTRIBUTE name="Doku" type="STRING">NOTEBOOK
+
+#-----------------------
+LANG &quot;en&quot;
+#-----------------------
+CHAPTER &quot;Description&quot;
+ATTR &quot;Denomination&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+
+
+CHAPTER &quot;Details (BPMN)&quot;
+
+ATTR &quot;Auditing&quot; 
+ATTR &quot;Monitoring&quot; 
+
+ATTR &quot;Default&quot; 
+ATTR &quot;Immediate&quot; 
+ATTR &quot;Category&quot;
+ATTR &quot;Id&quot; 
+
+
+CHAPTER &quot;Details (Simulation)&quot;
+
+ATTR &quot;Transition condition&quot; dialog:transcond
+
+ATTR &quot;Transition probability&quot;
+
+</aTTRIBUTE>
+<aTTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;Sub-Process&quot;</aTTRIBUTE>
+<aTTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Exclusive Gateway&quot;</aTTRIBUTE>
+<aTTRIBUTE name="ModelTypeExp" type="EXPRESSION">EXPR val:&quot;Business process diagram (BPMN 2.0)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16342" class="Is inside">
+<fROM instance="is decision taken?" class="Exclusive Gateway"></fROM>
+<tO instance="Monti Azzurri Consorsium" class="Pool"></tO>
+<aTTRIBUTE name="AutoConnect" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16343" class="Is inside">
+<fROM instance="is decision taken?" class="Exclusive Gateway"></fROM>
+<tO instance="Office SUAP" class="Lane"></tO>
+<aTTRIBUTE name="AutoConnect" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16344" class="Subsequent">
+<fROM instance="is decision taken?" class="Exclusive Gateway"></fROM>
+<tO instance="Send Authorization Document" class="Task"></tO>
+<aTTRIBUTE name="Transition condition" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Transition probability" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualized values" type="ENUMERATION">Denomination</aTTRIBUTE>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 0 index:34</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">15</aTTRIBUTE>
+<aTTRIBUTE name="Representation" type="ENUMERATION">above/below</aTTRIBUTE>
+<aTTRIBUTE name="Font colour" type="ENUMERATION">black</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Info zur Übergangsbedingung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Nachfolger</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Denomination" type="STRING">yes</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Auditing" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Monitoring" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Default" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Immediate" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Category" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16344&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Color" type="STRING">black</aTTRIBUTE>
+<aTTRIBUTE name="Doku" type="STRING">NOTEBOOK
+
+#-----------------------
+LANG &quot;en&quot;
+#-----------------------
+CHAPTER &quot;Description&quot;
+ATTR &quot;Denomination&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+
+
+CHAPTER &quot;Details (BPMN)&quot;
+
+ATTR &quot;Auditing&quot; 
+ATTR &quot;Monitoring&quot; 
+
+ATTR &quot;Default&quot; 
+ATTR &quot;Immediate&quot; 
+ATTR &quot;Category&quot;
+ATTR &quot;Id&quot; 
+
+
+CHAPTER &quot;Details (Simulation)&quot;
+
+ATTR &quot;Transition condition&quot; dialog:transcond
+
+ATTR &quot;Transition probability&quot;
+
+</aTTRIBUTE>
+<aTTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;Task&quot;</aTTRIBUTE>
+<aTTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Exclusive Gateway&quot;</aTTRIBUTE>
+<aTTRIBUTE name="ModelTypeExp" type="EXPRESSION">EXPR val:&quot;Business process diagram (BPMN 2.0)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16345" class="Subsequent">
+<fROM instance="is decision taken?" class="Exclusive Gateway"></fROM>
+<tO instance="Manage Inhibition" class="Sub-Process"></tO>
+<aTTRIBUTE name="Transition condition" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Transition probability" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualized values" type="ENUMERATION">Denomination</aTTRIBUTE>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 0 index:35</aTTRIBUTE>
+<aTTRIBUTE name="VisibleAttrs" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Visualization" type="ENUMERATION">RELATION</aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Connector number" type="INTEGER">16</aTTRIBUTE>
+<aTTRIBUTE name="Representation" type="ENUMERATION">above/below</aTTRIBUTE>
+<aTTRIBUTE name="Font colour" type="ENUMERATION">black</aTTRIBUTE>
+<aTTRIBUTE name="Kommentar" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Info zur Übergangsbedingung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Bezeichnung" type="STRING">Nachfolger</aTTRIBUTE>
+<aTTRIBUTE name="Beschreibung" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Denomination" type="STRING">no</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="__Variants__" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Auditing" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Monitoring" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Default" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Immediate" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Category" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16345&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Color" type="STRING">black</aTTRIBUTE>
+<aTTRIBUTE name="Doku" type="STRING">NOTEBOOK
+
+#-----------------------
+LANG &quot;en&quot;
+#-----------------------
+CHAPTER &quot;Description&quot;
+ATTR &quot;Denomination&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+
+
+CHAPTER &quot;Details (BPMN)&quot;
+
+ATTR &quot;Auditing&quot; 
+ATTR &quot;Monitoring&quot; 
+
+ATTR &quot;Default&quot; 
+ATTR &quot;Immediate&quot; 
+ATTR &quot;Category&quot;
+ATTR &quot;Id&quot; 
+
+
+CHAPTER &quot;Details (Simulation)&quot;
+
+ATTR &quot;Transition condition&quot; dialog:transcond
+
+ATTR &quot;Transition probability&quot;
+
+</aTTRIBUTE>
+<aTTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;Sub-Process&quot;</aTTRIBUTE>
+<aTTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Exclusive Gateway&quot;</aTTRIBUTE>
+<aTTRIBUTE name="ModelTypeExp" type="EXPRESSION">EXPR val:&quot;Business process diagram (BPMN 2.0)&quot;</aTTRIBUTE>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16346" class="Is inside">
+<fROM instance="Titolo Unico" class="Data Object"></fROM>
+<tO instance="Monti Azzurri Consorsium" class="Pool"></tO>
+<aTTRIBUTE name="AutoConnect" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16347" class="Is inside">
+<fROM instance="Titolo Unico" class="Data Object"></fROM>
+<tO instance="Office SUAP" class="Lane"></tO>
+<aTTRIBUTE name="AutoConnect" type="STRING"></aTTRIBUTE>
+</cONNECTOR>
+<cONNECTOR id="con.16348" class="Data Association">
+<fROM instance="Titolo Unico" class="Data Object"></fROM>
+<tO instance="Send Authorization Document" class="Task"></tO>
+<aTTRIBUTE name="Positions" type="STRING">EDGE 0 index:41</aTTRIBUTE>
+<aTTRIBUTE name="Name" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Representation" type="ENUMERATION">above/below</aTTRIBUTE>
+<aTTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Description" type="LONGSTRING"></aTTRIBUTE>
+<aTTRIBUTE name="Show name" type="ENUMERATION">No</aTTRIBUTE>
+<aTTRIBUTE name="Comment" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Doku" type="STRING">#-----------------------
+CHAPTER &quot;Description&quot;
+#-----------------------
+ATTR &quot;Name&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+ATTR &quot;Id&quot; </aTTRIBUTE>
+<aTTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Data Object&quot;</aTTRIBUTE>
+<aTTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;Task&quot;</aTTRIBUTE>
+<aTTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16348&quot;</aTTRIBUTE>
+<aTTRIBUTE name="id_bpmndi" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Annotation" type="STRING"></aTTRIBUTE>
+<aTTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</aTTRIBUTE>
+</cONNECTOR>
+</mODEL>
+</mODELS>
+<mODELGROUPS>
+<mODELGROUP name="TitoloUnico">
+<mODELREFERENCE name="TitoloUnico_MontiAzzurrSUB" version="" modeltype="Business process diagram (BPMN 2.0)" libtype="bp"></mODELREFERENCE>
+<mODELREFERENCE name="TitoloUnico_MontiAzzurrSUB_3" version="" modeltype="Business process diagram (BPMN 2.0)" libtype="bp"></mODELREFERENCE>
+<mODELREFERENCE name="TitoloUnico_MonitAzzurrSUB_4" version="" modeltype="Business process diagram (BPMN 2.0)" libtype="bp"></mODELREFERENCE>
+<mODELREFERENCE name="Competency model TitoloUnico" version="" modeltype="Competency model" libtype="bp"></mODELREFERENCE>
+<mODELREFERENCE name="BMM TitoloUnico" version="" modeltype="BMM" libtype="bp"></mODELREFERENCE>
+<mODELREFERENCE name="Document and Knowledge model TitoloUnico" version="" modeltype="Document and Knowledge model" libtype="bp"></mODELREFERENCE>
+<mODELREFERENCE name="Org Model Monti Azzurri" version="" modeltype="Organizational structure" libtype="we"></mODELREFERENCE>
+<mODELREFERENCE name="Org Model Senigallia Municipality" version="1" modeltype="Organizational structure" libtype="we"></mODELREFERENCE>
+<mODELREFERENCE name="Org Model Sarnano Municipality" version="1" modeltype="Organizational structure" libtype="we"></mODELREFERENCE>
+</mODELGROUP>
+</mODELGROUPS>
+</ado:ADOXMLType>

--- a/lp-collaborative-workspace/lp-cw-bridge/lp-cw-bridge-transformer/resources/model/TitoloUnico.xml
+++ b/lp-collaborative-workspace/lp-cw-bridge/lp-cw-bridge-transformer/resources/model/TitoloUnico.xml
@@ -1,0 +1,14152 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE ADOXML SYSTEM "adoxml31.dtd">
+<ADOXML version="3.1" date="10.09.2015" time="17:50" database="learnpad" username="Admin" adoversion="Version 1.0 4.0">
+<MODELS>
+<MODEL id="mod.16855" name="Org Model Sarnano Municipality" version="1" modeltype="Organizational structure" libtype="we" applib="LearnPAd Prototype Static Library 0.21">
+<MODELATTRIBUTES>
+<ATTRIBUTE name="Contact person" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Keywords" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Copyright info" type="STRING">Edit the model attributes to display your copyright info</ATTRIBUTE>
+<ATTRIBUTE name="Copyright info position" type="ENUMERATION">Bottom right</ATTRIBUTE>
+<ATTRIBUTE name="Model type" type="ENUMERATION">Current model</ATTRIBUTE>
+<ATTRIBUTE name="State" type="ENUMERATION">In process</ATTRIBUTE>
+<ATTRIBUTE name="Reviewed on" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Reviewed by" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Author" type="STRING">test</ATTRIBUTE>
+<ATTRIBUTE name="Creation date" type="STRING">16.02.2015, 09:38</ATTRIBUTE>
+<ATTRIBUTE name="Last user" type="STRING">congyu</ATTRIBUTE>
+<ATTRIBUTE name="Date last changed" type="STRING">03.09.2015, 15:24:47</ATTRIBUTE>
+<ATTRIBUTE name="Number of objects and relations" type="INTEGER">43</ATTRIBUTE>
+<ATTRIBUTE name="Context of version" type="STRING"></ATTRIBUTE>
+<RECORD name="Change history"></RECORD>
+<ATTRIBUTE name="Position" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-01] Internal error!  \&quot;fontcolor\&quot; (WEModel)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<RECORD name="Technical Attributes"></RECORD>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Keine Modellbezeichnung vergeben</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Pool Term" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="ParticipantType" type="ENUMERATION">Role</ATTRIBUTE>
+<ATTRIBUTE name="Role" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Entity" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="BoundaryVisible" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="BPD Model Attributes" type="STRING">NOTEBOOK
+
+CHAPTER &quot;Business Process Diagram Attributes&quot;
+ATTR &quot;Name&quot; write-protected
+ATTR &quot;Contact person&quot;
+ATTR &quot;Author&quot; write-protected
+ATTR &quot;Language (BPMN)&quot;
+ATTR &quot;ExpressionLanguage&quot;
+ATTR &quot;QueryLanguage&quot;
+ATTR &quot;Creation date&quot; write-protected
+ATTR &quot;Date last changed&quot; write-protected
+ATTR &quot;Documentation (Model)&quot;
+ATTR &quot;State&quot;
+
+GROUP &quot;Copyright&quot;
+ATTR &quot;Copyright info&quot; 
+ATTR &quot;Copyright info position&quot; 
+ENDGROUP
+
+CHAPTER &quot;Process Attributes&quot;
+ATTR &quot;Name&quot; write-protected
+ATTR &quot;Process Term&quot;
+ATTR &quot;ProcessType&quot;
+ATTR &quot;Status&quot;
+ATTR &quot;Assignments&quot; lines:5
+ATTR &quot;Properties (BPMN)&quot; lines:5
+ATTR &quot;AdHoc&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+GROUP &quot;AdHoc = True&quot;
+ATTR &quot;AdHocOrdering&quot;
+ATTR &quot;AdHocCompletionCondition&quot;
+ENDGROUP
+ATTR &quot;SuppressJoinFailure&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ATTR &quot;EnableInstanceCompensation&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ATTR &quot;Categories (Process)&quot;
+ATTR &quot;Documentation (Process)&quot;
+
+CHAPTER &quot;Pool Attributes&quot;
+GROUP &quot;Common Graphical Object Attributes&quot;
+ATTR &quot;Name&quot; write-protected
+ATTR &quot;Categories (Pool)&quot;
+ATTR &quot;Documentation (Pool)&quot;
+ENDGROUP
+GROUP &quot;Common Swimlane Attributes&quot;
+ATTR &quot;Pool Term&quot;
+ENDGROUP
+GROUP &quot;Pool Attributes&quot;
+ATTR &quot;ParticipantType&quot;
+ATTR &quot;Role&quot;
+ATTR &quot;Entity&quot;
+ATTR &quot;BoundaryVisible&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot; write-protected
+ENDGROUP</ATTRIBUTE>
+<ATTRIBUTE name="Language" type="ENUMERATION">System</ATTRIBUTE>
+<ATTRIBUTE name="ExpressionLanguage" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="QueryLanguage" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Process Term" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="BPD Term" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="ProcessType" type="ENUMERATION">None</ATTRIBUTE>
+<ATTRIBUTE name="Status" type="ENUMERATION">None</ATTRIBUTE>
+<RECORD name="Assignments"></RECORD>
+<ATTRIBUTE name="AdHoc" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="AdHocOrdering" type="ENUMERATION">None</ATTRIBUTE>
+<ATTRIBUTE name="AdHocCompletionCondition" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="EnableInstanceCompensation" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Categories (Process)" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation (Process)" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation (Pool)" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Categories (Pool)" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="SuppressJoinFailure" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="RACI/DEMI visualisation" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Modelling direction" type="ENUMERATION">vertical</ATTRIBUTE>
+<ATTRIBUTE name="IT systems" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Responsible role" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Input/Output" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Products" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Use cases" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Products color" type="STRING">whitesmoke</ATTRIBUTE>
+<ATTRIBUTE name="RACI/DEMI color" type="STRING">whitesmoke</ATTRIBUTE>
+<ATTRIBUTE name="Responsible role color" type="STRING">whitesmoke</ATTRIBUTE>
+<ATTRIBUTE name="Input/Output color" type="STRING">whitesmoke</ATTRIBUTE>
+<ATTRIBUTE name="Use cases color" type="STRING">whitesmoke</ATTRIBUTE>
+<ATTRIBUTE name="IT systems color" type="STRING">whitesmoke</ATTRIBUTE>
+<ATTRIBUTE name="_ToggleModelInfo_" type="PROGRAMCALL">ITEM &quot;_ToggleModelInfo_&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Display modelling information" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Documentation (Model)" type="STRING"></ATTRIBUTE>
+<RECORD name="Properties (BPMN)"></RECORD>
+<ATTRIBUTE name="CreationDate" type="EXPRESSION">EXPR val:&quot;16.02.2015, 09:38&quot;</ATTRIBUTE>
+<ATTRIBUTE name="ModificationDate" type="EXPRESSION">EXPR val:&quot;03.09.2015, 08:32:17&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Language (BPMN)" type="STRING">English</ATTRIBUTE>
+<ATTRIBUTE name="BPMN20 Model Attributes" type="LONGSTRING">NOTEBOOK
+# TODO AVAL sMfbRegistration:&quot;_MFB-Registration_&quot;
+CHAPTER &quot;Description&quot;
+ATTR &quot;Contact person&quot;
+ATTR &quot;Keywords&quot; lines:2
+ATTR &quot;Description&quot; lines:3
+ATTR &quot;Comment&quot; lines:3
+
+GROUP &quot;Copyright&quot;
+ATTR &quot;Copyright info&quot; 
+ATTR &quot;Copyright info position&quot; 
+ENDGROUP
+ATTR &quot;Name&quot; write-protected
+ATTR &quot;Id&quot; write-protected
+
+
+
+#---------------------------------------------
+CHAPTER &quot;Process properties&quot;
+#---------------------------------------------
+GROUP &quot;Process attributes&quot;
+ATTR &quot;Process type&quot; #None, Private, Public 
+ATTR &quot;Executable&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ATTR &quot;Closed&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ENDGROUP
+
+GROUP &quot;Process relevance&quot;
+ATTR &quot;Auditing&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ATTR &quot;Monitoring&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ENDGROUP
+
+CHAPTER &quot;User attributes&quot;
+ATTR &quot;Model type&quot;
+ATTR &quot;State&quot;
+ATTR &quot;Reviewed on&quot;
+ATTR &quot;Reviewed by&quot;
+
+CHAPTER &quot;System attributes&quot;
+ATTR &quot;Author&quot; write-protected
+ATTR &quot;Creation date&quot; write-protected
+ATTR &quot;Last user&quot; write-protected
+# ATTR &quot;Date last changed from&quot; write-protected
+ATTR &quot;Date last changed&quot; write-protected
+ATTR &quot;Number of objects and relations&quot; write-protected
+ATTR &quot;Context of version&quot; write-protected
+
+CHAPTER &quot;People-like view&quot;
+ATTR &quot;Action&quot;
+ATTR &quot;People-like view&quot;
+
+CHAPTER &quot;BAR Display&quot;
+ATTR &quot;BAR Display active&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot;
+AVAL s_Aktiv: &quot;BAR Display active&quot;
+ATTR &quot;Modelling direction&quot; ctrltype: radio enabled: (s_Aktiv = &quot;Yes&quot;)
+ATTR &quot;Modelling_size&quot;
+GROUP &quot;Actor&quot;
+ATTR &quot;Actor_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_Actor_display: &quot;Actor_display&quot;
+ATTR &quot;Actor_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_Actor_display = &quot;Yes&quot;))
+ATTR &quot;Actor_size&quot;
+ENDGROUP
+GROUP &quot;Description&quot;
+ATTR &quot;Description_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_Description_display: &quot;Description_display&quot;
+ATTR &quot;Description_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_Description_display = &quot;Yes&quot;))
+ATTR &quot;Description_size&quot;
+ENDGROUP
+
+CHAPTER &quot;Change history&quot;
+ATTR &quot;Change history&quot; lines:30
+
+</ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;97740&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Auditing" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Monitoring" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Process type" type="ENUMERATION">None</ATTRIBUTE>
+<ATTRIBUTE name="Executable" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Closed" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="_GoToAceHp_" type="PROGRAMCALL">ITEM &quot;_GoToAceHp_&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="__GfxThumb__" type="LONGSTRING">iVBORw0KGgoAAAANSUhEUgAAAQAAAADWCAIAAACxAMu3AAAACXBIWXMAAAsTAAALEwEAmpwYAAAeH0lEQVR4nO2df4zj5nnnv3IW+SNAGiBx616QteN4RGdprbe39iY7HLvJNWhijdIBGxjc4HoHXd0J99K79Si2dcG2hBMEzAXFdAJOAxsZxXWsBjlgWNfRytE76SXu2rWX48Dxxj+4tM1Xu469u2299vqCAoHXM0Py/qCk1cxoNJRESiPx/fyxS3HI53neV++X7/vyFfkkPM+7cOHC008/Dcbwc+nSJUmSBh3FMJE4e/bsyZMn9+/fv2vXrp///Ofr/pZIAPjEJz6xtrYG4CNXXdWp9XNvvOFvdHFu1EQd2z89+SR3PQfAfsX+g1tvjcKFT6MgAE6ePMk00BnHjh07ffrM6dNnHnvssddacfz48dOnT3srK97KimfNkelxuWxp4+OaZWnj09rctDw9rVkrdG5as1bI9LgwPq5ZK7XjV1bq51rauO9wWp6GMGd5K5Y2PUfL08J47US5bNG5ac2ySLmsjQPTZTIN35c8PQ5ALltkelwu+75qp8tli5TLpFz2LZCyRefGhbmyNj6uWStkGnK5LE9Py+PjWtkiZYtMXw5vXWzjc2RuWrPKpGzRclmbnm4UsB6eb7NMyhYpW97KCp3zqwLAuDAOAMLctDw9R8o1+8vLy8vLy759Yc4i05DLl6uiVgnjEObK/p56wCvN+4U5y7PKZBp+RXnWXOPgy5V8xv8OTx87dmxxcdFjBGYXgEuX3gHw3HPP+Vf6Dbz//e9/551L/nYVSXvP7SKqOHoU1SqOTtnfmiosQ9gzhYcfsJJ34dSysYxUFRirnf7OJf/cMe4GYHlcLk+JmBIBANyel7LlU1he1pempFPL5p5q5eEHrORdnH/mqXIJMPdUxaNHQcsClk1a5ffcLuInlYcf0DGl7HkpW4YyBftbU/rtZckPDKg8vGzcQJWjR1H9iX0K5h6awh7+9imOfhvp+9N3HW0U7dI77/gb3FHLuw3zn7pbx13KS3+WxQ2pUw+gepd4dMr+1pRfLnMPeCzrS2MKvo30/UCVJv9WpN8uARi/Xbph2Vgex8MPFJaBqSNpAMD73ve+poqs2qdg7qlibKlpX5W7AankGABheo6rHfOTpiP8yhuzT8EAlCpw2xHuhrvl28tc098bBWF0SuLYsWO7d+8GsGvXrhdeeGHzEQcOHPjNb37zH1Oppn3V+U/9Gf72iZmxzYdv5Jemuf5cLP35p+y7Ap3bA5sjrM7/+VLm/iPNbk+a5v71sQWyvMnOloe+9hqAsWuu6dBFx/zSNP2Ns2fPsiFQRySOHTt2VX0QfM0111y4cOGKK654z3vec8UVVwD4wAc+8Nrrr3uel/DwyZv2d2r95ydP+huf3N/xuVETdWz/8uabZ8+eBbB79+4P//ZvR+HC5+l6QQBceOMNJoCOSHieVy6XBx0GIzSYADpiF4CpqSld1wcdCYMxABKe5w06BgZjYOwadAAMxiBhAmDEGiYARqxhAmDEGiYARqxhAmDEGiYARqxhAmDEGiYARqxhAmDEGiYARqxhAmDEGiYARqxhAmDEGiYARqxhAmDEGiaAMDHrD6d3Tarjh/QZPcEEEDJ79+7t7sTz58+//fbb4QbD2BYmgJBZXV31PM913ea3LzV/bPOnQcceR5gAQqbr1u+67qBjjyNMACHTdetnPcBAYAIIma5bPxPAQGACCJmuWz8TwEBgAgiZrls/E8BAYAIIma5bP5sEDwQmgJDpuvWzHmAgMAGETNetnwlgIDABhEzXrZ8JYCAwAYRM162fzQEGAhNAyJw7d27QITA6gL0enRFrWA/AiDVMAGFRnZ9I5qARybIzeWSzVirF5/McpQBQUlUzJRUXZsaq8xPJXIoQTE4WBFkGxBNiKVESqVjK1o8ZdFHiBBNAWIxxKaCgqzAAUVEUDjYobHVSl4jEp1AoWHShlj3WLJUAyBLPg8OSbcLkKc+nUCjolfwMU0AfYXMARqxhPQAj1jABREsikVhcXGyZt7TNnxh9gwkgQhKJRBd/YvQTJoDIOXToEIANV3rP85gGdgJMABHit/LFxcVBB8LYEiaAfsAG+jsWJgBGrGECYMQaJgBGrGECYMQaJgBGrGECYMQaJgBGrGECYMSaDgTAlu4Zo0dQAYS+pH/o0CH2GwHGwOlsCBTikn7Ln4gxGH2GzQEYsYYJgBFrmACCEsU9gEOHDvlDQUbX9PhUHRNAB7DbADuN3i8fTACdMaS3Afr5/HE/fTEBMBg9wQTAiDVMAIxYwwTAiDVMAIxYwwTAiDVMAIxYwwQQFM/zdF3fyQaZry4I+nr00Fc3dtqrYU3T7N1IKpWKzn6kxtvbH2FfgXqAHz5/sfjsG79xnN6jichgKOzdu7eX01988cXo7EdqPIj9UfXVTgB/b/274zqO4zqO89iTBoCV1f2O4ziOe+TT13URTegGGYwe2VIAfmNdeuwJ/+OtnzzguI7xzEn/49zKyt2f3dORp9ANhs7KykrLbL4t92ze+etf/zqI/Tapgtu4Dmg8uuBH1VdrATQa62duFfwrtOM6juPcvG+v4ziO47zw0iv/e3X1LzI3BixG6AajoJeK9gJMpTafFbD1BzQeafCj6qu1AC431te+q37ha2caf8h876/vnFhz3evHPvZK9QwQtL2GbjAKeqnoIHneu279Qb7IqIMfVV+tBXD5Ur3mYeqh++75fcdxHefM8Tu/+vi58fGrHMdxrr16d3a+VJwRgxQjdINR0EtFe4Ev0i2NbOt64MGPqq8t5wC1gYrneZ7rT1sdx3Xhef6m4zod3sMJ3WDo9FLRQep6KyPbfsdBrmRRBz+qvtoIwHVcx3FdPHrHnY/W99523zd+p9ZYHbdTAYRsMHR6qeggdd3SSJDWH9x4dMGPqq+tBVC7MHtebZj+xD985dWJL483GqvjdDaYC91g6PRS0UHqevMpAVt/QOORBj+qvloLQDiw33jm5M379jqOC89dc13HEf7o0M/uve9J5UsH/cb6bxfeDD5eD91gFPRS0UHquuvWH8R41MGPqq/WAjgsXL2ysvqL51+88be8xiDd2Xf0i8bN3/+x/ief+3CnjTV0g1HQS0V3OkzvqPUH+SKjDn5UfW05BDry6evmVlZeeAmf+hxeqZ659urdjuO8N/OjzwDdNdbQDYZOLxXt9TZK2fYO6cCDH1Vf7X4Kcfdn9+CzewB8/UfPvvr6WQA9NtPQDYZLLxUdpK4D2ux9EhxF8KPqK9CP4b7+xzcBN3UUd58NhsL58+eH137UwY+qr80/h67OTyRzKUL5UiWzwM0mVJ5IegmSmdMlLZWzRMqrWR2QiidmxoI78s1qRORQUicLkElRLCVLope3D89a4PMLnVhjMMJhix7ALM2aBXB5TiQKAEW01QJSEkyYPBUVCZM5vVKd6bTNmpYtcuBTAgqmTXkTJr9U0QsFAwKf79ha+DRUmkmDztuqxRV5NZmDRk9kKhPJnAEIgoCUpOQz9mww3VaXlpDGbEI1BaRSMPlikaNI2rOVTB7ZZA4akSw7k0c2a6VSfL62AYDP55GdhQRk8shmsc0VZ50jScln7GwWxSJmK5mFmTG/aLJQKEAQpGKRoxQoTU6Cegud1/t2hapdQHk9qaeIIgK2OplLEW8h3bGrLVxPqAXDkIkGO1DlbM3mMVYzRBY02v6QUYJqAiBomgwIskYo0WSN1MpPZACyRimlhBCiCQAgk+2NEhkQNEIprZmvnS5olMjwJeXvJEQjhBJCCJEFQCa0fqR/4jbfRJOjeoSy5jvyPM+jlHpEru2pmxW07mpq60IRTQAEWRYgEyoDGqX1YAJUVgeuiaZpwStnK4I+EcZgjCatVFEXtSZrlGqCIMuyRikhmgzIxCMyZEI1oafOAcDi4mL35/eL/sQ5LLUxerQeArXsmjUBgNzcKffSp+3Mr3xzVM17oos5JMvU/1aoJmvUo5qsUUpkQRCaL2T+9YsIQM+DW6o1WojsNw5KZEEmtTDqjoTehj6UEOoRTRAEQRD8+AFBJpQQSmRBoxogE61RNL/gQa23ngSnFzxvYd0OAOm0N+N/8DdmZnrsfHZUlqQRSgFoV/SCDhF6QYco8SkUCnpFVBSFgw1atU2YvG0A6OI2xno4hZ5IY2mJ2nxKgGHalOclEdQGANt3lJKV3ma+YyglEqasKQrUSb2yJJkAUiIoANs0LKoIgmX7ha3fVrG4BQQsWU/i7I3FxcUd0gk0amNDSM37m7cjCmCH1Eas6CxLZLhX6x1y7QfgeV6jB9gqKv+YIU1pMar5AXpnYC/G2lHV1KZlb94fUcxDKq2IqS4tIZ0eWzqcKIlERBJA0s4mc5CJwquTOciaInKAraooFpFN6hJRuGTSDro00IEAdtSQPQq2KlrfijzCdds1tposwV8zTYpW1s4XbdWArIkAFOqlMT+RVCUiwdArVAIMywaHim4YKYog84Dgo6XQh+w7ZMiLTUP/DX/a6mPoMURh2Vs/k4nIxUB8hUIHPUDo16edcMFrDH52QjCMTul9ID2wSfCOmgPskDAiwuvj9L2fvkIh1m+HHq6vqnf6qfNhuaYEFYA3zC8Hb8m2g5+4yWPo8O9c93hvJu5zgG1j2AlBMqIjpnOA7q7uXn29jKliJxDKfCOOcwB252fE6MddoJGZA7DWz2gmpnMA1voZPvGaAwQfMrJbQDEhRnOALgY/rKMYeWI3B2BtmtFMXOYAbEjDaEks5gDszg9jK2I0B2Ctn7GZ0Z8DdDH4YeOl+DDic4BeBj+sx4gDozwH2PY5dwZjkM8E9+EhYzaSYbRnRCbBP3z+op916U8P/IfGTn+aEVxgP/jlm/U8fn1do/jh8xeLz76B6uMR2f/BL9/8/jP/ijP/HJH9ofa1TgDt347mX023OsZr9ZLd0A1u4O+tf/cT7DmO89iTBoCV1f1+1uEjn74OwbqXRfPXfs5ix3GOn3gawMrqqnPVzfP/RGf+ILnt6V2zKfj3/j/j9ebge2RTud578alf+e5CL9fw+lr3duhEInH++ILnrHnOqueuuf6Gs+Y5a5676jn+ntq2f5jrrHnu2r5caSsBhGuwGb8BLT32hP/x1k8ecFzHeOak//HGPdff/dk925bfr81/fPxJ/+PEJ25yHOfpZ5/zP6Y+zuU/x28oUShTl1CCb0On5Yqtr40C6DqyLnqALgw2aDSgz9wq1BLNN2WcdxznhZdeuX7sY3+RubGNkUZt/qeJg42LSj1vses4jvmyzV137V9+fl9ziXoXQCjBh1uurhl2XxvnAGd/+je7//DONo0vkUic++l3PvKHRwCceeRed/XdsUN/1eb40A36XG5Ar31X/cLXzjT+UMvC7V4/9rFXqmeAdm2oVpvXvPDNA39cvWzhgbncLX5D5K671j79KhDClxd68O3s97Fcw+5rowDc1Xe3Pcdde/dX5W+6a++6q++6a9scH7pBn8uXzzUPUw/dd8/vO47rOGeO3/nVx8+Nj1/lOI5z7dW7s/OlrRJR/p/nL9auJa8974rF+++uWXj8yP96/PVx4XdrF5WP7v5IGyPd0XvwbehnuUbA12YBXNr2nKvT9wSPO3SDDWrdn+d5nlsfPLguGnm4Xcdx2p3uujUjLuC6l3tSeJ7X1L267Yx0TY/Bt7Pcx3KNgK9uBHDmkXs/9oVv+NvW9+7gv/Rgm4NDN9igNnR2XTx6x52P1vfedt83fqcxLmwrAMcB4Liu47pe+U+PlBsW7levulybjtNZZvOA9Bh8W8v9K9cI+OpqCNR0TDhDoE4MNqjPGD2vNnR+4h++8urEl8cbDah9Xfy3m3/3+AnULfjjyMcfzp255X80T0y7vxJHGnwb+lmuEfDVTQ8wduivGtupL/+w/cGhG/QRDuw3njl58769juPCc9dc13GEPzr0s3vve1L50kG/Lv7twpvtx4IHb/q9p599bv8HXcBvj8LUF3+mfOef7z083qjNN958K/R09qEEv0PKNey+Ou4BNtyf2fZGZ+gGfQ4LV6+srP7i+Rdv/C2vMXB29h39onHz93+s/8nnPhykAX35lo+urKyePP6o5+6uDSh/7+h/PnHTg48+/F9u+3DL2gzl1UChBB9uuWLra+M6wKnv/tcb/vsPgqzCNk7B1vfsQze4gbn/+9ILL73ib1979W7HcV4//y/+x+AVMfuPlvmy7W9/dPdHHNc5e/5f2xgJay0slODb0Gm54umr9UJYiAII1+BWfP1Hz776+ln0Vt1fe+QXvzp7blsjof+ONZTg2xCwXPH0xRJld8yOerE7o1daZc2ghPj57WuJZv3k2H5yVk0IkiW7lkFWE2RZrqWPFYRG8traAQA0SjVB1upJXus5boncOgWxn4BWI4R6hGhaPSWtoNG6QQiCIMgaofVcuS3TGddyHtf9CuvygdfLK2hEE2p/ai4sukx/EsTp5Ty4mv8NdJCNPGr7o+mr5c+hx5L2RBaKpBcsLg9eErFk15Oz2gBAdcNon2W2lkGWE6EWdJ7y9Wy10As68jMzY1wKMKBXqKKItjppcXlO1OSSn+OWT4HbUrImbCQnTVlTiqI9ayvUS48B4FKAIWvFfAaUUlrPlWugVZ5aTqHUns3qhRSXh2lYFKIi6ZM5kxelenkN2BIMvVJB4HxT7Qng1LBoFSYAQ69QhbODp7rqg/3R9NWFJCPC1/GA2LZPuwxCS4DVgdMdaX8UfLE5QMewOcAo0XIIVJ2fSOZShPKlSibPUQokUcqqJqRiEdmspShiaXISxFvYPLgYGJ20S7+AGhEzadB5W7W4Iq8mc9DoiRnMH65kRCurmkhJSj5jz85a4PMLAXLOtva1tIQ0ZhOqKSCVgskXixxF0p6tZPLIJnPQiGTZmTyyWSuV4vO1DQB8Po/sLCQgk8f2eW/XOZKUfMbOZlEsYraSWZgZ84ssC4UCBEEqFjlKgdLkJKi30HnJtitUrfHwelJPEUUEbHUylwqlwdRcT6gFw5CJBjtQ5WzJ1o9EmqVZs2BClPRJXSKSaRgGUhSionCAzcuy1XUZdgat5xLVeb2gI18sFlGfSxQMyOJCt3OAMZQSCVMjxXwSlWyyYFaowqGiF3TklRRQ0FUYgKgoCgcbFFAUDiV1sgAxLyqirU7q4LHdpGu9Iz9yw0hVKmZt0jVTpJkxOgueN3N6hUr6pC5pgtBdsdoUSpRQazzgaAo5PpkEpd3VXVvXxK7Ytp4LVjlbMjpDIH8BoQ+DEzYEGiVG5KF47ICse4yhJJy59IiCVjd8Wu6MwlHn1JY96msgtTvlgiA33Tv3iAyZEAHo+UZKbbWHEEJkAagt+NQWZ2RSdyS0XNMJ7oUQ6hFNEARBuHy/XyaUEEpkQaMaIBOtUbTGWlMgRqcHYCOTOnZ9DaSgQ5TqKzD1OUbVNmHytgF0PW5uUFvtWaI2nxJgmDbleam+WGT7jlKt1mE6wR/0y5qiQJ3UK0tSfUkKgG0aFlUEwbL9wpow+aWKXrC4wHO2nsS5k0A0F+bNZvvmiNEHRqcH8CKYA3j1Hz9HTRTBMwIxYAEOA33oAaKmnzGH6osSQj2vNm8hhBJC/Z9/yYT4//tzkPqvtvw5yabfb23N6PQA0c0B+vYWazaB2YytJkugvAmTT4pW1s4XbdWArIkAFOqlMT+RVCUiwdArVAIMywaHSvAfA4Wk1MGDyC5yGyxH4Si64L2mdZ4+dAL99BUKo9MDeMM8jI40+H7WjOd5Q5ZeZLD6Gxai7gGipp8xD5ev0ekBIh1Gs59XBMcbqq54dAQQKcPeQPvcKPuW/BM9p1kZHQEM14VnA30Ivm/q7dvFIpxKC2EgFg+GehrQz4CHq3JGpweI+sITdT6/oR5iNeP1sSvuvd5GRwBRM9RttJ+NEkOVlnN0BBD1d+yF8VLENsbZHKALeq+30REAov+OI22mbIjVHT0WanQE0J/vOCL7o9RA2RxgZBneZsrmAFsxOgLow3fsRfZ4AJsDdAebA6xjaBZfWsHmAN3B5gA1+vYd+2vv4TJKDXS45gCjsxLsFyfSNcjmegvXUR+CH6LV2YCE8l2MTg/QB7x+PSIcBSM5B+idIRNA+/bnP4ex1TFeh+/A28pO42mPNsG09NXP4De7btkoe9Rzj1EFIUiltTls2wiH7NWIiUTi/PEFz1nznFXPXXP9DWfNc9Y8d9Vz/D21bf8w11nz3LV9uVIXAgjXVz+D3+x6KwGcP77guWv1MGobbiOG9X9yndXGnn1fObZVVLquh9UDRBThZftDJ4Cuzw2rB+jaVz+D30zLRjnsPcC2bB9h17OHgQDg7E//pn3YAM799Dt+6c48cm918avdFTN0X/0MPjhBmkGnxYziDkGIETYzZHMABEw9v/bur8rfdNfedVffDZ56vg+++hl8M5uHQI0r6+LiYpAbu5uj6tvruAPSXb0NowC2Tz1/dfqenemrn8Fvppcm2z6qZsvegB7N67LeQuii+giA0w//ZfuwAZx55N5GAa3v3dFdMUP31c/gN+MPSxYXF/2Nhgv/Rkr7c1tG1Ti9YT+69zJ1F2EQ48PYAwQYRTQdE/kQqBNf/Qx+A/5Vv3Ht9zq8Tm+OaoOFgQ+Euqy33gXaTwC88nf/s33YYRUzdF/9DD44QVwMtuVEGuEI9gAbqqOX+2ih++pn8CGyM6NqpusIh1EA288jd6yvfgbPCMKwLoQFD9s/pYtihu6rn8EHpwsXfYiqR3fBTxkyATAYIdPFpGRn0JyJjWoC/KQJ9WxtPVkmRJMFWZP9TGyk9pHU8rPJhBKikVoyNiIATcnnaD2FW4twGznkiCzIpHa8JmuUyP7HRhHqae3QSDjXS3mCFFkTAFlbn0iPEhmQ/XwTtTR7PefV6zgsv7ZlQfPT5MnEI7LQSAG4vg3Isuwn0qOE+LFv72L45gDrMEslwOQpD0CWRKCera2KdPfp32zVggQLkghqq5O6RCQJUJMJAxBkEdRWc5aS4fWCxYkpWRNF1JPPUZ6XBQEiquuzM1QpVxTt2ZKfQ46XRCz5x4u8lS1BEau2ebkIflq7/t9W5NYl0qM8Lwu5SZUnkl6wONEMnHQiJGqVZnP5fJFWsoZhyAqWbNOwaBV6QUf+RJFmxlCZgMlTURGhFgoGUhQcbBNAgGbAhkCMWDPkPQCD0RvDKIDq0lKlpFq8InKArao5w5AJFVEBZpL2RBZFhaNAMmnPVjILvWXCjQnV+YlkDrIME0pRLGXt/IlM5XBWN6WiYmVtUbLsTB7ZrJWCyRdPjFCdDqMA6mN0dVKXiKJIwqRh2pTX/XG5YRhJm1KO0ope0JHvMRd0PBjjUkDBBFFE0MYg2zCQoklesv001IqicCjBHnSwoTL8c4Dq/DydmektGTkjtgy/ABiMHhjKIRCDERZMAIxYwwTAiDVMAIxYwwTAiDVMAIxYwwTAiDVMAIxYwwTAiDVMAIxYwwTAiDVMAIxYwwTAiDVMAIxYwwTAiDVMAIx2VOcnkrkUIbxqcwpn26quI5VKFUyenuBmD2NBtCdsK2WJCws4fBgLC5ifsLkTXClREr2FNJYOH4ZYmJwUZAFQFEyWRE/EvDqZU4hcwkLenpjlirw6yykoYWEhDSzNJ1SLSuYsd0K0LxvLJ6uU0nQ6Xa1WKaVplBIlkYiArdrciRkcPlwCxAX/lEyySiktqZN8SrPEjFhKqjyR9JKliKKtlqDw+qQu0RMzY0wAjDZUK7oBWbLVHCQCcJyiKAAgiqDzasGURBGSxVsiqv7HeT0HicyrBaRE1HbysqyJPGwOtgqTX+L1nCFrtpozJbGiG1DAKaKtTppSHmnMqzmktIpegFIFJGBeLQB8FZi1sZAGQGdt5G21AKOg8kSBkklX5ycKBQMCL4qQgCrorA0RkC0eIihEogBQRA4AJJ6zdQPwXzsT8auNGIyuIZqsEdrY9jcbG21OaRyz/cu82CORjFjDhkCMYeHt+YkHc7iFSG/Zmes5+qEkLlZKryAvIGtAAjKf52YfKokTvHoCxQmOfghAOv3B6vxDs9wUrz6YM64UhLcMA4L28ZR1pSgeTKeZABjDA6fc4aUxP/GUDkGxyllcmTJfBhVE5XpbPWZxAsy3TB483tIrH1JgIPN54G3KTYm2UQIgfFxKPWUYV0J/uWAA4sE0eysEY0R5e/6wnVk4uO07oZgAGLGGDYEYsYYJgDG80KWlDyVhzNpCnvP/vUiTScz+dUm8Ryw9pJqQilMctQEOsIGD6TSq8z+uZAQ9+SC0O07MfJAJgDG8JFF6KIuPSyhnrdq/xfzFip/cwHzLMIDKRUl/ylI4Xn3KUg6mq09X9Jd1XJmSb/FXxdgcgBFr/j9Mw3VXPWTMrgAAAABJRU5ErkJggg==</ATTRIBUTE>
+<ATTRIBUTE name="NT Model Attributes" type="LONGSTRING">NOTEBOOK
+CHAPTER &quot;Description&quot;
+#ATTR &quot;Shared&quot;
+ATTR &quot;Model state&quot; enabled:(cond(search (sMfbRegistration, &quot;MFB_VERS&quot;, 0) = -1, 1, 0))
+ATTR &quot;Description&quot;
+ATTR &quot;Show State&quot; ctrltype:check unchecked-value:&quot;No&quot; checked-value:&quot;Yes&quot; 
+ATTR &quot;Last user&quot; write-protected
+ATTR &quot;Date last changed&quot; write-protected
+#CHAPTER &quot;Suggestion for improvement&quot;
+#ATTR &quot;Suggestion for improvement&quot;
+</ATTRIBUTE>
+<ATTRIBUTE name="Model state" type="ENUMERATION">Draft</ATTRIBUTE>
+<ATTRIBUTE name="People-like view" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Action" type="ENUMERATION">Fill in</ATTRIBUTE>
+<ATTRIBUTE name="Keywords" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Description" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Model type" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Show State" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="BAR Display active" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Actor_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="Actor_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Actor_size" type="ENUMERATION">5</ATTRIBUTE>
+<ATTRIBUTE name="Description_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="Description_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Description_size" type="ENUMERATION">5</ATTRIBUTE>
+<ATTRIBUTE name="ModelingAreaSize" type="ENUMERATION">15</ATTRIBUTE>
+<ATTRIBUTE name="Modelling_size" type="ENUMERATION">10</ATTRIBUTE>
+<ATTRIBUTE name="DrawingAreaWidth" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="DrawingAreaHeight" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Reference overview settings" type="LONGSTRING">Actor|Actors
+Modelling|Modelling
+Description|Description</ATTRIBUTE>
+<ATTRIBUTE name="Data Object_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="Data Object_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Data Object_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="Knowledge Product_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="Knowledge Product_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Knowledge Product_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="Documents and Resources_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Documents and Resources_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="Documents and Resources_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="Responsible for execution_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="Responsible for execution_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Responsible for execution_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="Accountable for approving results_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="Accountable for approving results_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Accountable for approving results_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="Cooperation/participation_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="Cooperation/participation_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Cooperation/participation_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="To inform_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="To inform_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="To inform_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="Incoming Data Object_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="Incoming Data Object_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Incoming Data Object_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="Outgoing Data Object_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="Outgoing Data Object_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Outgoing Data Object_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="id_bpmndi_diagram" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="id_bpmndi_plane" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="id_bpmndi_collaboration" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="CommentModellingAreaSize" type="ENUMERATION">3</ATTRIBUTE>
+<ATTRIBUTE name="CommentTypeSize" type="ENUMERATION">8</ATTRIBUTE>
+<ATTRIBUTE name="CommentAreaSize" type="ENUMERATION">2</ATTRIBUTE>
+<ATTRIBUTE name="Comment Mode" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="CommentxCoorTextBox" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="CommentyCoorTextBox" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="CommentModellingDirection" type="ENUMERATION">vertical</ATTRIBUTE>
+</MODELATTRIBUTES>
+<INSTANCE id="obj.16856" class="Organizational unit" name="Comune Sarnano">
+<ATTRIBUTE name="Position" type="STRING">NODE x:13.5cm y:3.5cm w:2.4cm h:1.5cm index:1</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<INTERREF name="Model reference"></INTERREF>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Organisationseinheit</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Submodelname" type="EXPRESSION">EXPR val:&quot;Bezeichnung&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Type" type="ENUMERATION">Standard</ATTRIBUTE>
+<ATTRIBUTE name="Functional unit" type="ENUMERATION">no</ATTRIBUTE>
+<ATTRIBUTE name="Manager" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Function" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Level" type="INTEGER">0</ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16859" class="Organizational unit" name="Ufficio Commercio">
+<ATTRIBUTE name="Position" type="STRING">NODE x:14.5cm y:9cm index:2</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<INTERREF name="Model reference"></INTERREF>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Organisationseinheit</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Submodelname" type="EXPRESSION">EXPR val:&quot;Bezeichnung&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Type" type="ENUMERATION">Standard</ATTRIBUTE>
+<ATTRIBUTE name="Functional unit" type="ENUMERATION">no</ATTRIBUTE>
+<ATTRIBUTE name="Manager" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Function" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Level" type="INTEGER">0</ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16862" class="Organizational unit" name="Ufficio Tributi Economato">
+<ATTRIBUTE name="Position" type="STRING">NODE x:18cm y:9cm w:2.4cm h:1.5cm index:3</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<INTERREF name="Model reference"></INTERREF>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Organisationseinheit</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Submodelname" type="EXPRESSION">EXPR val:&quot;Bezeichnung&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Type" type="ENUMERATION">Standard</ATTRIBUTE>
+<ATTRIBUTE name="Functional unit" type="ENUMERATION">no</ATTRIBUTE>
+<ATTRIBUTE name="Manager" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Function" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Level" type="INTEGER">0</ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16865" class="Organizational unit" name="Ufficio Servizi Finanziari">
+<ATTRIBUTE name="Position" type="STRING">NODE x:22cm y:9cm w:2.4cm h:1.5cm index:4</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<INTERREF name="Model reference"></INTERREF>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Organisationseinheit</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Submodelname" type="EXPRESSION">EXPR val:&quot;Bezeichnung&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Type" type="ENUMERATION">Standard</ATTRIBUTE>
+<ATTRIBUTE name="Functional unit" type="ENUMERATION">no</ATTRIBUTE>
+<ATTRIBUTE name="Manager" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Function" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Level" type="INTEGER">0</ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16868" class="Organizational unit" name="Ufficio Urbanistica e Lavori Pubblici">
+<ATTRIBUTE name="Position" type="STRING">NODE x:26cm y:9cm w:2.4cm h:1.5cm index:5</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<INTERREF name="Model reference"></INTERREF>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Organisationseinheit</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Submodelname" type="EXPRESSION">EXPR val:&quot;Bezeichnung&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Type" type="ENUMERATION">Standard</ATTRIBUTE>
+<ATTRIBUTE name="Functional unit" type="ENUMERATION">no</ATTRIBUTE>
+<ATTRIBUTE name="Manager" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Function" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Level" type="INTEGER">0</ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16871" class="Performer" name="Venanzio Scuderini">
+<ATTRIBUTE name="Position" type="STRING">NODE x:1.5cm y:14cm index:6</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Hourly wages" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Calendar" type="LONGSTRING">B@Working day@b@32400-43200@T@45000-59400@T@Free day@c@@@$cbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbcbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbcbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbcccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbccbbccb</ATTRIBUTE>
+<ATTRIBUTE name="Availability" type="EXPRESSION">EXPR expr:(round(paval(&quot;Presence&quot;,&quot;Hours per day&quot;)*paval(&quot;Presence&quot;,&quot;Days per week&quot;)/40*100)) val:100</ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Time dependent costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Info on results" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Workload" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Capacity" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Personnel costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Bearbeiter</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<RECORD name="Further education"></RECORD>
+<ATTRIBUTE name="Presence" type="ATTRPROFREF"></ATTRIBUTE>
+<ATTRIBUTE name="E-Mail" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16874" class="Performer" name="Franco Ceregioli">
+<ATTRIBUTE name="Position" type="STRING">NODE x:4.5cm y:14cm index:7</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Hourly wages" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Calendar" type="LONGSTRING">B@Working day@b@32400-43200@T@45000-59400@T@Free day@c@@@$cbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbcbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbcbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbcccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbccbbccb</ATTRIBUTE>
+<ATTRIBUTE name="Availability" type="EXPRESSION">EXPR expr:(round(paval(&quot;Presence&quot;,&quot;Hours per day&quot;)*paval(&quot;Presence&quot;,&quot;Days per week&quot;)/40*100)) val:100</ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Time dependent costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Info on results" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Workload" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Capacity" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Personnel costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Bearbeiter</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<RECORD name="Further education"></RECORD>
+<ATTRIBUTE name="Presence" type="ATTRPROFREF"></ATTRIBUTE>
+<ATTRIBUTE name="E-Mail" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16877" class="Performer" name="Anna Marinozzi">
+<ATTRIBUTE name="Position" type="STRING">NODE x:14.5cm y:19cm index:14</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Hourly wages" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Calendar" type="LONGSTRING">B@Working day@b@32400-43200@T@45000-59400@T@Free day@c@@@$cbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbcbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbcbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbcccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbccbbccb</ATTRIBUTE>
+<ATTRIBUTE name="Availability" type="EXPRESSION">EXPR expr:(round(paval(&quot;Presence&quot;,&quot;Hours per day&quot;)*paval(&quot;Presence&quot;,&quot;Days per week&quot;)/40*100)) val:100</ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Time dependent costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Info on results" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Workload" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Capacity" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Personnel costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Bearbeiter</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<RECORD name="Further education"></RECORD>
+<ATTRIBUTE name="Presence" type="ATTRPROFREF"></ATTRIBUTE>
+<ATTRIBUTE name="E-Mail" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16880" class="Performer" name="Emanuele Crisostomi">
+<ATTRIBUTE name="Position" type="STRING">NODE x:20cm y:19cm index:15</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Hourly wages" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Calendar" type="LONGSTRING">B@Working day@b@32400-43200@T@45000-59400@T@Free day@c@@@$cbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbcbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbcbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbcccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbccbbccb</ATTRIBUTE>
+<ATTRIBUTE name="Availability" type="EXPRESSION">EXPR expr:(round(paval(&quot;Presence&quot;,&quot;Hours per day&quot;)*paval(&quot;Presence&quot;,&quot;Days per week&quot;)/40*100)) val:100</ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Time dependent costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Info on results" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Workload" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Capacity" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Personnel costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Bearbeiter</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<RECORD name="Further education"></RECORD>
+<ATTRIBUTE name="Presence" type="ATTRPROFREF"></ATTRIBUTE>
+<ATTRIBUTE name="E-Mail" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16883" class="Performer" name="Alfonso Tardella">
+<ATTRIBUTE name="Position" type="STRING">NODE x:26cm y:19cm index:16</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Hourly wages" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Calendar" type="LONGSTRING">B@Working day@b@32400-43200@T@45000-59400@T@Free day@c@@@$cbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbcbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbcbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbcccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbccbbccb</ATTRIBUTE>
+<ATTRIBUTE name="Availability" type="EXPRESSION">EXPR expr:(round(paval(&quot;Presence&quot;,&quot;Hours per day&quot;)*paval(&quot;Presence&quot;,&quot;Days per week&quot;)/40*100)) val:100</ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Time dependent costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Info on results" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Workload" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Capacity" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Personnel costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Bearbeiter</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<RECORD name="Further education"></RECORD>
+<ATTRIBUTE name="Presence" type="ATTRPROFREF"></ATTRIBUTE>
+<ATTRIBUTE name="E-Mail" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16886" class="Role" name="Segretario Comunale">
+<ATTRIBUTE name="Position" type="STRING">NODE x:1.5cm y:9cm index:17</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Rolle</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16889" class="Role" name="Sindaco">
+<ATTRIBUTE name="Position" type="STRING">NODE x:4.5cm y:9cm index:18</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Rolle</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16892" class="Role" name="Responsabile Ufficio Commercio">
+<ATTRIBUTE name="Position" type="STRING">NODE x:14.5cm y:14cm index:19</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Rolle</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16895" class="Role" name="Responsabile Ufficio Tributi Economato">
+<ATTRIBUTE name="Position" type="STRING">NODE x:18cm y:14cm index:20</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Rolle</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16898" class="Role" name="Responsabile Ufficio Servizi Finanziari">
+<ATTRIBUTE name="Position" type="STRING">NODE x:22cm y:14cm index:21</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Rolle</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16901" class="Role" name="Responsabile Ufficio Urbanistica e Lavori Pubblici">
+<ATTRIBUTE name="Position" type="STRING">NODE x:26cm y:14cm index:22</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Rolle</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16904" class="Organizational unit" name="SUAP Office">
+<ATTRIBUTE name="Position" type="STRING">NODE x:11cm y:9cm index:33</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<INTERREF name="Model reference"></INTERREF>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Organisationseinheit</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Submodelname" type="EXPRESSION">EXPR val:&quot;Bezeichnung&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Type" type="ENUMERATION">Standard</ATTRIBUTE>
+<ATTRIBUTE name="Functional unit" type="ENUMERATION">no</ATTRIBUTE>
+<ATTRIBUTE name="Manager" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Function" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Level" type="INTEGER">0</ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16907" class="Role" name="SUAP Officer">
+<ATTRIBUTE name="Position" type="STRING">NODE x:7.5cm y:14cm index:34</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Rolle</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16910" class="Performer" name="Sabrina Kurjakovic ">
+<ATTRIBUTE name="Position" type="STRING">NODE x:7.5cm y:19cm index:35</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Hourly wages" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Calendar" type="LONGSTRING">B@Working day@b@32400-43200@T@45000-59400@T@Free day@c@@@$cbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbcbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbcbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbcccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbccbbccb</ATTRIBUTE>
+<ATTRIBUTE name="Availability" type="EXPRESSION">EXPR expr:(round(paval(&quot;Presence&quot;,&quot;Hours per day&quot;)*paval(&quot;Presence&quot;,&quot;Days per week&quot;)/40*100)) val:100</ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Time dependent costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Info on results" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Workload" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Capacity" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Personnel costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Bearbeiter</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<RECORD name="Further education"></RECORD>
+<ATTRIBUTE name="Presence" type="ATTRPROFREF"></ATTRIBUTE>
+<ATTRIBUTE name="E-Mail" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16913" class="Role" name="Responsible SUAP office">
+<ATTRIBUTE name="Position" type="STRING">NODE x:10cm y:14cm index:38</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Rolle</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16916" class="Performer" name="Knut Hinkelmann">
+<ATTRIBUTE name="Position" type="STRING">NODE x:11.5cm y:19cm index:40</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Hourly wages" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Calendar" type="LONGSTRING">B@Working day@b@32400-43200@T@45000-59400@T@Free day@c@@@$cbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbcbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbcbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbcccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbccbbccb</ATTRIBUTE>
+<ATTRIBUTE name="Availability" type="EXPRESSION">EXPR expr:(round(paval(&quot;Presence&quot;,&quot;Hours per day&quot;)*paval(&quot;Presence&quot;,&quot;Days per week&quot;)/40*100)) val:100</ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Time dependent costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Info on results" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Workload" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Capacity" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Personnel costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Bearbeiter</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<RECORD name="Further education"></RECORD>
+<ATTRIBUTE name="Presence" type="ATTRPROFREF"></ATTRIBUTE>
+<ATTRIBUTE name="E-Mail" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<CONNECTOR id="con.16919" class="Is subordinated">
+<FROM instance="Ufficio Commercio" class="Organizational unit"></FROM>
+<TO instance="Comune Sarnano" class="Organizational unit"></TO>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 1 x1:14cm y1:7cm index:44</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Representation" type="ENUMERATION">with arrow</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16920" class="Is subordinated">
+<FROM instance="Ufficio Tributi Economato" class="Organizational unit"></FROM>
+<TO instance="Comune Sarnano" class="Organizational unit"></TO>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 2 x1:18cm y1:7cm x2:14cm y2:7cm index:45</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Representation" type="ENUMERATION">with arrow</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16921" class="Is subordinated">
+<FROM instance="Ufficio Servizi Finanziari" class="Organizational unit"></FROM>
+<TO instance="Comune Sarnano" class="Organizational unit"></TO>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 2 x1:22cm y1:7cm x2:14cm y2:7cm index:46</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Representation" type="ENUMERATION">with arrow</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16922" class="Is subordinated">
+<FROM instance="Ufficio Urbanistica e Lavori Pubblici" class="Organizational unit"></FROM>
+<TO instance="Comune Sarnano" class="Organizational unit"></TO>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 2 x1:26cm y1:7cm x2:14cm y2:7cm index:47</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Representation" type="ENUMERATION">with arrow</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16923" class="Has role">
+<FROM instance="Venanzio Scuderini" class="Performer"></FROM>
+<TO instance="Segretario Comunale" class="Role"></TO>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 0 index:23</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">6</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16924" class="Has role">
+<FROM instance="Franco Ceregioli" class="Performer"></FROM>
+<TO instance="Sindaco" class="Role"></TO>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 0 index:24</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">8</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16925" class="Has role">
+<FROM instance="Anna Marinozzi" class="Performer"></FROM>
+<TO instance="Responsabile Ufficio Commercio" class="Role"></TO>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 0 index:25</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">9</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16926" class="Has role">
+<FROM instance="Emanuele Crisostomi" class="Performer"></FROM>
+<TO instance="Responsabile Ufficio Tributi Economato" class="Role"></TO>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 1 x1:18cm y1:19cm index:26</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">11</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16927" class="Has role">
+<FROM instance="Emanuele Crisostomi" class="Performer"></FROM>
+<TO instance="Responsabile Ufficio Servizi Finanziari" class="Role"></TO>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 1 x1:22cm y1:19cm index:27</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">12</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16928" class="Has role">
+<FROM instance="Alfonso Tardella" class="Performer"></FROM>
+<TO instance="Responsabile Ufficio Urbanistica e Lavori Pubblici" class="Role"></TO>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 0 index:28</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">15</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16929" class="belongs to">
+<FROM instance="Segretario Comunale" class="Role"></FROM>
+<TO instance="Comune Sarnano" class="Organizational unit"></TO>
+<ATTRIBUTE name="Connector number" type="INTEGER">5</ATTRIBUTE>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 2 x1:1.5cm y1:6.5cm x2:13cm y2:6.5cm index:12</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16930" class="belongs to">
+<FROM instance="Sindaco" class="Role"></FROM>
+<TO instance="Comune Sarnano" class="Organizational unit"></TO>
+<ATTRIBUTE name="Connector number" type="INTEGER">7</ATTRIBUTE>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 2 x1:4.5cm y1:6.5cm x2:13cm y2:6.5cm index:13</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16931" class="belongs to">
+<FROM instance="Responsabile Ufficio Commercio" class="Role"></FROM>
+<TO instance="Ufficio Commercio" class="Organizational unit"></TO>
+<ATTRIBUTE name="Connector number" type="INTEGER">10</ATTRIBUTE>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 0 index:29</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16932" class="belongs to">
+<FROM instance="Responsabile Ufficio Tributi Economato" class="Role"></FROM>
+<TO instance="Ufficio Tributi Economato" class="Organizational unit"></TO>
+<ATTRIBUTE name="Connector number" type="INTEGER">13</ATTRIBUTE>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 0 index:30</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16933" class="belongs to">
+<FROM instance="Responsabile Ufficio Servizi Finanziari" class="Role"></FROM>
+<TO instance="Ufficio Servizi Finanziari" class="Organizational unit"></TO>
+<ATTRIBUTE name="Connector number" type="INTEGER">14</ATTRIBUTE>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 0 index:31</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16934" class="belongs to">
+<FROM instance="Responsabile Ufficio Urbanistica e Lavori Pubblici" class="Role"></FROM>
+<TO instance="Ufficio Urbanistica e Lavori Pubblici" class="Organizational unit"></TO>
+<ATTRIBUTE name="Connector number" type="INTEGER">16</ATTRIBUTE>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 0 index:32</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16935" class="Is subordinated">
+<FROM instance="SUAP Office" class="Organizational unit"></FROM>
+<TO instance="Comune Sarnano" class="Organizational unit"></TO>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 2 x1:11cm y1:7cm x2:14cm y2:7cm index:43</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Representation" type="ENUMERATION">with arrow</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16936" class="belongs to">
+<FROM instance="SUAP Officer" class="Role"></FROM>
+<TO instance="SUAP Office" class="Organizational unit"></TO>
+<ATTRIBUTE name="Connector number" type="INTEGER">2</ATTRIBUTE>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 0 index:37</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16937" class="Has role">
+<FROM instance="Sabrina Kurjakovic " class="Performer"></FROM>
+<TO instance="SUAP Officer" class="Role"></TO>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 0 index:36</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">1</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16938" class="belongs to">
+<FROM instance="Responsible SUAP office" class="Role"></FROM>
+<TO instance="SUAP Office" class="Organizational unit"></TO>
+<ATTRIBUTE name="Connector number" type="INTEGER">16</ATTRIBUTE>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 0 index:39</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16939" class="Has role">
+<FROM instance="Knut Hinkelmann" class="Performer"></FROM>
+<TO instance="Responsible SUAP office" class="Role"></TO>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 0 index:41</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">17</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16940" class="Is manager">
+<FROM instance="Knut Hinkelmann" class="Performer"></FROM>
+<TO instance="SUAP Office" class="Organizational unit"></TO>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 0 index:42</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">19</ATTRIBUTE>
+</CONNECTOR>
+</MODEL>
+<MODEL id="mod.16637" name="Org Model Senigallia Municipality" version="1" modeltype="Organizational structure" libtype="we" applib="LearnPAd Prototype Static Library 0.21">
+<MODELATTRIBUTES>
+<ATTRIBUTE name="Contact person" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Keywords" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Copyright info" type="STRING">Edit the model attributes to display your copyright info</ATTRIBUTE>
+<ATTRIBUTE name="Copyright info position" type="ENUMERATION">Bottom right</ATTRIBUTE>
+<ATTRIBUTE name="Model type" type="ENUMERATION">Current model</ATTRIBUTE>
+<ATTRIBUTE name="State" type="ENUMERATION">In process</ATTRIBUTE>
+<ATTRIBUTE name="Reviewed on" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Reviewed by" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Author" type="STRING">learnpad</ATTRIBUTE>
+<ATTRIBUTE name="Creation date" type="STRING">16.02.2015, 11:15</ATTRIBUTE>
+<ATTRIBUTE name="Last user" type="STRING">congyu</ATTRIBUTE>
+<ATTRIBUTE name="Date last changed" type="STRING">03.09.2015, 08:37:38</ATTRIBUTE>
+<ATTRIBUTE name="Number of objects and relations" type="INTEGER">108</ATTRIBUTE>
+<ATTRIBUTE name="Context of version" type="STRING"></ATTRIBUTE>
+<RECORD name="Change history"></RECORD>
+<ATTRIBUTE name="Position" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-01] Internal error!  \&quot;fontcolor\&quot; (WEModel)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<RECORD name="Technical Attributes"></RECORD>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Keine Modellbezeichnung vergeben</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Pool Term" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="ParticipantType" type="ENUMERATION">Role</ATTRIBUTE>
+<ATTRIBUTE name="Role" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Entity" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="BoundaryVisible" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="BPD Model Attributes" type="STRING">NOTEBOOK
+
+CHAPTER &quot;Business Process Diagram Attributes&quot;
+ATTR &quot;Name&quot; write-protected
+ATTR &quot;Contact person&quot;
+ATTR &quot;Author&quot; write-protected
+ATTR &quot;Language (BPMN)&quot;
+ATTR &quot;ExpressionLanguage&quot;
+ATTR &quot;QueryLanguage&quot;
+ATTR &quot;Creation date&quot; write-protected
+ATTR &quot;Date last changed&quot; write-protected
+ATTR &quot;Documentation (Model)&quot;
+ATTR &quot;State&quot;
+
+GROUP &quot;Copyright&quot;
+ATTR &quot;Copyright info&quot; 
+ATTR &quot;Copyright info position&quot; 
+ENDGROUP
+
+CHAPTER &quot;Process Attributes&quot;
+ATTR &quot;Name&quot; write-protected
+ATTR &quot;Process Term&quot;
+ATTR &quot;ProcessType&quot;
+ATTR &quot;Status&quot;
+ATTR &quot;Assignments&quot; lines:5
+ATTR &quot;Properties (BPMN)&quot; lines:5
+ATTR &quot;AdHoc&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+GROUP &quot;AdHoc = True&quot;
+ATTR &quot;AdHocOrdering&quot;
+ATTR &quot;AdHocCompletionCondition&quot;
+ENDGROUP
+ATTR &quot;SuppressJoinFailure&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ATTR &quot;EnableInstanceCompensation&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ATTR &quot;Categories (Process)&quot;
+ATTR &quot;Documentation (Process)&quot;
+
+CHAPTER &quot;Pool Attributes&quot;
+GROUP &quot;Common Graphical Object Attributes&quot;
+ATTR &quot;Name&quot; write-protected
+ATTR &quot;Categories (Pool)&quot;
+ATTR &quot;Documentation (Pool)&quot;
+ENDGROUP
+GROUP &quot;Common Swimlane Attributes&quot;
+ATTR &quot;Pool Term&quot;
+ENDGROUP
+GROUP &quot;Pool Attributes&quot;
+ATTR &quot;ParticipantType&quot;
+ATTR &quot;Role&quot;
+ATTR &quot;Entity&quot;
+ATTR &quot;BoundaryVisible&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot; write-protected
+ENDGROUP</ATTRIBUTE>
+<ATTRIBUTE name="Language" type="ENUMERATION">System</ATTRIBUTE>
+<ATTRIBUTE name="ExpressionLanguage" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="QueryLanguage" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Process Term" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="BPD Term" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="ProcessType" type="ENUMERATION">None</ATTRIBUTE>
+<ATTRIBUTE name="Status" type="ENUMERATION">None</ATTRIBUTE>
+<RECORD name="Assignments"></RECORD>
+<ATTRIBUTE name="AdHoc" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="AdHocOrdering" type="ENUMERATION">None</ATTRIBUTE>
+<ATTRIBUTE name="AdHocCompletionCondition" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="EnableInstanceCompensation" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Categories (Process)" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation (Process)" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation (Pool)" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Categories (Pool)" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="SuppressJoinFailure" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="RACI/DEMI visualisation" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Modelling direction" type="ENUMERATION">vertical</ATTRIBUTE>
+<ATTRIBUTE name="IT systems" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Responsible role" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Input/Output" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Products" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Use cases" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Products color" type="STRING">whitesmoke</ATTRIBUTE>
+<ATTRIBUTE name="RACI/DEMI color" type="STRING">whitesmoke</ATTRIBUTE>
+<ATTRIBUTE name="Responsible role color" type="STRING">whitesmoke</ATTRIBUTE>
+<ATTRIBUTE name="Input/Output color" type="STRING">whitesmoke</ATTRIBUTE>
+<ATTRIBUTE name="Use cases color" type="STRING">whitesmoke</ATTRIBUTE>
+<ATTRIBUTE name="IT systems color" type="STRING">whitesmoke</ATTRIBUTE>
+<ATTRIBUTE name="_ToggleModelInfo_" type="PROGRAMCALL">ITEM &quot;_ToggleModelInfo_&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Display modelling information" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Documentation (Model)" type="STRING"></ATTRIBUTE>
+<RECORD name="Properties (BPMN)"></RECORD>
+<ATTRIBUTE name="CreationDate" type="EXPRESSION">EXPR val:&quot;16.02.2015, 11:15&quot;</ATTRIBUTE>
+<ATTRIBUTE name="ModificationDate" type="EXPRESSION">EXPR val:&quot;03.09.2015, 08:12:03&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Language (BPMN)" type="STRING">English</ATTRIBUTE>
+<ATTRIBUTE name="BPMN20 Model Attributes" type="LONGSTRING">NOTEBOOK
+# TODO AVAL sMfbRegistration:&quot;_MFB-Registration_&quot;
+CHAPTER &quot;Description&quot;
+ATTR &quot;Contact person&quot;
+ATTR &quot;Keywords&quot; lines:2
+ATTR &quot;Description&quot; lines:3
+ATTR &quot;Comment&quot; lines:3
+
+GROUP &quot;Copyright&quot;
+ATTR &quot;Copyright info&quot; 
+ATTR &quot;Copyright info position&quot; 
+ENDGROUP
+ATTR &quot;Name&quot; write-protected
+ATTR &quot;Id&quot; write-protected
+
+
+
+#---------------------------------------------
+CHAPTER &quot;Process properties&quot;
+#---------------------------------------------
+GROUP &quot;Process attributes&quot;
+ATTR &quot;Process type&quot; #None, Private, Public 
+ATTR &quot;Executable&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ATTR &quot;Closed&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ENDGROUP
+
+GROUP &quot;Process relevance&quot;
+ATTR &quot;Auditing&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ATTR &quot;Monitoring&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ENDGROUP
+
+CHAPTER &quot;User attributes&quot;
+ATTR &quot;Model type&quot;
+ATTR &quot;State&quot;
+ATTR &quot;Reviewed on&quot;
+ATTR &quot;Reviewed by&quot;
+
+CHAPTER &quot;System attributes&quot;
+ATTR &quot;Author&quot; write-protected
+ATTR &quot;Creation date&quot; write-protected
+ATTR &quot;Last user&quot; write-protected
+# ATTR &quot;Date last changed from&quot; write-protected
+ATTR &quot;Date last changed&quot; write-protected
+ATTR &quot;Number of objects and relations&quot; write-protected
+ATTR &quot;Context of version&quot; write-protected
+
+CHAPTER &quot;People-like view&quot;
+ATTR &quot;Action&quot;
+ATTR &quot;People-like view&quot;
+
+CHAPTER &quot;BAR Display&quot;
+ATTR &quot;BAR Display active&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot;
+AVAL s_Aktiv: &quot;BAR Display active&quot;
+ATTR &quot;Modelling direction&quot; ctrltype: radio enabled: (s_Aktiv = &quot;Yes&quot;)
+ATTR &quot;Modelling_size&quot;
+
+GROUP &quot;Responsible for execution&quot;
+ATTR &quot;Responsible for execution_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_Responsible_for_execution_display: &quot;Responsible for execution_display&quot;
+ATTR &quot;Responsible for execution_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_Responsible_for_execution_display = &quot;Yes&quot;))
+ATTR &quot;Responsible for execution_size&quot;
+ENDGROUP
+
+GROUP &quot;Accountable for approving results&quot;
+ATTR &quot;Accountable for approving results_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_Accountableforapprovingresults_display: &quot;Actor_display&quot;
+ATTR &quot;Accountable for approving results_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_Accountableforapprovingresults_display = &quot;Yes&quot;))
+ATTR &quot;Accountable for approving results_size&quot;
+ENDGROUP
+
+GROUP &quot;Cooperation/participation&quot;
+ATTR &quot;Cooperation/participation_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_Cooperationparticipation_display: &quot;Cooperation/participation_display&quot;
+ATTR &quot;Cooperation/participation_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_Cooperationparticipation_display = &quot;Yes&quot;))
+ATTR &quot;Cooperation/participation_size&quot;
+ENDGROUP
+
+GROUP &quot;To inform&quot;
+ATTR &quot;To inform_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_Toinform_display: &quot;To inform_display&quot;
+ATTR &quot;To inform_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_Toinform_display = &quot;Yes&quot;))
+ATTR &quot;To inform_size&quot;
+ENDGROUP
+
+GROUP &quot;Knowledge Product&quot;
+ATTR &quot;Knowledge Product_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_KnowledgeProduct_display: &quot;Knowledge Product_display&quot;
+ATTR &quot;Knowledge Product_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_KnowledgeProduct_display = &quot;Yes&quot;))
+ATTR &quot;Knowledge Product_size&quot;
+ENDGROUP
+
+GROUP &quot;Documents and Resources&quot;
+ATTR &quot;Documents and Resources_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_DocumentsandResources_display: &quot;Documents and Resources_display&quot;
+ATTR &quot;Documents and Resources_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_DocumentsandResources_display = &quot;Yes&quot;))
+ATTR &quot;Documents and Resources_size&quot;
+ENDGROUP
+
+GROUP &quot;Incoming Data Object&quot;
+ATTR &quot;Incoming Data Object_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_IncomingDataObject_display: &quot;Incoming Data Object_display&quot;
+ATTR &quot;Incoming Data Object_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_IncomingDataObject_display = &quot;Yes&quot;))
+ATTR &quot;Incoming Data Object_size&quot;
+ENDGROUP
+
+GROUP &quot;Outgoing Data Object&quot;
+ATTR &quot;Outgoing Data Object_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_OutgoingDataObject_display: &quot;Outgoing Data Object_display&quot;
+ATTR &quot;Outgoing Data Object_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_OutgoingDataObject_display = &quot;Yes&quot;))
+ATTR &quot;Outgoing Data Object_size&quot;
+ENDGROUP
+
+GROUP &quot;Description&quot;
+ATTR &quot;Description_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_Description_display: &quot;Description_display&quot;
+ATTR &quot;Description_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_Description_display = &quot;Yes&quot;))
+ATTR &quot;Description_size&quot;
+ENDGROUP
+
+CHAPTER &quot;Change history&quot;
+ATTR &quot;Change history&quot; lines:30
+
+</ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;97522&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Auditing" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Monitoring" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Process type" type="ENUMERATION">None</ATTRIBUTE>
+<ATTRIBUTE name="Executable" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Closed" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="_GoToAceHp_" type="PROGRAMCALL">ITEM &quot;_GoToAceHp_&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="__GfxThumb__" type="LONGSTRING">iVBORw0KGgoAAAANSUhEUgAAAQAAAABkCAIAAADmAnnJAAAACXBIWXMAAAsTAAALEwEAmpwYAAANjElEQVR4nO2db2gcxxXA3xl/KJR+ihtLEaKxczJRLJqPicbtlzQQbIrj0KIrBOQU3A2lNKdCSimOTWndP9ioHZV+kQoFQ0NyMq58wl7bxK4bEx/BbamNZDnV2nGwZftLsb+0yL4gbT/s3u7e/pl9uzu3u3f7foRg3c6+efNm3szc3nuzpfv371+5cmVwcBAAAGBlZeWVl16CbmP+9OlHjx6NjY1lrQjRZWy8fPny3bt3N2zYYPx969atbBUiiFSp1+u3b9+en58/efLkqVOnVlZW9OaStrTER0fZqF1MbTb15hIfBTY5r85PKrBPbS5xu0BbYWXevGR/ODrJJye1lhADtm8UAPjSPACozXnzw8lJR3WW2FG2b1+rIuO/fcqkcXtTbzbr9XqtVtMJIiKler0u2aUygrZARAw27t69e3Z2Nms1CCIbSrquZ6vB4uJiuVxeX19fW1uz/m/94+HDhyMjI9lqSPQwG7NWAAAgaPSvra1lrRrR4+TCAYJG//r6etaqET1OLhwgaPTTCkB0mlw4wJ07d7JWgSgo2X8JbnFjasfQRIMx1mg0AAC4plfLWStF9Dr5cQCTUqlUq9XoiT6RDrnYAhFEVpADEIWGHIAoNOQARKEhByAKTYgDlEqldPTISb1EDxDpKWL4ClCr1ZLpE4dMKiV6gEqlEu0GcboAAKScaJJ+jb1BD9hNShOiCqHvAEShIQcgio3cBSUGCwsLAvUWFhY6Wnv3IrZb1tqhkNX1SYTQCkAUmlw4wOrqqiAlMmvt8svq6qplNKf1Hjx4kLVqWKR0/cLCQrlcjmeKXDgApUTGw7fLu8tosro+tilCHEDX9RTOjKCUyHj4dnl3OYCsro9tikAH2Dt1AgCOVvekEJpPKZHx8O3y7po1ZHV9bFP4OMDLO0rnG7D1rQ/f2vPU3qkTR6t7IqkSA0qJjMfKykrWKiRFVtfHN4X3wdA3GAAA+7V2+My1Q/NXxvlc1MdbEdE4A8a5Aowxxpitm9rhirscw24KAHBNNSxmdF0X2s3ZliT3cgBgijmGMKJ8UiJffvPgwHOwfHbgm99/cfnTW/2bn/zNdxgQRE/i6xaHz1wb53PjfO4n712K6o+x0LgxdymWpyldOI2ljD3zMc4Vu0u7yHRGE1RVbalv7wBitgIi/nQbmBR/8Pjfm59/TnM/0V0YgfQRIqJdDtFyRdMT05pLWiuAPZF10TSWJaoCjNn9FX0DnQfM3ldUJfmQM0Y/fhEIDBqBjMJrs6q3O9E4s7cNCmcpzlmyMEZ/28OPJG4cdfz4/w5ACVldQrl6Sa86/p6uBhbNK+4mpIztAL6D3vpQz9n5WYSLnjlQLOWGBP4STEmJXQSt2PFx7Z9cf/oWC92EdRHI/WLWaqLI1ZwV4Wuo371RRQluF4sKjwZdfndi2+sc3fAQDQCgUqkICoivSsfIocYsuLkaXkHkR0mkYY0Nj/dz54ehorxCguzgI8rlRkFehfRmHfE1XFwg9HZ8MVll8MWSk1pF8cCrl2Y/JtGqbQVYmnnDNeiB9pdET9PmAMPf2z+1ozQ7po7NHpqFRqNhPpHNSjmC6DQS3g+wuLgoLjAyMiIuE1ogTSG+n3fu2Vw8fdIEqaFEw0YVJeidcFGO7ZAZmcSZMyJJYWFRCYLc/nv37hlp+QIljAL5ESLACBDE7DXxJNEnHZAaCowvaIivSaOKEvRLqPLOLVDrN7nqzrZf5hArhCC12aosNG05P0K8dC5JKElCdzrgNYyUpL936sTd2dfON+DpH5zzmhQpSiwEo7ycpHhManNo2nJ+hATR1/9Us9nctnWLXB+IrU9qIDWM2pDhTXAeoK+vf9vWTS6T4kUJhGBEyXGAoDHnTMoMTVvOjxAfRg6Mj8Hy2fPN7WaSkBS7xdcnXZAaRm3I9b4Dh88MHPvdheUvDbhMihclEIIRJXkFcI0519D0KuEdl3kQ4uXc9M+PnF0CWO5EilwMfVIGqWGkhhyt7jlydtviJ8vDO8FrUqQosRCMKDkOgEltDk1bzo8QX378ynMH//u/TiQJ5T+3Halh1IYITIoXFdovIaLiPBcoFma6RitmnTJ1EtJKAFAUKwGWmelQ+DwAKUJ0XZAQEx2NMwCFq5yBJ6fBSjRTVENh+0mr2rpXUQAAuNbKD2olhzlEaZxZecOKogAonLdlQjnlmAcEuB7jqo7kWasuZDoVdCZOwakS46qar7wWp80ZY6CoRhe6JoK23ldbjYqVp+aqkRmZYorKQ5/I+4pyjEmf7k7uABpnZi4S49zoQu5Yi1zD1+xm/5ZgEiOtM1QguIxJ0HhVFXPyUDVulEFOG51wAKMNltgO+VgyNM6AtS2DQcO6LUOtVqsJk9RCj0Ixp3kwg9ucHR3tKBRzijEVaxswGWyBMH0sZRx0oiK5o9Ma/YZYlzPkELx6wSUjnwQRWmkSo8lyAHOtsX5FNvwyXnuEZdwHqAjmbozh5A44iI4x+mPcGK+u5A3ER+dLMSxSVHABTdM0zpi5UNjbE9PZZJ0ObWV2VieMwIzyWDU41RMfhR9UUSYZgJhK8aPZmflg/aNz6RCR3x4nlJPY8jemdgxNNEBRlZldM6qu70wgKyipAAAAyuUyVC9dAgBzQLaPy2yOR5fSx8l7Qtf1TgR7I1Xy1V/S8AqsLjmYvkMY1s6Fn9ank4kScfrN0q4ZYAwaDUVRZmZm7Etc06vl7N4PkLyP85P9FAPhpJV3JE3/jLFGo2F+ZAzHeOjBh/jvnNYd/jU9M+New3PxgozYpLAF8k4/yU/KsEZ/DxziEAt7+pe1lcVI8F1J5DvAOJ87dR8E6oQWSE0Isgw4xrphxJvH33nmW4fiSROPfqQ+MZAiGS9EYkNCRSG9yH+hSP493cI4V33rjz76w4ef+sZnj/M5s0z1YlAAdzpC7DLVi1MXNEGUv8tKQabDaGVJ8H1kgdQnBpZuW354IbZkvBCM8S0MSwY9w0GKEgsRi5K/AvT3P/W42RweesY3NvX5PjgP0NffP/LsE4Kg4hSEGPT19z9+3Bza8nTyCGeMVqFbf4n6ONm+2YwZHh4SWUyiEIHxBUew6X67Sl9R8c5x84qS6gAjB8bHQPvgXHP7i9e1mwN9m71Frm46MHXhK+8dPr/4hc2DA/0ZCrEinB8Pv6Dd+gw5JvTggwJCtQrZ+sfSB8m1Lx+Y/GCwNvnX61/s97eGRCEY4zsQzQhoUeFPFAJEScgJdvLbc/++eu06AAz0bf5VZdRb4Pd/u/HPq4sAMDjQf+jbL2QoBACOnF1a/GQZAJ7c9MSR17+OaJ+IUK1Ct6py9XGCsYZEIeKSrsneOZt4R2OQqEhCRKLEW7QY/GzuHz99vyEo8Iv6v/Yf+zgPQnRd33/s47f/fDH4uuaMazJ+RxREZQm0Atyx3WH6xAdjDYlCBCVdA8/4c/ndiaDR6CsqqpAgUZJXAMKXwj/3bCPG5N0hIWbpxIQGZ2Oit6WUkVWRxLbrengIjR1R2yL5i+6s0NpW9AtTWqHWABFClPHmwpYMGnhLM2/gRSGEoERRPoBtkbjvZXA33A5zNEwc5Z0lYa4SnwSS3SkBBu27QHw+gCMqnkHr/TZOn8fnA7gP8vH0YBr5APmlc4MJX2OM0Z8/B+hlKCHGnqqT46oxxoBOOEzB8UDQlWMguBRWr29CTHAPOl53lOytTa63JwUNhraj3HwVSyEhJo/5ADoif0X6vOh1gEi3J9fHuN3peNa/BZd0XK4PXj2Jhk0mKiQfIJstEKY9KazXKWw5fIUHTcMGgnk6D+D9RFZCTOf6SO+EA4T2VrIVQKYQZBk8rh1F0OivtTA+cf7bkuAtkLA54tuRdui6FcDxXVxRHPtma+/Q3eHQOUfw1N95ybeYt4CsjJZCkdN8ACl5T8mFdCIdrFKpxE5rDNVH3OSEtyPBCJFo2E6LkuMAoVkjrgLG+DA+vMpf+2r1L7kSEglfgQBQqVSevf9+qFYuXPo8PzEXdDW0OVGFg8dWggb6WsxZ0qWJUyAGWaLE9tFlfQewxDn/vHn8HdeHrls+m/+l9648CIlKQq0Et8drjlUmtN5Q4fhiYk30iKQmSk4sECYwo1Rqq8vr0PkREpWEWgluT9Ic35KuekOFhyqPsYO3ZCipiaIvwUSh6YgD6H7bU99XUF7/43fzLySUhFrhb7dmMudV/Ls9fW/H3IgUIvEto6mJonBoothE/UrhxQitUdT2nxnMwE/FCva0foVuBaOa8TxWLIMVMaq2p6G0Qje8gR9mMI91arn3V49WWBHjmqqqZi2KasWGgB1qwtxxo2g0zpiiWpoA+MSAeAOeQQ2/5H/VG15l2VZR1VaEJajCq0rwJb/gTaM3TVsx/+hLjSuKwoz4TZUzowvMgREl2Mrb0c4QVLMfI0rjCjClLRDYvEwrAFFsInkTEYCxCJgLUNyVhOgQdlSpNxiOVgCi0NBjUKLQkAMQhYYcgCg05ABEoSEHIAoNOQBRaMgBiEJDDkAUGnIAotCQAxDFJtsoDYIIxo5mVVUOnsM9AcCKQWaMMaXt9F8zaNUMjFWdd1mRyDrFAhEFh7ZARE/yYGrHnyYaAABM2dSY+Q/XXp0Yqqv6q7tKdQBg/GuNiY90/W1aAYhCQysAUWj+D//cKR3k9XGpAAAAAElFTkSuQmCC</ATTRIBUTE>
+<ATTRIBUTE name="NT Model Attributes" type="LONGSTRING">NOTEBOOK
+CHAPTER &quot;Description&quot;
+#ATTR &quot;Shared&quot;
+ATTR &quot;Model state&quot; enabled:(cond(search (sMfbRegistration, &quot;MFB_VERS&quot;, 0) = -1, 1, 0))
+ATTR &quot;Description&quot;
+ATTR &quot;Show State&quot; ctrltype:check unchecked-value:&quot;No&quot; checked-value:&quot;Yes&quot; 
+ATTR &quot;Last user&quot; write-protected
+ATTR &quot;Date last changed&quot; write-protected
+#CHAPTER &quot;Suggestion for improvement&quot;
+#ATTR &quot;Suggestion for improvement&quot;
+</ATTRIBUTE>
+<ATTRIBUTE name="Model state" type="ENUMERATION">Draft</ATTRIBUTE>
+<ATTRIBUTE name="People-like view" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Action" type="ENUMERATION">Fill in</ATTRIBUTE>
+<ATTRIBUTE name="Keywords" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Description" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Model type" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Show State" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="BAR Display active" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Actor_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="Actor_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Actor_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="Description_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="Description_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Description_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="ModelingAreaSize" type="ENUMERATION">15</ATTRIBUTE>
+<ATTRIBUTE name="Modelling_size" type="ENUMERATION">3</ATTRIBUTE>
+<ATTRIBUTE name="DrawingAreaWidth" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="DrawingAreaHeight" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Reference overview settings" type="LONGSTRING">Responsible for execution|Responsible for execution
+Accountable for approving results|Accountable for approving results
+Cooperation/participation|Cooperation/participation
+To inform|To inform
+Modelling|Modelling
+Knowledge Product|Knowledge Product
+Documents and Resources|Documents and Resources
+#Data Object|Data Object
+Incoming Data Object|Incoming Data Object
+Outgoing Data Object|Outgoing Data Object
+Description|Description</ATTRIBUTE>
+<ATTRIBUTE name="Data Object_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="Data Object_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Data Object_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="Knowledge Product_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="Knowledge Product_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Knowledge Product_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="Documents and Resources_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Documents and Resources_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="Documents and Resources_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="Responsible for execution_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="Responsible for execution_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Responsible for execution_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="Accountable for approving results_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="Accountable for approving results_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Accountable for approving results_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="Cooperation/participation_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="Cooperation/participation_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Cooperation/participation_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="To inform_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="To inform_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="To inform_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="Incoming Data Object_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="Incoming Data Object_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Incoming Data Object_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="Outgoing Data Object_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="Outgoing Data Object_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Outgoing Data Object_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="id_bpmndi_diagram" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="id_bpmndi_plane" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="id_bpmndi_collaboration" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="CommentModellingAreaSize" type="ENUMERATION">3</ATTRIBUTE>
+<ATTRIBUTE name="CommentTypeSize" type="ENUMERATION">8</ATTRIBUTE>
+<ATTRIBUTE name="CommentAreaSize" type="ENUMERATION">2</ATTRIBUTE>
+<ATTRIBUTE name="Comment Mode" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="CommentxCoorTextBox" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="CommentyCoorTextBox" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="CommentModellingDirection" type="ENUMERATION">vertical</ATTRIBUTE>
+</MODELATTRIBUTES>
+<INSTANCE id="obj.16638" class="Organizational unit" name="Comune">
+<ATTRIBUTE name="Position" type="STRING">NODE x:12.5cm y:1.5cm w:2.4cm h:1.5cm index:1</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<INTERREF name="Model reference"></INTERREF>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Organisationseinheit</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Submodelname" type="EXPRESSION">EXPR val:&quot;Bezeichnung&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Type" type="ENUMERATION">Standard</ATTRIBUTE>
+<ATTRIBUTE name="Functional unit" type="ENUMERATION">no</ATTRIBUTE>
+<ATTRIBUTE name="Manager" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Function" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Level" type="INTEGER">0</ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16641" class="Role" name="Sindaco">
+<ATTRIBUTE name="Position" type="STRING">NODE x:2cm y:7.5cm w:1.5cm h:1.47cm index:2</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Rolle</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16644" class="Performer" name="Maurizio Mangialardi">
+<ATTRIBUTE name="Position" type="STRING">NODE x:2cm y:10cm w:2.2cm h:1.15cm index:4</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Hourly wages" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Calendar" type="LONGSTRING">B@Working day@b@32400-43200@T@45000-59400@T@Free day@c@@@$cbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbcbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbcbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbcccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbccbbccb</ATTRIBUTE>
+<ATTRIBUTE name="Availability" type="EXPRESSION">EXPR expr:(round(paval(&quot;Presence&quot;,&quot;Hours per day&quot;)*paval(&quot;Presence&quot;,&quot;Days per week&quot;)/40*100)) val:100</ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Time dependent costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Info on results" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Workload" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Capacity" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Personnel costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Bearbeiter</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<RECORD name="Further education"></RECORD>
+<ATTRIBUTE name="Presence" type="ATTRPROFREF"></ATTRIBUTE>
+<ATTRIBUTE name="E-Mail" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16647" class="Organizational unit" name="Area Tecnica Territorio e Ambiente">
+<ATTRIBUTE name="Position" type="STRING">NODE x:12.5cm y:6.5cm w:2.4cm h:1.5cm index:6</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<INTERREF name="Model reference"></INTERREF>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Organisationseinheit</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Submodelname" type="EXPRESSION">EXPR val:&quot;Bezeichnung&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Type" type="ENUMERATION">Standard</ATTRIBUTE>
+<ATTRIBUTE name="Functional unit" type="ENUMERATION">no</ATTRIBUTE>
+<ATTRIBUTE name="Manager" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Function" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Level" type="INTEGER">0</ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16650" class="Organizational unit" name="Area Turismo Promozione e Sviluppo Econmico">
+<ATTRIBUTE name="Position" type="STRING">NODE x:39.5cm y:6.5cm w:2.4cm h:1.5cm index:7</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<INTERREF name="Model reference"></INTERREF>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Organisationseinheit</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Submodelname" type="EXPRESSION">EXPR val:&quot;Bezeichnung&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Type" type="ENUMERATION">Standard</ATTRIBUTE>
+<ATTRIBUTE name="Functional unit" type="ENUMERATION">no</ATTRIBUTE>
+<ATTRIBUTE name="Manager" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Function" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Level" type="INTEGER">0</ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16653" class="Organizational unit" name="Area Organizzativa e Risorse Finanziarie">
+<ATTRIBUTE name="Position" type="STRING">NODE x:56.5cm y:6.5cm w:2.4cm h:1.5cm index:8</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<INTERREF name="Model reference"></INTERREF>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Organisationseinheit</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Submodelname" type="EXPRESSION">EXPR val:&quot;Bezeichnung&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Type" type="ENUMERATION">Standard</ATTRIBUTE>
+<ATTRIBUTE name="Functional unit" type="ENUMERATION">no</ATTRIBUTE>
+<ATTRIBUTE name="Manager" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Function" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Level" type="INTEGER">0</ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16656" class="Organizational unit" name="Area Persona">
+<ATTRIBUTE name="Position" type="STRING">NODE x:62.5cm y:6.5cm w:2.4cm h:1.5cm index:9</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<INTERREF name="Model reference"></INTERREF>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Organisationseinheit</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Submodelname" type="EXPRESSION">EXPR val:&quot;Bezeichnung&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Type" type="ENUMERATION">Standard</ATTRIBUTE>
+<ATTRIBUTE name="Functional unit" type="ENUMERATION">no</ATTRIBUTE>
+<ATTRIBUTE name="Manager" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Function" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Level" type="INTEGER">0</ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16659" class="Organizational unit" name="Ufficio Programmazione Urbanistica">
+<ATTRIBUTE name="Position" type="STRING">NODE x:7cm y:12cm w:2.4cm h:1.5cm index:10</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<INTERREF name="Model reference"></INTERREF>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Organisationseinheit</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Submodelname" type="EXPRESSION">EXPR val:&quot;Bezeichnung&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Type" type="ENUMERATION">Standard</ATTRIBUTE>
+<ATTRIBUTE name="Functional unit" type="ENUMERATION">no</ATTRIBUTE>
+<ATTRIBUTE name="Manager" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Function" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Level" type="INTEGER">0</ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16662" class="Organizational unit" name="Sportello Unico Edilizia">
+<ATTRIBUTE name="Position" type="STRING">NODE x:10cm y:12cm w:2.4cm h:1.5cm index:12</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<INTERREF name="Model reference"></INTERREF>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Organisationseinheit</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Submodelname" type="EXPRESSION">EXPR val:&quot;Bezeichnung&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Type" type="ENUMERATION">Standard</ATTRIBUTE>
+<ATTRIBUTE name="Functional unit" type="ENUMERATION">no</ATTRIBUTE>
+<ATTRIBUTE name="Manager" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Function" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Level" type="INTEGER">0</ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16665" class="Organizational unit" name="Ufficio Gestione Ambiente">
+<ATTRIBUTE name="Position" type="STRING">NODE x:13cm y:12cm w:2.4cm h:1.5cm index:13</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<INTERREF name="Model reference"></INTERREF>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Organisationseinheit</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Submodelname" type="EXPRESSION">EXPR val:&quot;Bezeichnung&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Type" type="ENUMERATION">Standard</ATTRIBUTE>
+<ATTRIBUTE name="Functional unit" type="ENUMERATION">no</ATTRIBUTE>
+<ATTRIBUTE name="Manager" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Function" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Level" type="INTEGER">0</ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16668" class="Organizational unit" name="Ufficio Strade Mobilità e Territorio">
+<ATTRIBUTE name="Position" type="STRING">NODE x:16cm y:12cm w:2.4cm h:1.5cm index:14</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<INTERREF name="Model reference"></INTERREF>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Organisationseinheit</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Submodelname" type="EXPRESSION">EXPR val:&quot;Bezeichnung&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Type" type="ENUMERATION">Standard</ATTRIBUTE>
+<ATTRIBUTE name="Functional unit" type="ENUMERATION">no</ATTRIBUTE>
+<ATTRIBUTE name="Manager" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Function" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Level" type="INTEGER">0</ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16671" class="Organizational unit" name="Ufficio Porto">
+<ATTRIBUTE name="Position" type="STRING">NODE x:19cm y:12cm w:2.4cm h:1.5cm index:15</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<INTERREF name="Model reference"></INTERREF>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Organisationseinheit</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Submodelname" type="EXPRESSION">EXPR val:&quot;Bezeichnung&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Type" type="ENUMERATION">Standard</ATTRIBUTE>
+<ATTRIBUTE name="Functional unit" type="ENUMERATION">no</ATTRIBUTE>
+<ATTRIBUTE name="Manager" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Function" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Level" type="INTEGER">0</ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16674" class="Organizational unit" name="Sviluppo Urbano Sostenibile">
+<ATTRIBUTE name="Position" type="STRING">NODE x:22cm y:12cm w:2.4cm h:1.5cm index:16</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<INTERREF name="Model reference"></INTERREF>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Organisationseinheit</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Submodelname" type="EXPRESSION">EXPR val:&quot;Bezeichnung&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Type" type="ENUMERATION">Standard</ATTRIBUTE>
+<ATTRIBUTE name="Functional unit" type="ENUMERATION">no</ATTRIBUTE>
+<ATTRIBUTE name="Manager" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Function" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Level" type="INTEGER">0</ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16677" class="Role" name="Responsabile Ufficio Programmazione Urbanistica">
+<ATTRIBUTE name="Position" type="STRING">NODE x:7cm y:16cm w:1.5cm h:1.47cm index:26</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Rolle</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16680" class="Performer" name="Serenalli Roberto">
+<ATTRIBUTE name="Position" type="STRING">NODE x:7cm y:20cm w:2.2cm h:1.15cm index:27</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Hourly wages" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Calendar" type="LONGSTRING">B@Working day@b@32400-43200@T@45000-59400@T@Free day@c@@@$cbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbcbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbcbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbcccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbccbbccb</ATTRIBUTE>
+<ATTRIBUTE name="Availability" type="EXPRESSION">EXPR expr:(round(paval(&quot;Presence&quot;,&quot;Hours per day&quot;)*paval(&quot;Presence&quot;,&quot;Days per week&quot;)/40*100)) val:100</ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Time dependent costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Info on results" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Workload" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Capacity" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Personnel costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Bearbeiter</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<RECORD name="Further education"></RECORD>
+<ATTRIBUTE name="Presence" type="ATTRPROFREF"></ATTRIBUTE>
+<ATTRIBUTE name="E-Mail" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16683" class="Role" name="Responsabile Sportello Unico Edilizia">
+<ATTRIBUTE name="Position" type="STRING">NODE x:10cm y:16cm w:1.5cm h:1.47cm index:30</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Rolle</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16686" class="Role" name="Responsabile Ufficio Gestione Ambiente">
+<ATTRIBUTE name="Position" type="STRING">NODE x:13cm y:16cm w:1.5cm h:1.47cm index:31</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Rolle</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16689" class="Role" name="Responsabile Ufficio Strade Mobilità e Territorio">
+<ATTRIBUTE name="Position" type="STRING">NODE x:16cm y:16cm w:1.5cm h:1.47cm index:32</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Rolle</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16692" class="Role" name="Responsabile Ufficio Porto">
+<ATTRIBUTE name="Position" type="STRING">NODE x:19cm y:16cm w:1.5cm h:1.47cm index:33</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Rolle</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16695" class="Role" name="Responsabile Sviluppo Urbano Sostenibile">
+<ATTRIBUTE name="Position" type="STRING">NODE x:22cm y:16cm w:1.5cm h:1.47cm index:34</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Rolle</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16698" class="Performer" name="Mario Partenico">
+<ATTRIBUTE name="Position" type="STRING">NODE x:10cm y:20cm w:2.2cm h:1.15cm index:35</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Hourly wages" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Calendar" type="LONGSTRING">B@Working day@b@32400-43200@T@45000-59400@T@Free day@c@@@$cbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbcbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbcbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbcccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbccbbccb</ATTRIBUTE>
+<ATTRIBUTE name="Availability" type="EXPRESSION">EXPR expr:(round(paval(&quot;Presence&quot;,&quot;Hours per day&quot;)*paval(&quot;Presence&quot;,&quot;Days per week&quot;)/40*100)) val:100</ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Time dependent costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Info on results" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Workload" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Capacity" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Personnel costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Bearbeiter</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<RECORD name="Further education"></RECORD>
+<ATTRIBUTE name="Presence" type="ATTRPROFREF"></ATTRIBUTE>
+<ATTRIBUTE name="E-Mail" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16701" class="Performer" name="Sara Giorgetti">
+<ATTRIBUTE name="Position" type="STRING">NODE x:13cm y:20cm w:2.2cm h:1.15cm index:36</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Hourly wages" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Calendar" type="LONGSTRING">B@Working day@b@32400-43200@T@45000-59400@T@Free day@c@@@$cbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbcbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbcbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbcccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbccbbccb</ATTRIBUTE>
+<ATTRIBUTE name="Availability" type="EXPRESSION">EXPR expr:(round(paval(&quot;Presence&quot;,&quot;Hours per day&quot;)*paval(&quot;Presence&quot;,&quot;Days per week&quot;)/40*100)) val:100</ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Time dependent costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Info on results" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Workload" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Capacity" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Personnel costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Bearbeiter</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<RECORD name="Further education"></RECORD>
+<ATTRIBUTE name="Presence" type="ATTRPROFREF"></ATTRIBUTE>
+<ATTRIBUTE name="E-Mail" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16704" class="Performer" name="Maurizio Piccini">
+<ATTRIBUTE name="Position" type="STRING">NODE x:16cm y:20cm w:2.2cm h:1.15cm index:37</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Hourly wages" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Calendar" type="LONGSTRING">B@Working day@b@32400-43200@T@45000-59400@T@Free day@c@@@$cbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbcbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbcbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbcccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbccbbccb</ATTRIBUTE>
+<ATTRIBUTE name="Availability" type="EXPRESSION">EXPR expr:(round(paval(&quot;Presence&quot;,&quot;Hours per day&quot;)*paval(&quot;Presence&quot;,&quot;Days per week&quot;)/40*100)) val:100</ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Time dependent costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Info on results" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Workload" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Capacity" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Personnel costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Bearbeiter</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<RECORD name="Further education"></RECORD>
+<ATTRIBUTE name="Presence" type="ATTRPROFREF"></ATTRIBUTE>
+<ATTRIBUTE name="E-Mail" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16707" class="Performer" name="Silvano Simonetti">
+<ATTRIBUTE name="Position" type="STRING">NODE x:19cm y:20cm w:2.2cm h:1.15cm index:38</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Hourly wages" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Calendar" type="LONGSTRING">B@Working day@b@32400-43200@T@45000-59400@T@Free day@c@@@$cbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbcbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbcbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbcccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbccbbccb</ATTRIBUTE>
+<ATTRIBUTE name="Availability" type="EXPRESSION">EXPR expr:(round(paval(&quot;Presence&quot;,&quot;Hours per day&quot;)*paval(&quot;Presence&quot;,&quot;Days per week&quot;)/40*100)) val:100</ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Time dependent costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Info on results" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Workload" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Capacity" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Personnel costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Bearbeiter</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<RECORD name="Further education"></RECORD>
+<ATTRIBUTE name="Presence" type="ATTRPROFREF"></ATTRIBUTE>
+<ATTRIBUTE name="E-Mail" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16710" class="Performer" name="Stefano Giacai">
+<ATTRIBUTE name="Position" type="STRING">NODE x:22cm y:20cm w:2.2cm h:1.15cm index:39</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Hourly wages" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Calendar" type="LONGSTRING">B@Working day@b@32400-43200@T@45000-59400@T@Free day@c@@@$cbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbcbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbcbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbcccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbccbbccb</ATTRIBUTE>
+<ATTRIBUTE name="Availability" type="EXPRESSION">EXPR expr:(round(paval(&quot;Presence&quot;,&quot;Hours per day&quot;)*paval(&quot;Presence&quot;,&quot;Days per week&quot;)/40*100)) val:100</ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Time dependent costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Info on results" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Workload" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Capacity" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Personnel costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Bearbeiter</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<RECORD name="Further education"></RECORD>
+<ATTRIBUTE name="Presence" type="ATTRPROFREF"></ATTRIBUTE>
+<ATTRIBUTE name="E-Mail" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16713" class="Role" name="Dirigente">
+<ATTRIBUTE name="Position" type="STRING">NODE x:26cm y:12cm w:1.5cm h:1.47cm index:50</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Rolle</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16716" class="Performer" name="Paolo Mattei">
+<ATTRIBUTE name="Position" type="STRING">NODE x:26cm y:15.5cm w:2.2cm h:1.15cm index:51</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Hourly wages" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Calendar" type="LONGSTRING">B@Working day@b@32400-43200@T@45000-59400@T@Free day@c@@@$cbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbcbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbcbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbcccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbccbbccb</ATTRIBUTE>
+<ATTRIBUTE name="Availability" type="EXPRESSION">EXPR expr:(round(paval(&quot;Presence&quot;,&quot;Hours per day&quot;)*paval(&quot;Presence&quot;,&quot;Days per week&quot;)/40*100)) val:100</ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Time dependent costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Info on results" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Workload" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Capacity" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Personnel costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Bearbeiter</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<RECORD name="Further education"></RECORD>
+<ATTRIBUTE name="Presence" type="ATTRPROFREF"></ATTRIBUTE>
+<ATTRIBUTE name="E-Mail" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16719" class="Organizational unit" name="SUAP Office">
+<ATTRIBUTE name="Position" type="STRING">NODE x:34.5cm y:12cm w:2.4cm h:1.5cm index:54</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<INTERREF name="Model reference"></INTERREF>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Organisationseinheit</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Submodelname" type="EXPRESSION">EXPR val:&quot;Bezeichnung&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Type" type="ENUMERATION">Standard</ATTRIBUTE>
+<ATTRIBUTE name="Functional unit" type="ENUMERATION">no</ATTRIBUTE>
+<ATTRIBUTE name="Manager" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Function" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Level" type="INTEGER">0</ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16722" class="Role" name="Geometra">
+<ATTRIBUTE name="Position" type="STRING">NODE x:34.5cm y:16cm w:1.5cm h:1.47cm index:55</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Rolle</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16725" class="Role" name="Responsabile Ufficio SUAP">
+<ATTRIBUTE name="Position" type="STRING">NODE x:29cm y:16cm w:1.5cm h:1.47cm index:56</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Rolle</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16728" class="Role" name="Amministrazione">
+<ATTRIBUTE name="Position" type="STRING">NODE x:42.5cm y:16cm w:1.5cm h:1.47cm index:57</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Rolle</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16731" class="Performer" name="Francesca Freschi">
+<ATTRIBUTE name="Position" type="STRING">NODE x:29cm y:20cm w:2.2cm h:1.15cm index:62</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Hourly wages" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Calendar" type="LONGSTRING">B@Working day@b@32400-43200@T@45000-59400@T@Free day@c@@@$cbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbcbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbcbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbcccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbccbbccb</ATTRIBUTE>
+<ATTRIBUTE name="Availability" type="EXPRESSION">EXPR expr:(round(paval(&quot;Presence&quot;,&quot;Hours per day&quot;)*paval(&quot;Presence&quot;,&quot;Days per week&quot;)/40*100)) val:100</ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Time dependent costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Info on results" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Workload" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Capacity" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Personnel costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Bearbeiter</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<RECORD name="Further education"></RECORD>
+<ATTRIBUTE name="Presence" type="ATTRPROFREF"></ATTRIBUTE>
+<ATTRIBUTE name="E-Mail" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16734" class="Performer" name="Geometra1">
+<ATTRIBUTE name="Position" type="STRING">NODE x:32cm y:20cm w:2.2cm h:1.15cm index:63</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Hourly wages" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Calendar" type="LONGSTRING">B@Working day@b@32400-43200@T@45000-59400@T@Free day@c@@@$cbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbcbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbcbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbcccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbccbbccb</ATTRIBUTE>
+<ATTRIBUTE name="Availability" type="EXPRESSION">EXPR expr:(round(paval(&quot;Presence&quot;,&quot;Hours per day&quot;)*paval(&quot;Presence&quot;,&quot;Days per week&quot;)/40*100)) val:100</ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Time dependent costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Info on results" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Workload" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Capacity" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Personnel costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Bearbeiter</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<RECORD name="Further education"></RECORD>
+<ATTRIBUTE name="Presence" type="ATTRPROFREF"></ATTRIBUTE>
+<ATTRIBUTE name="E-Mail" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16737" class="Performer" name="Amministrativo2">
+<ATTRIBUTE name="Position" type="STRING">NODE x:42.5cm y:20cm w:2.2cm h:1.15cm index:64</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Hourly wages" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Calendar" type="LONGSTRING">B@Working day@b@32400-43200@T@45000-59400@T@Free day@c@@@$cbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbcbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbcbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbcccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbccbbccb</ATTRIBUTE>
+<ATTRIBUTE name="Availability" type="EXPRESSION">EXPR expr:(round(paval(&quot;Presence&quot;,&quot;Hours per day&quot;)*paval(&quot;Presence&quot;,&quot;Days per week&quot;)/40*100)) val:100</ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Time dependent costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Info on results" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Workload" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Capacity" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Personnel costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Bearbeiter</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<RECORD name="Further education"></RECORD>
+<ATTRIBUTE name="Presence" type="ATTRPROFREF"></ATTRIBUTE>
+<ATTRIBUTE name="E-Mail" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16740" class="Performer" name="Geometra2">
+<ATTRIBUTE name="Position" type="STRING">NODE x:34.5cm y:20cm w:2.2cm h:1.15cm index:65</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Hourly wages" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Calendar" type="LONGSTRING">B@Working day@b@32400-43200@T@45000-59400@T@Free day@c@@@$cbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbcbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbcbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbcccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbccbbccb</ATTRIBUTE>
+<ATTRIBUTE name="Availability" type="EXPRESSION">EXPR expr:(round(paval(&quot;Presence&quot;,&quot;Hours per day&quot;)*paval(&quot;Presence&quot;,&quot;Days per week&quot;)/40*100)) val:100</ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Time dependent costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Info on results" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Workload" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Capacity" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Personnel costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Bearbeiter</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<RECORD name="Further education"></RECORD>
+<ATTRIBUTE name="Presence" type="ATTRPROFREF"></ATTRIBUTE>
+<ATTRIBUTE name="E-Mail" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16743" class="Performer" name="Geometra3">
+<ATTRIBUTE name="Position" type="STRING">NODE x:37cm y:20cm w:2.2cm h:1.15cm index:66</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Hourly wages" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Calendar" type="LONGSTRING">B@Working day@b@32400-43200@T@45000-59400@T@Free day@c@@@$cbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbcbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbcbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbcccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbccbbccb</ATTRIBUTE>
+<ATTRIBUTE name="Availability" type="EXPRESSION">EXPR expr:(round(paval(&quot;Presence&quot;,&quot;Hours per day&quot;)*paval(&quot;Presence&quot;,&quot;Days per week&quot;)/40*100)) val:100</ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Time dependent costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Info on results" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Workload" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Capacity" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Personnel costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Bearbeiter</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<RECORD name="Further education"></RECORD>
+<ATTRIBUTE name="Presence" type="ATTRPROFREF"></ATTRIBUTE>
+<ATTRIBUTE name="E-Mail" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16746" class="Performer" name="Amministrativo1">
+<ATTRIBUTE name="Position" type="STRING">NODE x:40cm y:20cm w:2.2cm h:1.15cm index:70</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Hourly wages" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Calendar" type="LONGSTRING">B@Working day@b@32400-43200@T@45000-59400@T@Free day@c@@@$cbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbcbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbcbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbcccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbccbbccb</ATTRIBUTE>
+<ATTRIBUTE name="Availability" type="EXPRESSION">EXPR expr:(round(paval(&quot;Presence&quot;,&quot;Hours per day&quot;)*paval(&quot;Presence&quot;,&quot;Days per week&quot;)/40*100)) val:100</ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Time dependent costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Info on results" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Workload" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Capacity" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Personnel costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Bearbeiter</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<RECORD name="Further education"></RECORD>
+<ATTRIBUTE name="Presence" type="ATTRPROFREF"></ATTRIBUTE>
+<ATTRIBUTE name="E-Mail" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16749" class="Performer" name="Amministrativo3">
+<ATTRIBUTE name="Position" type="STRING">NODE x:45cm y:20cm w:2.2cm h:1.15cm index:71</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Hourly wages" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Calendar" type="LONGSTRING">B@Working day@b@32400-43200@T@45000-59400@T@Free day@c@@@$cbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbcbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbcbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbcccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbccbbccb</ATTRIBUTE>
+<ATTRIBUTE name="Availability" type="EXPRESSION">EXPR expr:(round(paval(&quot;Presence&quot;,&quot;Hours per day&quot;)*paval(&quot;Presence&quot;,&quot;Days per week&quot;)/40*100)) val:100</ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Time dependent costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Info on results" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Workload" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Capacity" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Personnel costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Bearbeiter</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<RECORD name="Further education"></RECORD>
+<ATTRIBUTE name="Presence" type="ATTRPROFREF"></ATTRIBUTE>
+<ATTRIBUTE name="E-Mail" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16752" class="Organizational unit" name="Ufficio Attività Economiche">
+<ATTRIBUTE name="Position" type="STRING">NODE x:48.5cm y:12cm w:2.4cm h:1.5cm index:76</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<INTERREF name="Model reference"></INTERREF>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Organisationseinheit</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Submodelname" type="EXPRESSION">EXPR val:&quot;Bezeichnung&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Type" type="ENUMERATION">Standard</ATTRIBUTE>
+<ATTRIBUTE name="Functional unit" type="ENUMERATION">no</ATTRIBUTE>
+<ATTRIBUTE name="Manager" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Function" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Level" type="INTEGER">0</ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16755" class="Organizational unit" name="Ufficio Sviluppo Economico">
+<ATTRIBUTE name="Position" type="STRING">NODE x:52cm y:12cm w:2.4cm h:1.5cm index:77</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<INTERREF name="Model reference"></INTERREF>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Organisationseinheit</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Submodelname" type="EXPRESSION">EXPR val:&quot;Bezeichnung&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Type" type="ENUMERATION">Standard</ATTRIBUTE>
+<ATTRIBUTE name="Functional unit" type="ENUMERATION">no</ATTRIBUTE>
+<ATTRIBUTE name="Manager" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Function" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Level" type="INTEGER">0</ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16758" class="Role" name="Responsabile Ufficio Tributi Economato">
+<ATTRIBUTE name="Position" type="STRING">NODE x:48.5cm y:16cm w:1.5cm h:1.47cm index:80</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Rolle</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16761" class="Performer" name="Perini Rosanna">
+<ATTRIBUTE name="Position" type="STRING">NODE x:48.5cm y:20cm w:2.2cm h:1.15cm index:82</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Hourly wages" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Calendar" type="LONGSTRING">B@Working day@b@32400-43200@T@45000-59400@T@Free day@c@@@$cbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbcbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbcbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbcccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbccbbccb</ATTRIBUTE>
+<ATTRIBUTE name="Availability" type="EXPRESSION">EXPR expr:(round(paval(&quot;Presence&quot;,&quot;Hours per day&quot;)*paval(&quot;Presence&quot;,&quot;Days per week&quot;)/40*100)) val:100</ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Time dependent costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Info on results" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Workload" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Capacity" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Personnel costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Bearbeiter</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<RECORD name="Further education"></RECORD>
+<ATTRIBUTE name="Presence" type="ATTRPROFREF"></ATTRIBUTE>
+<ATTRIBUTE name="E-Mail" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16764" class="Role" name="Responsabile Ufficio Sviluppo Economico">
+<ATTRIBUTE name="Position" type="STRING">NODE x:52cm y:16cm w:1.5cm h:1.47cm index:84</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Rolle</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16767" class="Performer" name="Laura Sorellini">
+<ATTRIBUTE name="Position" type="STRING">NODE x:52cm y:20cm w:2.2cm h:1.15cm index:85</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Hourly wages" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Calendar" type="LONGSTRING">B@Working day@b@32400-43200@T@45000-59400@T@Free day@c@@@$cbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbcbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbcbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbcccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbccbbccb</ATTRIBUTE>
+<ATTRIBUTE name="Availability" type="EXPRESSION">EXPR expr:(round(paval(&quot;Presence&quot;,&quot;Hours per day&quot;)*paval(&quot;Presence&quot;,&quot;Days per week&quot;)/40*100)) val:100</ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Time dependent costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Info on results" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Workload" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Capacity" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Personnel costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Bearbeiter</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<RECORD name="Further education"></RECORD>
+<ATTRIBUTE name="Presence" type="ATTRPROFREF"></ATTRIBUTE>
+<ATTRIBUTE name="E-Mail" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16770" class="Organizational unit" name="Ufficio Tributi e Canoni">
+<ATTRIBUTE name="Position" type="STRING">NODE x:58.5cm y:12cm w:2.4cm h:1.5cm index:88</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<INTERREF name="Model reference"></INTERREF>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Organisationseinheit</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Submodelname" type="EXPRESSION">EXPR val:&quot;Bezeichnung&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Type" type="ENUMERATION">Standard</ATTRIBUTE>
+<ATTRIBUTE name="Functional unit" type="ENUMERATION">no</ATTRIBUTE>
+<ATTRIBUTE name="Manager" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Function" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Level" type="INTEGER">0</ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16773" class="Role" name="Responsabile Ufficio Tributi e Canoni">
+<ATTRIBUTE name="Position" type="STRING">NODE x:58.5cm y:16cm w:1.5cm h:1.47cm index:89</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Rolle</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16776" class="Performer" name="Gabriele Paoletti">
+<ATTRIBUTE name="Position" type="STRING">NODE x:58.5cm y:20cm w:2.2cm h:1.15cm index:90</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Hourly wages" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Calendar" type="LONGSTRING">B@Working day@b@32400-43200@T@45000-59400@T@Free day@c@@@$cbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbcbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbcbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbcccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbccbbccb</ATTRIBUTE>
+<ATTRIBUTE name="Availability" type="EXPRESSION">EXPR expr:(round(paval(&quot;Presence&quot;,&quot;Hours per day&quot;)*paval(&quot;Presence&quot;,&quot;Days per week&quot;)/40*100)) val:100</ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Time dependent costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Info on results" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Workload" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Capacity" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Personnel costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Bearbeiter</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<RECORD name="Further education"></RECORD>
+<ATTRIBUTE name="Presence" type="ATTRPROFREF"></ATTRIBUTE>
+<ATTRIBUTE name="E-Mail" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16779" class="Role" name="Responsabile Area Organizzativa e Risorse Finanziarie">
+<ATTRIBUTE name="Position" type="STRING">NODE x:55.5cm y:12cm w:1.5cm h:1.47cm index:94</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Rolle</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16782" class="Performer" name="Fiorenzi Laura">
+<ATTRIBUTE name="Position" type="STRING">NODE x:55.5cm y:16.5cm w:2.2cm h:1.15cm index:95</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Hourly wages" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Calendar" type="LONGSTRING">B@Working day@b@32400-43200@T@45000-59400@T@Free day@c@@@$cbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbcbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbcbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbcccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbccbbccb</ATTRIBUTE>
+<ATTRIBUTE name="Availability" type="EXPRESSION">EXPR expr:(round(paval(&quot;Presence&quot;,&quot;Hours per day&quot;)*paval(&quot;Presence&quot;,&quot;Days per week&quot;)/40*100)) val:100</ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Time dependent costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Info on results" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Workload" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Capacity" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Personnel costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Bearbeiter</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<RECORD name="Further education"></RECORD>
+<ATTRIBUTE name="Presence" type="ATTRPROFREF"></ATTRIBUTE>
+<ATTRIBUTE name="E-Mail" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16785" class="Role" name="Responsabile Area Persona">
+<ATTRIBUTE name="Position" type="STRING">NODE x:61.5cm y:12cm w:1.5cm h:1.47cm index:98</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Rolle</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16788" class="Organizational unit" name="Ufficio Politiche Sociali e Integrazioni Socio Sanitarie">
+<ATTRIBUTE name="Position" type="STRING">NODE x:65cm y:12cm w:2.4cm h:1.5cm index:100</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<INTERREF name="Model reference"></INTERREF>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Organisationseinheit</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Submodelname" type="EXPRESSION">EXPR val:&quot;Bezeichnung&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Type" type="ENUMERATION">Standard</ATTRIBUTE>
+<ATTRIBUTE name="Functional unit" type="ENUMERATION">no</ATTRIBUTE>
+<ATTRIBUTE name="Manager" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Function" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Level" type="INTEGER">0</ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16791" class="Performer" name="Maurizio Mandolini">
+<ATTRIBUTE name="Position" type="STRING">NODE x:61.5cm y:16.5cm w:2.2cm h:1.15cm index:102</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Hourly wages" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Calendar" type="LONGSTRING">B@Working day@b@32400-43200@T@45000-59400@T@Free day@c@@@$cbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbcbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbcbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbcccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbccbbccb</ATTRIBUTE>
+<ATTRIBUTE name="Availability" type="EXPRESSION">EXPR expr:(round(paval(&quot;Presence&quot;,&quot;Hours per day&quot;)*paval(&quot;Presence&quot;,&quot;Days per week&quot;)/40*100)) val:100</ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Time dependent costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Info on results" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Workload" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Capacity" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Personnel costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Bearbeiter</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<RECORD name="Further education"></RECORD>
+<ATTRIBUTE name="Presence" type="ATTRPROFREF"></ATTRIBUTE>
+<ATTRIBUTE name="E-Mail" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16794" class="Role" name="Responsabile Ufficio Politiche Sociali e Integrazioni Socio Sanitarie">
+<ATTRIBUTE name="Position" type="STRING">NODE x:65cm y:16cm w:1.5cm h:1.47cm index:104</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Rolle</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16797" class="Performer" name="Giuseppina Campolini">
+<ATTRIBUTE name="Position" type="STRING">NODE x:65cm y:20cm w:2.2cm h:1.15cm index:106</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Hourly wages" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Calendar" type="LONGSTRING">B@Working day@b@32400-43200@T@45000-59400@T@Free day@c@@@$cbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbcbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbcbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbcccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbccbbccb</ATTRIBUTE>
+<ATTRIBUTE name="Availability" type="EXPRESSION">EXPR expr:(round(paval(&quot;Presence&quot;,&quot;Hours per day&quot;)*paval(&quot;Presence&quot;,&quot;Days per week&quot;)/40*100)) val:100</ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Time dependent costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Info on results" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Workload" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Capacity" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Personnel costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Bearbeiter</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<RECORD name="Further education"></RECORD>
+<ATTRIBUTE name="Presence" type="ATTRPROFREF"></ATTRIBUTE>
+<ATTRIBUTE name="E-Mail" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<CONNECTOR id="con.16800" class="belongs to">
+<FROM instance="Sindaco" class="Role"></FROM>
+<TO instance="Comune" class="Organizational unit"></TO>
+<ATTRIBUTE name="Connector number" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 2 x1:2.5cm y1:4.5cm x2:12.5cm y2:4.5cm index:3</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16801" class="Has role">
+<FROM instance="Maurizio Mangialardi" class="Performer"></FROM>
+<TO instance="Sindaco" class="Role"></TO>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 0 index:5</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">0</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16802" class="Is subordinated">
+<FROM instance="Area Tecnica Territorio e Ambiente" class="Organizational unit"></FROM>
+<TO instance="Comune" class="Organizational unit"></TO>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 0 index:22</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Representation" type="ENUMERATION">with arrow</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16803" class="Is subordinated">
+<FROM instance="Area Turismo Promozione e Sviluppo Econmico" class="Organizational unit"></FROM>
+<TO instance="Comune" class="Organizational unit"></TO>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 2 x1:39.5cm y1:4.5cm x2:12.5cm y2:4.5cm index:23</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Representation" type="ENUMERATION">with arrow</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16804" class="Is subordinated">
+<FROM instance="Area Organizzativa e Risorse Finanziarie" class="Organizational unit"></FROM>
+<TO instance="Comune" class="Organizational unit"></TO>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 2 x1:56.5cm y1:4.5cm x2:12.5cm y2:4.5cm index:24</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Representation" type="ENUMERATION">with arrow</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16805" class="Is subordinated">
+<FROM instance="Area Persona" class="Organizational unit"></FROM>
+<TO instance="Comune" class="Organizational unit"></TO>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 2 x1:62.5cm y1:4.5cm x2:12.5cm y2:4.5cm index:25</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Representation" type="ENUMERATION">with arrow</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16806" class="Is subordinated">
+<FROM instance="Ufficio Programmazione Urbanistica" class="Organizational unit"></FROM>
+<TO instance="Area Tecnica Territorio e Ambiente" class="Organizational unit"></TO>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 2 x1:7cm y1:10cm x2:12.5cm y2:10cm index:11</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Representation" type="ENUMERATION">with arrow</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16807" class="Is subordinated">
+<FROM instance="Sportello Unico Edilizia" class="Organizational unit"></FROM>
+<TO instance="Area Tecnica Territorio e Ambiente" class="Organizational unit"></TO>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 2 x1:10cm y1:10cm x2:12.5cm y2:10cm index:17</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Representation" type="ENUMERATION">with arrow</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16808" class="Is subordinated">
+<FROM instance="Ufficio Gestione Ambiente" class="Organizational unit"></FROM>
+<TO instance="Area Tecnica Territorio e Ambiente" class="Organizational unit"></TO>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 1 x1:12.5cm y1:10.5cm index:18</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Representation" type="ENUMERATION">with arrow</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16809" class="Is subordinated">
+<FROM instance="Ufficio Strade Mobilità e Territorio" class="Organizational unit"></FROM>
+<TO instance="Area Tecnica Territorio e Ambiente" class="Organizational unit"></TO>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 2 x1:16cm y1:10cm x2:12.5cm y2:10cm index:19</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Representation" type="ENUMERATION">with arrow</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16810" class="Is subordinated">
+<FROM instance="Ufficio Porto" class="Organizational unit"></FROM>
+<TO instance="Area Tecnica Territorio e Ambiente" class="Organizational unit"></TO>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 2 x1:19cm y1:10cm x2:12.5cm y2:10cm index:20</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Representation" type="ENUMERATION">with arrow</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16811" class="Is subordinated">
+<FROM instance="Sviluppo Urbano Sostenibile" class="Organizational unit"></FROM>
+<TO instance="Area Tecnica Territorio e Ambiente" class="Organizational unit"></TO>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 2 x1:22cm y1:10cm x2:12.5cm y2:10cm index:21</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Representation" type="ENUMERATION">with arrow</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16812" class="belongs to">
+<FROM instance="Responsabile Ufficio Programmazione Urbanistica" class="Role"></FROM>
+<TO instance="Ufficio Programmazione Urbanistica" class="Organizational unit"></TO>
+<ATTRIBUTE name="Connector number" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 0 index:28</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16813" class="Has role">
+<FROM instance="Serenalli Roberto" class="Performer"></FROM>
+<TO instance="Responsabile Ufficio Programmazione Urbanistica" class="Role"></TO>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 0 index:29</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">0</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16814" class="belongs to">
+<FROM instance="Responsabile Sportello Unico Edilizia" class="Role"></FROM>
+<TO instance="Sportello Unico Edilizia" class="Organizational unit"></TO>
+<ATTRIBUTE name="Connector number" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 0 index:40</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16815" class="belongs to">
+<FROM instance="Responsabile Ufficio Gestione Ambiente" class="Role"></FROM>
+<TO instance="Ufficio Gestione Ambiente" class="Organizational unit"></TO>
+<ATTRIBUTE name="Connector number" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 1 x1:13cm y1:14.5cm index:41</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16816" class="belongs to">
+<FROM instance="Responsabile Ufficio Strade Mobilità e Territorio" class="Role"></FROM>
+<TO instance="Ufficio Strade Mobilità e Territorio" class="Organizational unit"></TO>
+<ATTRIBUTE name="Connector number" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 0 index:42</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16817" class="belongs to">
+<FROM instance="Responsabile Ufficio Porto" class="Role"></FROM>
+<TO instance="Ufficio Porto" class="Organizational unit"></TO>
+<ATTRIBUTE name="Connector number" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 0 index:43</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16818" class="belongs to">
+<FROM instance="Responsabile Sviluppo Urbano Sostenibile" class="Role"></FROM>
+<TO instance="Sviluppo Urbano Sostenibile" class="Organizational unit"></TO>
+<ATTRIBUTE name="Connector number" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 0 index:44</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16819" class="Has role">
+<FROM instance="Mario Partenico" class="Performer"></FROM>
+<TO instance="Responsabile Sportello Unico Edilizia" class="Role"></TO>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 0 index:45</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">0</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16820" class="Has role">
+<FROM instance="Sara Giorgetti" class="Performer"></FROM>
+<TO instance="Responsabile Ufficio Gestione Ambiente" class="Role"></TO>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 0 index:46</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">0</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16821" class="Has role">
+<FROM instance="Maurizio Piccini" class="Performer"></FROM>
+<TO instance="Responsabile Ufficio Strade Mobilità e Territorio" class="Role"></TO>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 0 index:47</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">0</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16822" class="Has role">
+<FROM instance="Silvano Simonetti" class="Performer"></FROM>
+<TO instance="Responsabile Ufficio Porto" class="Role"></TO>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 0 index:48</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">0</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16823" class="Has role">
+<FROM instance="Stefano Giacai" class="Performer"></FROM>
+<TO instance="Responsabile Sviluppo Urbano Sostenibile" class="Role"></TO>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 0 index:49</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">0</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16824" class="belongs to">
+<FROM instance="Dirigente" class="Role"></FROM>
+<TO instance="Area Turismo Promozione e Sviluppo Econmico" class="Organizational unit"></TO>
+<ATTRIBUTE name="Connector number" type="INTEGER">25</ATTRIBUTE>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 2 x1:25.5cm y1:10cm x2:39.5cm y2:10cm index:52</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16825" class="Has role">
+<FROM instance="Paolo Mattei" class="Performer"></FROM>
+<TO instance="Dirigente" class="Role"></TO>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 0 index:53</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">26</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16826" class="Is subordinated">
+<FROM instance="SUAP Office" class="Organizational unit"></FROM>
+<TO instance="Area Turismo Promozione e Sviluppo Econmico" class="Organizational unit"></TO>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 2 x1:34.5cm y1:10cm x2:39.5cm y2:10cm index:61</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">27</ATTRIBUTE>
+<ATTRIBUTE name="Representation" type="ENUMERATION">with arrow</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16827" class="belongs to">
+<FROM instance="Geometra" class="Role"></FROM>
+<TO instance="SUAP Office" class="Organizational unit"></TO>
+<ATTRIBUTE name="Connector number" type="INTEGER">28</ATTRIBUTE>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 0 index:59</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16828" class="belongs to">
+<FROM instance="Responsabile Ufficio SUAP" class="Role"></FROM>
+<TO instance="SUAP Office" class="Organizational unit"></TO>
+<ATTRIBUTE name="Connector number" type="INTEGER">29</ATTRIBUTE>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 2 x1:29cm y1:14cm x2:34.5cm y2:14cm index:58</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16829" class="belongs to">
+<FROM instance="Amministrazione" class="Role"></FROM>
+<TO instance="SUAP Office" class="Organizational unit"></TO>
+<ATTRIBUTE name="Connector number" type="INTEGER">30</ATTRIBUTE>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 2 x1:42.5cm y1:14cm x2:34.5cm y2:14cm index:60</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16830" class="Has role">
+<FROM instance="Francesca Freschi" class="Performer"></FROM>
+<TO instance="Responsabile Ufficio SUAP" class="Role"></TO>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 0 index:75</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">31</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16831" class="Is manager">
+<FROM instance="Francesca Freschi" class="Performer"></FROM>
+<TO instance="SUAP Office" class="Organizational unit"></TO>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 0 index:108</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">0</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16832" class="Has role">
+<FROM instance="Geometra1" class="Performer"></FROM>
+<TO instance="Geometra" class="Role"></TO>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 2 x1:32cm y1:18.5cm x2:34.5cm y2:18.5cm index:67</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">32</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16833" class="Has role">
+<FROM instance="Amministrativo2" class="Performer"></FROM>
+<TO instance="Amministrazione" class="Role"></TO>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 0 index:73</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">33</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16834" class="Has role">
+<FROM instance="Geometra2" class="Performer"></FROM>
+<TO instance="Geometra" class="Role"></TO>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 0 index:68</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">34</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16835" class="Has role">
+<FROM instance="Geometra3" class="Performer"></FROM>
+<TO instance="Geometra" class="Role"></TO>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 2 x1:37cm y1:18.5cm x2:34.5cm y2:18.5cm index:69</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">35</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16836" class="Has role">
+<FROM instance="Amministrativo1" class="Performer"></FROM>
+<TO instance="Amministrazione" class="Role"></TO>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 2 x1:40cm y1:18cm x2:42.5cm y2:18cm index:72</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">36</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16837" class="Has role">
+<FROM instance="Amministrativo3" class="Performer"></FROM>
+<TO instance="Amministrazione" class="Role"></TO>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 2 x1:45cm y1:18cm x2:42.5cm y2:18cm index:74</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">37</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16838" class="Is subordinated">
+<FROM instance="Ufficio Attività Economiche" class="Organizational unit"></FROM>
+<TO instance="Area Turismo Promozione e Sviluppo Econmico" class="Organizational unit"></TO>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 2 x1:48.5cm y1:10cm x2:39.5cm y2:10cm index:78</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Representation" type="ENUMERATION">with arrow</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16839" class="Is subordinated">
+<FROM instance="Ufficio Sviluppo Economico" class="Organizational unit"></FROM>
+<TO instance="Area Turismo Promozione e Sviluppo Econmico" class="Organizational unit"></TO>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 2 x1:52cm y1:10cm x2:39.5cm y2:10cm index:79</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Representation" type="ENUMERATION">with arrow</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16840" class="belongs to">
+<FROM instance="Responsabile Ufficio Tributi Economato" class="Role"></FROM>
+<TO instance="Ufficio Attività Economiche" class="Organizational unit"></TO>
+<ATTRIBUTE name="Connector number" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 0 index:81</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16841" class="Has role">
+<FROM instance="Perini Rosanna" class="Performer"></FROM>
+<TO instance="Responsabile Ufficio Tributi Economato" class="Role"></TO>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 0 index:83</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">0</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16842" class="belongs to">
+<FROM instance="Responsabile Ufficio Sviluppo Economico" class="Role"></FROM>
+<TO instance="Ufficio Sviluppo Economico" class="Organizational unit"></TO>
+<ATTRIBUTE name="Connector number" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 0 index:87</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16843" class="Has role">
+<FROM instance="Laura Sorellini" class="Performer"></FROM>
+<TO instance="Responsabile Ufficio Sviluppo Economico" class="Role"></TO>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 0 index:86</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">0</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16844" class="Is subordinated">
+<FROM instance="Ufficio Tributi e Canoni" class="Organizational unit"></FROM>
+<TO instance="Area Organizzativa e Risorse Finanziarie" class="Organizational unit"></TO>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 2 x1:58.5cm y1:10cm x2:57cm y2:10cm index:93</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Representation" type="ENUMERATION">with arrow</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16845" class="belongs to">
+<FROM instance="Responsabile Ufficio Tributi e Canoni" class="Role"></FROM>
+<TO instance="Ufficio Tributi e Canoni" class="Organizational unit"></TO>
+<ATTRIBUTE name="Connector number" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 0 index:91</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16846" class="Has role">
+<FROM instance="Gabriele Paoletti" class="Performer"></FROM>
+<TO instance="Responsabile Ufficio Tributi e Canoni" class="Role"></TO>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 0 index:92</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">0</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16847" class="belongs to">
+<FROM instance="Responsabile Area Organizzativa e Risorse Finanziarie" class="Role"></FROM>
+<TO instance="Area Organizzativa e Risorse Finanziarie" class="Organizational unit"></TO>
+<ATTRIBUTE name="Connector number" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 2 x1:55.5cm y1:10cm x2:57cm y2:10cm index:97</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16848" class="Has role">
+<FROM instance="Fiorenzi Laura" class="Performer"></FROM>
+<TO instance="Responsabile Area Organizzativa e Risorse Finanziarie" class="Role"></TO>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 0 index:96</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">0</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16849" class="belongs to">
+<FROM instance="Responsabile Area Persona" class="Role"></FROM>
+<TO instance="Area Persona" class="Organizational unit"></TO>
+<ATTRIBUTE name="Connector number" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 2 x1:61.5cm y1:10cm x2:62.5cm y2:10cm index:99</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16850" class="Is subordinated">
+<FROM instance="Ufficio Politiche Sociali e Integrazioni Socio Sanitarie" class="Organizational unit"></FROM>
+<TO instance="Area Persona" class="Organizational unit"></TO>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 2 x1:65cm y1:10cm x2:62.5cm y2:10cm index:101</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Representation" type="ENUMERATION">with arrow</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16851" class="Has role">
+<FROM instance="Maurizio Mandolini" class="Performer"></FROM>
+<TO instance="Responsabile Area Persona" class="Role"></TO>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 0 index:103</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">0</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16852" class="belongs to">
+<FROM instance="Responsabile Ufficio Politiche Sociali e Integrazioni Socio Sanitarie" class="Role"></FROM>
+<TO instance="Ufficio Politiche Sociali e Integrazioni Socio Sanitarie" class="Organizational unit"></TO>
+<ATTRIBUTE name="Connector number" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 0 index:105</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16853" class="Has role">
+<FROM instance="Giuseppina Campolini" class="Performer"></FROM>
+<TO instance="Responsabile Ufficio Politiche Sociali e Integrazioni Socio Sanitarie" class="Role"></TO>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 0 index:107</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">0</ATTRIBUTE>
+</CONNECTOR>
+</MODEL>
+<MODEL id="mod.16579" name="Org Model Monti Azzurri" version="" modeltype="Organizational structure" libtype="we" applib="LearnPAd Prototype Static Library 0.21">
+<MODELATTRIBUTES>
+<ATTRIBUTE name="Contact person" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Keywords" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Copyright info" type="STRING">Edit the model attributes to display your copyright info</ATTRIBUTE>
+<ATTRIBUTE name="Copyright info position" type="ENUMERATION">Bottom right</ATTRIBUTE>
+<ATTRIBUTE name="Model type" type="ENUMERATION">Current model</ATTRIBUTE>
+<ATTRIBUTE name="State" type="ENUMERATION">In process</ATTRIBUTE>
+<ATTRIBUTE name="Reviewed on" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Reviewed by" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Author" type="STRING">barbara</ATTRIBUTE>
+<ATTRIBUTE name="Creation date" type="STRING">13.08.2015, 15:04</ATTRIBUTE>
+<ATTRIBUTE name="Last user" type="STRING">congyu</ATTRIBUTE>
+<ATTRIBUTE name="Date last changed" type="STRING">03.09.2015, 15:24:47</ATTRIBUTE>
+<ATTRIBUTE name="Number of objects and relations" type="INTEGER">28</ATTRIBUTE>
+<ATTRIBUTE name="Context of version" type="STRING"></ATTRIBUTE>
+<RECORD name="Change history"></RECORD>
+<ATTRIBUTE name="Position" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-01] Internal error!  \&quot;fontcolor\&quot; (WEModel)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<RECORD name="Technical Attributes"></RECORD>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Keine Modellbezeichnung vergeben</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Pool Term" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="ParticipantType" type="ENUMERATION">Role</ATTRIBUTE>
+<ATTRIBUTE name="Role" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Entity" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="BoundaryVisible" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="BPD Model Attributes" type="STRING">NOTEBOOK
+
+CHAPTER &quot;Business Process Diagram Attributes&quot;
+ATTR &quot;Name&quot; write-protected
+ATTR &quot;Contact person&quot;
+ATTR &quot;Author&quot; write-protected
+ATTR &quot;Language (BPMN)&quot;
+ATTR &quot;ExpressionLanguage&quot;
+ATTR &quot;QueryLanguage&quot;
+ATTR &quot;Creation date&quot; write-protected
+ATTR &quot;Date last changed&quot; write-protected
+ATTR &quot;Documentation (Model)&quot;
+ATTR &quot;State&quot;
+
+GROUP &quot;Copyright&quot;
+ATTR &quot;Copyright info&quot; 
+ATTR &quot;Copyright info position&quot; 
+ENDGROUP
+
+CHAPTER &quot;Process Attributes&quot;
+ATTR &quot;Name&quot; write-protected
+ATTR &quot;Process Term&quot;
+ATTR &quot;ProcessType&quot;
+ATTR &quot;Status&quot;
+ATTR &quot;Assignments&quot; lines:5
+ATTR &quot;Properties (BPMN)&quot; lines:5
+ATTR &quot;AdHoc&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+GROUP &quot;AdHoc = True&quot;
+ATTR &quot;AdHocOrdering&quot;
+ATTR &quot;AdHocCompletionCondition&quot;
+ENDGROUP
+ATTR &quot;SuppressJoinFailure&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ATTR &quot;EnableInstanceCompensation&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ATTR &quot;Categories (Process)&quot;
+ATTR &quot;Documentation (Process)&quot;
+
+CHAPTER &quot;Pool Attributes&quot;
+GROUP &quot;Common Graphical Object Attributes&quot;
+ATTR &quot;Name&quot; write-protected
+ATTR &quot;Categories (Pool)&quot;
+ATTR &quot;Documentation (Pool)&quot;
+ENDGROUP
+GROUP &quot;Common Swimlane Attributes&quot;
+ATTR &quot;Pool Term&quot;
+ENDGROUP
+GROUP &quot;Pool Attributes&quot;
+ATTR &quot;ParticipantType&quot;
+ATTR &quot;Role&quot;
+ATTR &quot;Entity&quot;
+ATTR &quot;BoundaryVisible&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot; write-protected
+ENDGROUP</ATTRIBUTE>
+<ATTRIBUTE name="Language" type="ENUMERATION">System</ATTRIBUTE>
+<ATTRIBUTE name="ExpressionLanguage" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="QueryLanguage" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Process Term" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="BPD Term" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="ProcessType" type="ENUMERATION">None</ATTRIBUTE>
+<ATTRIBUTE name="Status" type="ENUMERATION">None</ATTRIBUTE>
+<RECORD name="Assignments"></RECORD>
+<ATTRIBUTE name="AdHoc" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="AdHocOrdering" type="ENUMERATION">None</ATTRIBUTE>
+<ATTRIBUTE name="AdHocCompletionCondition" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="EnableInstanceCompensation" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Categories (Process)" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation (Process)" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation (Pool)" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Categories (Pool)" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="SuppressJoinFailure" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="RACI/DEMI visualisation" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Modelling direction" type="ENUMERATION">vertical</ATTRIBUTE>
+<ATTRIBUTE name="IT systems" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Responsible role" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Input/Output" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Products" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Use cases" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Products color" type="STRING">whitesmoke</ATTRIBUTE>
+<ATTRIBUTE name="RACI/DEMI color" type="STRING">whitesmoke</ATTRIBUTE>
+<ATTRIBUTE name="Responsible role color" type="STRING">whitesmoke</ATTRIBUTE>
+<ATTRIBUTE name="Input/Output color" type="STRING">whitesmoke</ATTRIBUTE>
+<ATTRIBUTE name="Use cases color" type="STRING">whitesmoke</ATTRIBUTE>
+<ATTRIBUTE name="IT systems color" type="STRING">whitesmoke</ATTRIBUTE>
+<ATTRIBUTE name="_ToggleModelInfo_" type="PROGRAMCALL">ITEM &quot;_ToggleModelInfo_&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Display modelling information" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Documentation (Model)" type="STRING"></ATTRIBUTE>
+<RECORD name="Properties (BPMN)"></RECORD>
+<ATTRIBUTE name="CreationDate" type="EXPRESSION">EXPR val:&quot;13.08.2015, 15:04&quot;</ATTRIBUTE>
+<ATTRIBUTE name="ModificationDate" type="EXPRESSION">EXPR val:&quot;03.09.2015, 08:23:29&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Language (BPMN)" type="STRING">English</ATTRIBUTE>
+<ATTRIBUTE name="BPMN20 Model Attributes" type="LONGSTRING">NOTEBOOK
+# TODO AVAL sMfbRegistration:&quot;_MFB-Registration_&quot;
+CHAPTER &quot;Description&quot;
+ATTR &quot;Contact person&quot;
+ATTR &quot;Keywords&quot; lines:2
+ATTR &quot;Description&quot; lines:3
+ATTR &quot;Comment&quot; lines:3
+
+GROUP &quot;Copyright&quot;
+ATTR &quot;Copyright info&quot; 
+ATTR &quot;Copyright info position&quot; 
+ENDGROUP
+ATTR &quot;Name&quot; write-protected
+ATTR &quot;Id&quot; write-protected
+
+
+
+#---------------------------------------------
+CHAPTER &quot;Process properties&quot;
+#---------------------------------------------
+GROUP &quot;Process attributes&quot;
+ATTR &quot;Process type&quot; #None, Private, Public 
+ATTR &quot;Executable&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ATTR &quot;Closed&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ENDGROUP
+
+GROUP &quot;Process relevance&quot;
+ATTR &quot;Auditing&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ATTR &quot;Monitoring&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ENDGROUP
+
+CHAPTER &quot;User attributes&quot;
+ATTR &quot;Model type&quot;
+ATTR &quot;State&quot;
+ATTR &quot;Reviewed on&quot;
+ATTR &quot;Reviewed by&quot;
+
+CHAPTER &quot;System attributes&quot;
+ATTR &quot;Author&quot; write-protected
+ATTR &quot;Creation date&quot; write-protected
+ATTR &quot;Last user&quot; write-protected
+# ATTR &quot;Date last changed from&quot; write-protected
+ATTR &quot;Date last changed&quot; write-protected
+ATTR &quot;Number of objects and relations&quot; write-protected
+ATTR &quot;Context of version&quot; write-protected
+
+CHAPTER &quot;People-like view&quot;
+ATTR &quot;Action&quot;
+ATTR &quot;People-like view&quot;
+
+CHAPTER &quot;BAR Display&quot;
+ATTR &quot;BAR Display active&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot;
+AVAL s_Aktiv: &quot;BAR Display active&quot;
+ATTR &quot;Modelling direction&quot; ctrltype: radio enabled: (s_Aktiv = &quot;Yes&quot;)
+ATTR &quot;Modelling_size&quot;
+
+GROUP &quot;Responsible for execution&quot;
+ATTR &quot;Responsible for execution_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_Responsible_for_execution_display: &quot;Responsible for execution_display&quot;
+ATTR &quot;Responsible for execution_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_Responsible_for_execution_display = &quot;Yes&quot;))
+ATTR &quot;Responsible for execution_size&quot;
+ENDGROUP
+
+GROUP &quot;Accountable for approving results&quot;
+ATTR &quot;Accountable for approving results_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_Accountableforapprovingresults_display: &quot;Actor_display&quot;
+ATTR &quot;Accountable for approving results_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_Accountableforapprovingresults_display = &quot;Yes&quot;))
+ATTR &quot;Accountable for approving results_size&quot;
+ENDGROUP
+
+GROUP &quot;Cooperation/participation&quot;
+ATTR &quot;Cooperation/participation_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_Cooperationparticipation_display: &quot;Cooperation/participation_display&quot;
+ATTR &quot;Cooperation/participation_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_Cooperationparticipation_display = &quot;Yes&quot;))
+ATTR &quot;Cooperation/participation_size&quot;
+ENDGROUP
+
+GROUP &quot;To inform&quot;
+ATTR &quot;To inform_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_Toinform_display: &quot;To inform_display&quot;
+ATTR &quot;To inform_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_Toinform_display = &quot;Yes&quot;))
+ATTR &quot;To inform_size&quot;
+ENDGROUP
+
+GROUP &quot;Knowledge Product&quot;
+ATTR &quot;Knowledge Product_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_KnowledgeProduct_display: &quot;Knowledge Product_display&quot;
+ATTR &quot;Knowledge Product_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_KnowledgeProduct_display = &quot;Yes&quot;))
+ATTR &quot;Knowledge Product_size&quot;
+ENDGROUP
+
+GROUP &quot;Documents and Resources&quot;
+ATTR &quot;Documents and Resources_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_DocumentsandResources_display: &quot;Documents and Resources_display&quot;
+ATTR &quot;Documents and Resources_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_DocumentsandResources_display = &quot;Yes&quot;))
+ATTR &quot;Documents and Resources_size&quot;
+ENDGROUP
+
+GROUP &quot;Incoming Data Object&quot;
+ATTR &quot;Incoming Data Object_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_IncomingDataObject_display: &quot;Incoming Data Object_display&quot;
+ATTR &quot;Incoming Data Object_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_IncomingDataObject_display = &quot;Yes&quot;))
+ATTR &quot;Incoming Data Object_size&quot;
+ENDGROUP
+
+GROUP &quot;Outgoing Data Object&quot;
+ATTR &quot;Outgoing Data Object_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_OutgoingDataObject_display: &quot;Outgoing Data Object_display&quot;
+ATTR &quot;Outgoing Data Object_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_OutgoingDataObject_display = &quot;Yes&quot;))
+ATTR &quot;Outgoing Data Object_size&quot;
+ENDGROUP
+
+GROUP &quot;Description&quot;
+ATTR &quot;Description_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_Description_display: &quot;Description_display&quot;
+ATTR &quot;Description_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_Description_display = &quot;Yes&quot;))
+ATTR &quot;Description_size&quot;
+ENDGROUP
+
+CHAPTER &quot;Comment View&quot;
+ATTR &quot;Comment Mode&quot; ctrltype: check checked-value: &quot;No&quot; unchecked-value: &quot;Yes&quot;
+AVAL s_Aktiv: &quot;Comment Mode&quot;
+ATTR &quot;CommentAreaSize&quot;
+ATTR &quot;CommentModellingAreaSize&quot;
+ATTR &quot;CommentModellingDirection&quot;
+
+
+
+
+CHAPTER &quot;Change history&quot;
+ATTR &quot;Change history&quot; lines:30
+
+</ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;90409&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Auditing" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Monitoring" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Process type" type="ENUMERATION">None</ATTRIBUTE>
+<ATTRIBUTE name="Executable" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Closed" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="_GoToAceHp_" type="PROGRAMCALL">ITEM &quot;_GoToAceHp_&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="__GfxThumb__" type="LONGSTRING">iVBORw0KGgoAAAANSUhEUgAAAJcAAAEACAIAAAAx6XNhAAAACXBIWXMAAAsTAAALEwEAmpwYAAAOx0lEQVR4nO2dX2xb1RnAP9OKipc9oQ4KKXRLWtYFDbXQ4tMWUB/YSkfVScMFbZpRFU7RxJZqIxtTuw02HiaFbNdDgwUJqhamLRajSaZeTTCGBk1LJpEVYkyT6ykLbdUWkXUPTEvNPT57ONeOY1/b97+dz9/vobJv7vnO5/u755x763N8Y1LKixcvjo+PAxEC8/PziUQi7Fpis7Ozp06duu3WW//y+uszMzMAsGzZsmXLlq1cufKObXdcueJKAFh97bUOw314/jwA5HK57du2hZGuiu8qpUYBLxQDXhNIQCvsBSvPU/84FYXIkZGR01NTL7300vtVHDly5PTUlMznZT5rZLNavEfPZ7V4nI9mZX6UA0A8ziDOegaMfFbrGTDyeZnPj4+Py3xWiwMbGNVHBzioUsAGiqUAAOJaNl/cbYBDnMWtLUY2q8UB4ipmD4/H+eioPpqV+ayRzct8/vTUlCoIEGdx4KOjHMpSgh49ryKrxPLFnYGPWllpixMuBlQ5qBc9usqkp4fHe/hAD7e2FCPHi7X0WH+yYlrb8zKfn5qampqaGhkZGRoakiETGxkZueGGG2ZnZy9durRixYqS3cuXL69cuXLVqlVfWr/e1WnxQS73hc7OQM4wW97NZt2mFHHAUlgAmJ2djaAtLgeA+fn51atXL1++XAgRi8WuuOIKALjqqqs6OjrmPp4bf2di88YNDsONT0wAwJkLFzquCbKDqog/PjGxeYPTlCIOqHh7YiLAaA2JSSlHR0ejrLLdiKgt7tq1K51Oh1oNESoxKWWzcyD8srzZCRABQBYxQBYxQBYxQBYxQBYxQBYxQBYxQBYxQBYxQBYxQBYxQBYxsMQsZjKZm2++2UNB3F/dLDGLhC1Lz2I+n5dSFgoFNXFIvSj/t/rtpUuXmp11uCw9i24VFgqFZqccOkvDYiwWGxoaUrNX3CosHxHL42AimBkbsVjMfxAnDA0N3Xvvva4UFgqFTz75xNs1kavEmnhyBNAW1QnuP04d9uzZU6rCrUJ1mkop0+l0eZxg0ws8pisC61FDPRMTiUQ6nU4kEplMxq3C0riYSCRKcYJND4/FUClv7m4VVgwZ+AZFaLpF5wPqnj17VH/Y0dHhSiHu+31FMy06H1Btx0WHCulOIwqcdHHl4+LZs2cjyGpp0XyLDlGyu7u7m51IK7JkLJaRS23pSie07v3pDIPE4bHezlwuB8eSXftBM8Z2HtvXn81k4ODB3dC1Ywfkcp1hLsRrDaRvAMDbQkvPBVuNpn+QpdgWiUrIIgbIIgbIIgbIIgbIIgbIYgBIKZv7wwhk0SmZTKbOX9evX19rhwj+v4ksusDDhIHJyckwMqmALLqgZaffkUUXuFUY2ZdiZNEFfqbfhQpZdIFbhdQWWxG3CqkttiKep9+FDVl0gVuF1BZbEbcKyWIr4lYh9aitSMtOvyOLTmnl6Xdk0TPlU/G6D44N7oBcakv/2rHBHZGnQhY909k7JnsBoLe3bMtgU1Ihixggixggi96xXV/elEXnZNEjtmv2IlsZXwFZ9IiUstqZ7cYIIIsYIIsYIIsYIIsYIIuV+L88UT8kUWeHwG9FyOIi/P8Ck2w0TzyMH8chizb4bCj1i5NFwh6yiAGyuIiGo1prVtHuFqsXOtVZ/VSi4ff+ES+waneL4S2DinKBVbtbnJycXLdune0ktlqz3Bwug4pygVW7W4Qa8/b9T9p3q9DPtEeyaDNvP5BJ+1EusCKL9dqin0n7bhVSW/SFK4XOj7VbhdQWfeFKofNjHeUCK7LY+HAH0hYD7KurIYsNDncgbdFJFWTRF64UemiLDhVSj+qLc+fOhRE2ygVW7W4xpJVQUS+wkr6BJf6L0zovHQymGVJKQ2PANF3XDSkNXeeMaYbUOXDdaUhDYwDAuFXW0Bhw3dAY16Wh6xoHrlu1qCp0T7UsQBYx0O49Kg7IIgr8N2dY4j2qOg4VmVRsCTtVn/HbvS2q2adhPz/SCWpunLfpd+1uURZXOVUfvvLDWme3VqDdLdaZRhxlA5XFR7WCpxOlrS2WFNY6cFG2vEQi4XnCcVtbVDhUFUGn6rmK9rUYwUOxI6NNLTbsS21p2ebYphYVrXnB6YF2tIipL1W0nUVvfWmJaDrV0kKOw+9cFELs3bSqfpG2s6ho8b40kUj87t2PTVP89fhJAJi/fIspzO/eVfPBvO1lcan0pcl9Xz7y3KvFdw+c0+A6gOS7mcO9u233927RYWNvOtV5+myIYXeqydTw9i9+9l/auW9sEqYpzBM/+sN/v9C9UZhCJFPDtiK9WKxo7Kk3DPhowlWEocx/TGF+SzsKkH/u5BnTFN/edqOHTFzlaQpTOlg7GE1u9RFSvrn/ujetd3v2/lmYQghT1No/Jl1OoEumhtWLLZs2mqYYnzil3tZq7HUi3BnfZAox9vd33EYIL0+HuYX3k33J1PCd8U3m8R+8WHjyvlvNzFNdk7e/v2uDEKYwhWkKcebc+eqP4K4tJlPD22OvPNj7IgAcAQC4/6HXHu8S9Rp7dYS7lx/95iNHihEeePiNn601XUQIL89kavjuu7aaf/veg70vHrG2WQUrSoXaqZpCmIVCQZjCFF3f+e2pr/z09MiBNcI0hTBrNEfXPaqQctvAh/ffJkxhihMH02+LNRvqNXa7LOUd5Z3+CfG5jcIULiKEl6dpCtuCweZWh8O9u5Op4Y1CSiFMIUzBtvY886vfvHngoc2mKc5f/MjvuFhs7C+/9f3Vb1nb7nvwmNXYO667tmFjSqaGt2+Ni+N/tO3016y+PpDm6C1PKzchTCGrC1bnFmpzFBsf/5qwDstn7nn+gBCmKUTtE91dW1SNnf3C+PpGkfnlTZO3//jzxf66VmOvzE8IU8it/TPFTv8nnWKh03eVTOB5CnX61ygYVG4NUc1RvV6z+no1Fpb+ZFvEhcWKxt75yDPv7Xzig1ceWyNEncZeHWFzjU7fdtz2gLc8rdw23GLaFQwqN+cfQb1QOhtW7X5cFFIWVGOPx/c++/Szx3+4d1Odxl6NWaPTd5tJGHmawrQtaLtzBP8b5/DU8X6n4bCx14nQteZGU5gzH551GyG8PN3mFtwtRy61pWv/Ca7Lvul9/dkM7B7bPRx7MsO6D471Te/rX9vXN51MwuGD2a7h3bLykR2uLZZw2NhDjRBeLQ5LNeW33m3S8GyRULSEyFoTVa01KIxruiGlzoFphqExxnVDSkPj1iISpi2sHQFgXNfVmhLDqA65eH8OAFyXOgfGahZxQe1FM2rdjM4YY6DWu1TUpJJXWXHOFmWlca4bhsaYZtgvhYHAJhwvHEPD0DnjnKn61GG3jpvtUaK26JdWaIvt9c1UGMgWmHBMFlsKdaXKuJ6Ae9IZ3n2wrw8MY3p4eufgTsh1dtb6nthzLw6+xwP/EYKqpTimWmO/ZqhtjC+MqQ2WiEbzWWrhsS36/4n0aJ4B47CWHYNSlp65NzZW3Fa6K+scG9sBAGVbWguPFqXvR/H4j9A6tQRBLrUlmQaAbtWLHhu+J23d8i96Vmdfl22/6qch++9DoumFPNQC7ntID0WCwtfVjf+rsmiu65r+fyth492i//ukaO60WuF+LmzoTsMe6f432mUIN44OT0HvFj18zsAjhFrLUmq+TRmNWx/wdKnirVR9nASku/4gS/kp6CcajYv2yEh6+6CgcbEmrbCoymnyQbV9ZICPjtFPWY81eiwG4DPX0mkU9m86eaulRSw6TJ7GRXukj95eRv6NI1msiWcH0a+SbGCxzhcCKlHbHeTiWSC1gpQ+avUO0v08kmBrcfX/drZV1386scNDBA6Ps5N+2S3+g3geQoKqBdyMbf6r9hChPEjj41X/AwPAmVdTADBz9Ilc+rFae9YJAgBnXvu12uGfLx8wfv9o/eMbap7luLXYsGoA8HaIZJlm2/wDsFj/LGsYpP5Z5pxA8qwookSq/Wu9hmKn57NqP/kHYHHm6BNqn9OHHvZmcWbk56XkPnj+oZAsOsmzglJzHBoasn3t0GKp6kAsVucfwDWq+PR/6kXh03lvEcoLeg7SEA95lq5uyi9zyl9LZzckpaoDoTr/xrOK1dVRrd0cXvjVCeLkKtcJgeTpjbAPUcMgfttieSxv85Qq8g5pspP/PAOp2nPt9fOnu/6oee/p+wKPSes0UFDnCq0MQ2OMMWCatSRKY2pJkVpL5eK5OjoHgIWy3FqQ5eWxPIvTg/IVWxpjjDHGNWPhr2q1lF62PErzt0jLvt7ia1k6aAursbi1aKu4Q2Wc0mFh1tKtUpCKY155uKgtYoDGRQyQRRQ4HQA452qsKS4tZowxziuX5dYcP0rDqlrpqyJAcTmxwnahL9EYGhcxQD0qBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiBsgiCiRhYWgMAIBphnqr67rGGGNcl4bG1HZDYxaaoYowruu6rmuaZhjWX7kqyFUgFUcF4brUOeOcAUBpSykm16WhabqUhsY5X6iaMY1zsN7quiGlzoExtSfjUsqYlLLJ5xHhG+pRUdC8HoyQUs5prB/gEGP9XJ/mcIjrc1JOc+gH+JNu7XCI8ZPGws79XJ/TWD/TpjV+0pBzknpUHFCPigGyiAGy2FL8O7Xlhf0nAAC4vrevC44lX9h/4iZdrhuOjWX41d1wdd/gWsjN9XeNgb5rcMfcvtjUoPwqjYutRSz2lNsiUj5KFjHwf1Pz/biDycooAAAAAElFTkSuQmCC</ATTRIBUTE>
+<ATTRIBUTE name="NT Model Attributes" type="LONGSTRING">NOTEBOOK
+CHAPTER &quot;Description&quot;
+#ATTR &quot;Shared&quot;
+ATTR &quot;Model state&quot; enabled:(cond(search (sMfbRegistration, &quot;MFB_VERS&quot;, 0) = -1, 1, 0))
+ATTR &quot;Description&quot;
+ATTR &quot;Show State&quot; ctrltype:check unchecked-value:&quot;No&quot; checked-value:&quot;Yes&quot; 
+ATTR &quot;Last user&quot; write-protected
+ATTR &quot;Date last changed&quot; write-protected
+#CHAPTER &quot;Suggestion for improvement&quot;
+#ATTR &quot;Suggestion for improvement&quot;
+</ATTRIBUTE>
+<ATTRIBUTE name="Model state" type="ENUMERATION">Draft</ATTRIBUTE>
+<ATTRIBUTE name="People-like view" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Action" type="ENUMERATION">Fill in</ATTRIBUTE>
+<ATTRIBUTE name="Keywords" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Description" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Model type" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Show State" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="BAR Display active" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Actor_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="Actor_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Actor_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="Description_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="Description_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Description_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="ModelingAreaSize" type="ENUMERATION">20</ATTRIBUTE>
+<ATTRIBUTE name="Modelling_size" type="ENUMERATION">3</ATTRIBUTE>
+<ATTRIBUTE name="DrawingAreaWidth" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="DrawingAreaHeight" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Reference overview settings" type="LONGSTRING">Responsible for execution|Responsible for execution
+Accountable for approving results|Accountable for approving results
+Cooperation/participation|Cooperation/participation
+To inform|To inform
+Modelling|Modelling
+Knowledge Product|Knowledge Product
+Documents and Resources|Documents and Resources
+#Data Object|Data Object
+Incoming Data Object|Incoming Data Object
+Outgoing Data Object|Outgoing Data Object
+Description|Description</ATTRIBUTE>
+<ATTRIBUTE name="Data Object_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="Data Object_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Data Object_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="Knowledge Product_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="Knowledge Product_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Knowledge Product_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="Documents and Resources_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Documents and Resources_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="Documents and Resources_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="Responsible for execution_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="Responsible for execution_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Responsible for execution_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="Accountable for approving results_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="Accountable for approving results_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Accountable for approving results_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="Cooperation/participation_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="Cooperation/participation_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Cooperation/participation_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="To inform_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="To inform_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="To inform_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="Incoming Data Object_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="Incoming Data Object_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Incoming Data Object_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="Outgoing Data Object_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="Outgoing Data Object_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Outgoing Data Object_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="id_bpmndi_diagram" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="id_bpmndi_plane" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="id_bpmndi_collaboration" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="CommentModellingAreaSize" type="ENUMERATION">3</ATTRIBUTE>
+<ATTRIBUTE name="CommentTypeSize" type="ENUMERATION">8</ATTRIBUTE>
+<ATTRIBUTE name="CommentAreaSize" type="ENUMERATION">2</ATTRIBUTE>
+<ATTRIBUTE name="Comment Mode" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="CommentxCoorTextBox" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="CommentyCoorTextBox" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="CommentModellingDirection" type="ENUMERATION">vertical</ATTRIBUTE>
+</MODELATTRIBUTES>
+<INSTANCE id="obj.16580" class="Organizational unit" name="Agriculture Office">
+<ATTRIBUTE name="Position" type="STRING">NODE x:16.5cm y:10.5cm index:1</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<INTERREF name="Model reference"></INTERREF>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Organisationseinheit</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Submodelname" type="EXPRESSION">EXPR val:&quot;Bezeichnung&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Type" type="ENUMERATION">Standard</ATTRIBUTE>
+<ATTRIBUTE name="Functional unit" type="ENUMERATION">no</ATTRIBUTE>
+<ATTRIBUTE name="Manager" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Function" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Level" type="INTEGER">0</ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16583" class="Organizational unit" name="SUAP Office">
+<ATTRIBUTE name="Position" type="STRING">NODE x:12.5cm y:10.5cm index:2</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<INTERREF name="Model reference"></INTERREF>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Organisationseinheit</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Submodelname" type="EXPRESSION">EXPR val:&quot;Bezeichnung&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Type" type="ENUMERATION">Standard</ATTRIBUTE>
+<ATTRIBUTE name="Functional unit" type="ENUMERATION">no</ATTRIBUTE>
+<ATTRIBUTE name="Manager" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Function" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Level" type="INTEGER">0</ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16586" class="Role" name="SUAP Officer">
+<ATTRIBUTE name="Position" type="STRING">NODE x:10cm y:14.5cm index:3</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Rolle</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16589" class="Performer" name="Barnaby Barnes">
+<ATTRIBUTE name="Position" type="STRING">NODE x:10cm y:18.5cm index:4</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Hourly wages" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Calendar" type="LONGSTRING">B@Working day@b@32400-43200@T@45000-59400@T@Free day@c@@@$cbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbcbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbcbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbcccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbccbbccb</ATTRIBUTE>
+<ATTRIBUTE name="Availability" type="EXPRESSION">EXPR expr:(round(paval(&quot;Presence&quot;,&quot;Hours per day&quot;)*paval(&quot;Presence&quot;,&quot;Days per week&quot;)/40*100)) val:100</ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Time dependent costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Info on results" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Workload" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Capacity" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Personnel costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Bearbeiter</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<RECORD name="Further education"></RECORD>
+<ATTRIBUTE name="Presence" type="ATTRPROFREF"></ATTRIBUTE>
+<ATTRIBUTE name="E-Mail" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16592" class="Organizational unit" name="Monti Azzurri">
+<ATTRIBUTE name="Position" type="STRING">NODE x:9cm y:3.5cm index:7</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<INTERREF name="Model reference"></INTERREF>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Organisationseinheit</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Submodelname" type="EXPRESSION">EXPR val:&quot;Bezeichnung&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Type" type="ENUMERATION">Standard</ATTRIBUTE>
+<ATTRIBUTE name="Functional unit" type="ENUMERATION">no</ATTRIBUTE>
+<ATTRIBUTE name="Manager" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Function" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Level" type="INTEGER">0</ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16595" class="Role" name="Secretary General">
+<ATTRIBUTE name="Position" type="STRING">NODE x:2.5cm y:14.5cm index:11</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Rolle</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16598" class="Role" name="President">
+<ATTRIBUTE name="Position" type="STRING">NODE x:5.5cm y:14.5cm index:12</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Rolle</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16601" class="Organizational unit" name="Area 3">
+<ATTRIBUTE name="Position" type="STRING">NODE x:14.5cm y:6.5cm index:13</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<INTERREF name="Model reference"></INTERREF>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Organisationseinheit</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Submodelname" type="EXPRESSION">EXPR val:&quot;Bezeichnung&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Type" type="ENUMERATION">Standard</ATTRIBUTE>
+<ATTRIBUTE name="Functional unit" type="ENUMERATION">no</ATTRIBUTE>
+<ATTRIBUTE name="Manager" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Function" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Level" type="INTEGER">0</ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16604" class="Role" name="Responsible Agriculture, Forestry, Environment">
+<ATTRIBUTE name="Position" type="STRING">NODE x:18.5cm y:14cm index:17</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Rolle</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16607" class="Performer" name="Emanuele Laurenzi ">
+<ATTRIBUTE name="Position" type="STRING">NODE x:2.5cm y:18.5cm index:21</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Hourly wages" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Calendar" type="LONGSTRING">B@Working day@b@32400-43200@T@45000-59400@T@Free day@c@@@$cbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbcbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbcbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbcccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbccbbccb</ATTRIBUTE>
+<ATTRIBUTE name="Availability" type="EXPRESSION">EXPR expr:(round(paval(&quot;Presence&quot;,&quot;Hours per day&quot;)*paval(&quot;Presence&quot;,&quot;Days per week&quot;)/40*100)) val:100</ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Time dependent costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Info on results" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Workload" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Capacity" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Personnel costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Bearbeiter</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<RECORD name="Further education"></RECORD>
+<ATTRIBUTE name="Presence" type="ATTRPROFREF"></ATTRIBUTE>
+<ATTRIBUTE name="E-Mail" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16610" class="Performer" name="Sandro Emmenegger">
+<ATTRIBUTE name="Position" type="STRING">NODE x:5.5cm y:18.5cm index:24</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Hourly wages" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Calendar" type="LONGSTRING">B@Working day@b@32400-43200@T@45000-59400@T@Free day@c@@@$cbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbcbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbcbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbcccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbccbbccb</ATTRIBUTE>
+<ATTRIBUTE name="Availability" type="EXPRESSION">EXPR expr:(round(paval(&quot;Presence&quot;,&quot;Hours per day&quot;)*paval(&quot;Presence&quot;,&quot;Days per week&quot;)/40*100)) val:100</ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Time dependent costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Info on results" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Workload" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Capacity" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Personnel costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Bearbeiter</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<RECORD name="Further education"></RECORD>
+<ATTRIBUTE name="Presence" type="ATTRPROFREF"></ATTRIBUTE>
+<ATTRIBUTE name="E-Mail" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16613" class="Performer" name="Congyu Zhang">
+<ATTRIBUTE name="Position" type="STRING">NODE x:18.5cm y:18.5cm index:27</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Hourly wages" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Calendar" type="LONGSTRING">B@Working day@b@32400-43200@T@45000-59400@T@Free day@c@@@$cbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbcbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbcbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbcccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbccbbccb</ATTRIBUTE>
+<ATTRIBUTE name="Availability" type="EXPRESSION">EXPR expr:(round(paval(&quot;Presence&quot;,&quot;Hours per day&quot;)*paval(&quot;Presence&quot;,&quot;Days per week&quot;)/40*100)) val:100</ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Time dependent costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Info on results" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Workload" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Capacity" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Personnel costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Bearbeiter</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<RECORD name="Further education"></RECORD>
+<ATTRIBUTE name="Presence" type="ATTRPROFREF"></ATTRIBUTE>
+<ATTRIBUTE name="E-Mail" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16616" class="Role" name="Responsible SUAP office">
+<ATTRIBUTE name="Position" type="STRING">NODE x:12.5cm y:14.5cm index:29</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Rolle</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16619" class="Performer" name="Barbara Thössen">
+<ATTRIBUTE name="Position" type="STRING">NODE x:15.5cm y:18.5cm index:31</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Hourly wages" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Calendar" type="LONGSTRING">B@Working day@b@32400-43200@T@45000-59400@T@Free day@c@@@$cbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbcbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbcbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbcccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbccbbccb</ATTRIBUTE>
+<ATTRIBUTE name="Availability" type="EXPRESSION">EXPR expr:(round(paval(&quot;Presence&quot;,&quot;Hours per day&quot;)*paval(&quot;Presence&quot;,&quot;Days per week&quot;)/40*100)) val:100</ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Time dependent costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Info on results" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Workload" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Capacity" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Personnel costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Bearbeiter</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<RECORD name="Further education"></RECORD>
+<ATTRIBUTE name="Presence" type="ATTRPROFREF"></ATTRIBUTE>
+<ATTRIBUTE name="E-Mail" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<CONNECTOR id="con.16622" class="Is subordinated">
+<FROM instance="Agriculture Office" class="Organizational unit"></FROM>
+<TO instance="Area 3" class="Organizational unit"></TO>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 2 x1:16.5cm y1:9cm x2:15cm y2:9cm index:39</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Representation" type="ENUMERATION">with arrow</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16623" class="Is subordinated">
+<FROM instance="SUAP Office" class="Organizational unit"></FROM>
+<TO instance="Area 3" class="Organizational unit"></TO>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 2 x1:12cm y1:9cm x2:14cm y2:9cm index:9</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">4</ATTRIBUTE>
+<ATTRIBUTE name="Representation" type="ENUMERATION">with arrow</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16624" class="belongs to">
+<FROM instance="SUAP Officer" class="Role"></FROM>
+<TO instance="SUAP Office" class="Organizational unit"></TO>
+<ATTRIBUTE name="Connector number" type="INTEGER">2</ATTRIBUTE>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 0 index:6</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16625" class="Has role">
+<FROM instance="Barnaby Barnes" class="Performer"></FROM>
+<TO instance="SUAP Officer" class="Role"></TO>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 0 index:5</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">1</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16626" class="belongs to">
+<FROM instance="Secretary General" class="Role"></FROM>
+<TO instance="Monti Azzurri" class="Organizational unit"></TO>
+<ATTRIBUTE name="Connector number" type="INTEGER">8</ATTRIBUTE>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 1 x1:3cm y1:3.5cm index:20</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16627" class="belongs to">
+<FROM instance="President" class="Role"></FROM>
+<TO instance="Monti Azzurri" class="Organizational unit"></TO>
+<ATTRIBUTE name="Connector number" type="INTEGER">10</ATTRIBUTE>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 1 x1:5.5cm y1:4cm index:23</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16628" class="Is subordinated">
+<FROM instance="Area 3" class="Organizational unit"></FROM>
+<TO instance="Monti Azzurri" class="Organizational unit"></TO>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 1 x1:14.5cm y1:3.5cm index:8</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">3</ATTRIBUTE>
+<ATTRIBUTE name="Representation" type="ENUMERATION">with arrow</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16629" class="belongs to">
+<FROM instance="Responsible Agriculture, Forestry, Environment" class="Role"></FROM>
+<TO instance="Agriculture Office" class="Organizational unit"></TO>
+<ATTRIBUTE name="Connector number" type="INTEGER">14</ATTRIBUTE>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 0 index:26</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16630" class="Has role">
+<FROM instance="Emanuele Laurenzi " class="Performer"></FROM>
+<TO instance="Secretary General" class="Role"></TO>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 0 index:22</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">9</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16631" class="Has role">
+<FROM instance="Sandro Emmenegger" class="Performer"></FROM>
+<TO instance="President" class="Role"></TO>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 0 index:25</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">11</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16632" class="Has role">
+<FROM instance="Congyu Zhang" class="Performer"></FROM>
+<TO instance="Responsible Agriculture, Forestry, Environment" class="Role"></TO>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 0 index:28</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">15</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16633" class="belongs to">
+<FROM instance="Responsible SUAP office" class="Role"></FROM>
+<TO instance="SUAP Office" class="Organizational unit"></TO>
+<ATTRIBUTE name="Connector number" type="INTEGER">16</ATTRIBUTE>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 0 index:30</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16634" class="Has role">
+<FROM instance="Barbara Thössen" class="Performer"></FROM>
+<TO instance="Responsible SUAP office" class="Role"></TO>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 1 x1:12.5cm y1:18.5cm index:32</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">17</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16635" class="Is manager">
+<FROM instance="Barbara Thössen" class="Performer"></FROM>
+<TO instance="SUAP Office" class="Organizational unit"></TO>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 0 index:37</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">19</ATTRIBUTE>
+</CONNECTOR>
+</MODEL>
+<MODEL id="mod.16520" name="Document and Knowledge model TitoloUnico" version="" modeltype="Document and Knowledge model" libtype="bp" applib="LearnPAd Prototype Dynamic Library 0.21">
+<MODELATTRIBUTES>
+<ATTRIBUTE name="Contact person" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Keywords" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Copyright info" type="STRING">Edit the model attributes to display your copyright info</ATTRIBUTE>
+<ATTRIBUTE name="Copyright info position" type="ENUMERATION">Bottom right</ATTRIBUTE>
+<ATTRIBUTE name="Model type" type="ENUMERATION">Current model</ATTRIBUTE>
+<ATTRIBUTE name="State" type="ENUMERATION">In process</ATTRIBUTE>
+<ATTRIBUTE name="Reviewed on" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Reviewed by" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Author" type="STRING">barbara</ATTRIBUTE>
+<ATTRIBUTE name="Creation date" type="STRING">13.08.2015, 13:16</ATTRIBUTE>
+<ATTRIBUTE name="Last user" type="STRING">congyu</ATTRIBUTE>
+<ATTRIBUTE name="Date last changed" type="STRING">08.09.2015, 01:54:25</ATTRIBUTE>
+<ATTRIBUTE name="Number of objects and relations" type="INTEGER">19</ATTRIBUTE>
+<ATTRIBUTE name="Context of version" type="STRING"></ATTRIBUTE>
+<RECORD name="Change history"></RECORD>
+<ATTRIBUTE name="Position" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-01] Internal error!  \&quot;fontcolor\&quot; (BPModel)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<RECORD name="Technical Attributes"></RECORD>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Keine Modellbezeichnung vergeben</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Pool Term" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="ParticipantType" type="ENUMERATION">Role</ATTRIBUTE>
+<ATTRIBUTE name="Role" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Entity" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="BoundaryVisible" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="BPD Model Attributes" type="STRING">NOTEBOOK
+
+CHAPTER &quot;Business Process Diagram Attributes&quot;
+ATTR &quot;Name&quot; write-protected
+ATTR &quot;Contact person&quot;
+ATTR &quot;Author&quot; write-protected
+ATTR &quot;Language (BPMN)&quot;
+ATTR &quot;ExpressionLanguage&quot;
+ATTR &quot;QueryLanguage&quot;
+ATTR &quot;Creation date&quot; write-protected
+ATTR &quot;Date last changed&quot; write-protected
+ATTR &quot;Documentation (Model)&quot;
+ATTR &quot;State&quot;
+
+GROUP &quot;Copyright&quot;
+ATTR &quot;Copyright info&quot; 
+ATTR &quot;Copyright info position&quot; 
+ENDGROUP
+
+CHAPTER &quot;Process Attributes&quot;
+ATTR &quot;Name&quot; write-protected
+ATTR &quot;Process Term&quot;
+ATTR &quot;ProcessType&quot;
+ATTR &quot;Status&quot;
+ATTR &quot;Assignments&quot; lines:5
+ATTR &quot;Properties (BPMN)&quot; lines:5
+ATTR &quot;AdHoc&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+GROUP &quot;AdHoc = True&quot;
+ATTR &quot;AdHocOrdering&quot;
+ATTR &quot;AdHocCompletionCondition&quot;
+ENDGROUP
+ATTR &quot;SuppressJoinFailure&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ATTR &quot;EnableInstanceCompensation&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ATTR &quot;Categories (Process)&quot;
+ATTR &quot;Documentation (Process)&quot;
+
+CHAPTER &quot;Pool Attributes&quot;
+GROUP &quot;Common Graphical Object Attributes&quot;
+ATTR &quot;Name&quot; write-protected
+ATTR &quot;Categories (Pool)&quot;
+ATTR &quot;Documentation (Pool)&quot;
+ENDGROUP
+GROUP &quot;Common Swimlane Attributes&quot;
+ATTR &quot;Pool Term&quot;
+ENDGROUP
+GROUP &quot;Pool Attributes&quot;
+ATTR &quot;ParticipantType&quot;
+ATTR &quot;Role&quot;
+ATTR &quot;Entity&quot;
+ATTR &quot;BoundaryVisible&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot; write-protected
+ENDGROUP</ATTRIBUTE>
+<ATTRIBUTE name="Language" type="ENUMERATION">System</ATTRIBUTE>
+<ATTRIBUTE name="ExpressionLanguage" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="QueryLanguage" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Process Term" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="BPD Term" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="ProcessType" type="ENUMERATION">None</ATTRIBUTE>
+<ATTRIBUTE name="Status" type="ENUMERATION">None</ATTRIBUTE>
+<RECORD name="Assignments"></RECORD>
+<ATTRIBUTE name="AdHoc" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="AdHocOrdering" type="ENUMERATION">None</ATTRIBUTE>
+<ATTRIBUTE name="AdHocCompletionCondition" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="EnableInstanceCompensation" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Categories (Process)" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation (Process)" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation (Pool)" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Categories (Pool)" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="SuppressJoinFailure" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="RACI/DEMI visualisation" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Modelling direction" type="ENUMERATION">vertical</ATTRIBUTE>
+<ATTRIBUTE name="IT systems" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Responsible role" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Input/Output" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Products" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Use cases" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Products color" type="STRING">whitesmoke</ATTRIBUTE>
+<ATTRIBUTE name="RACI/DEMI color" type="STRING">whitesmoke</ATTRIBUTE>
+<ATTRIBUTE name="Responsible role color" type="STRING">whitesmoke</ATTRIBUTE>
+<ATTRIBUTE name="Input/Output color" type="STRING">whitesmoke</ATTRIBUTE>
+<ATTRIBUTE name="Use cases color" type="STRING">whitesmoke</ATTRIBUTE>
+<ATTRIBUTE name="IT systems color" type="STRING">whitesmoke</ATTRIBUTE>
+<ATTRIBUTE name="_ToggleModelInfo_" type="PROGRAMCALL">ITEM &quot;_ToggleModelInfo_&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Display modelling information" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Documentation (Model)" type="STRING"></ATTRIBUTE>
+<RECORD name="Properties (BPMN)"></RECORD>
+<ATTRIBUTE name="CreationDate" type="EXPRESSION">EXPR val:&quot;13.08.2015, 13:16&quot;</ATTRIBUTE>
+<ATTRIBUTE name="ModificationDate" type="EXPRESSION">EXPR val:&quot;08.09.2015, 01:54:18&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Language (BPMN)" type="STRING">English</ATTRIBUTE>
+<ATTRIBUTE name="BPMN20 Model Attributes" type="LONGSTRING">NOTEBOOK
+# TODO AVAL sMfbRegistration:&quot;_MFB-Registration_&quot;
+CHAPTER &quot;Description&quot;
+ATTR &quot;Contact person&quot;
+ATTR &quot;Keywords&quot; lines:2
+ATTR &quot;Description&quot; lines:3
+ATTR &quot;Comment&quot; lines:3
+
+GROUP &quot;Copyright&quot;
+ATTR &quot;Copyright info&quot; 
+ATTR &quot;Copyright info position&quot; 
+ENDGROUP
+ATTR &quot;Name&quot; write-protected
+ATTR &quot;Id&quot; write-protected
+
+
+
+#---------------------------------------------
+CHAPTER &quot;Process properties&quot;
+#---------------------------------------------
+GROUP &quot;Process attributes&quot;
+ATTR &quot;Process type&quot; #None, Private, Public 
+ATTR &quot;Executable&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ATTR &quot;Closed&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ENDGROUP
+
+GROUP &quot;Process relevance&quot;
+ATTR &quot;Auditing&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ATTR &quot;Monitoring&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ENDGROUP
+
+CHAPTER &quot;User attributes&quot;
+ATTR &quot;Model type&quot;
+ATTR &quot;State&quot;
+ATTR &quot;Reviewed on&quot;
+ATTR &quot;Reviewed by&quot;
+
+CHAPTER &quot;System attributes&quot;
+ATTR &quot;Author&quot; write-protected
+ATTR &quot;Creation date&quot; write-protected
+ATTR &quot;Last user&quot; write-protected
+# ATTR &quot;Date last changed from&quot; write-protected
+ATTR &quot;Date last changed&quot; write-protected
+ATTR &quot;Number of objects and relations&quot; write-protected
+ATTR &quot;Context of version&quot; write-protected
+
+CHAPTER &quot;People-like view&quot;
+ATTR &quot;Action&quot;
+ATTR &quot;People-like view&quot;
+
+CHAPTER &quot;BAR Display&quot;
+ATTR &quot;BAR Display active&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot;
+AVAL s_Aktiv: &quot;BAR Display active&quot;
+ATTR &quot;Modelling direction&quot; ctrltype: radio enabled: (s_Aktiv = &quot;Yes&quot;)
+ATTR &quot;Modelling_size&quot;
+
+GROUP &quot;Responsible for execution&quot;
+ATTR &quot;Responsible for execution_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_Responsible_for_execution_display: &quot;Responsible for execution_display&quot;
+ATTR &quot;Responsible for execution_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_Responsible_for_execution_display = &quot;Yes&quot;))
+ATTR &quot;Responsible for execution_size&quot;
+ENDGROUP
+
+GROUP &quot;Accountable for approving results&quot;
+ATTR &quot;Accountable for approving results_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_Accountableforapprovingresults_display: &quot;Actor_display&quot;
+ATTR &quot;Accountable for approving results_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_Accountableforapprovingresults_display = &quot;Yes&quot;))
+ATTR &quot;Accountable for approving results_size&quot;
+ENDGROUP
+
+GROUP &quot;Cooperation/participation&quot;
+ATTR &quot;Cooperation/participation_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_Cooperationparticipation_display: &quot;Cooperation/participation_display&quot;
+ATTR &quot;Cooperation/participation_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_Cooperationparticipation_display = &quot;Yes&quot;))
+ATTR &quot;Cooperation/participation_size&quot;
+ENDGROUP
+
+GROUP &quot;To inform&quot;
+ATTR &quot;To inform_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_Toinform_display: &quot;To inform_display&quot;
+ATTR &quot;To inform_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_Toinform_display = &quot;Yes&quot;))
+ATTR &quot;To inform_size&quot;
+ENDGROUP
+
+GROUP &quot;Knowledge Product&quot;
+ATTR &quot;Knowledge Product_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_KnowledgeProduct_display: &quot;Knowledge Product_display&quot;
+ATTR &quot;Knowledge Product_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_KnowledgeProduct_display = &quot;Yes&quot;))
+ATTR &quot;Knowledge Product_size&quot;
+ENDGROUP
+
+GROUP &quot;Documents and Resources&quot;
+ATTR &quot;Documents and Resources_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_DocumentsandResources_display: &quot;Documents and Resources_display&quot;
+ATTR &quot;Documents and Resources_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_DocumentsandResources_display = &quot;Yes&quot;))
+ATTR &quot;Documents and Resources_size&quot;
+ENDGROUP
+
+GROUP &quot;Incoming Data Object&quot;
+ATTR &quot;Incoming Data Object_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_IncomingDataObject_display: &quot;Incoming Data Object_display&quot;
+ATTR &quot;Incoming Data Object_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_IncomingDataObject_display = &quot;Yes&quot;))
+ATTR &quot;Incoming Data Object_size&quot;
+ENDGROUP
+
+GROUP &quot;Outgoing Data Object&quot;
+ATTR &quot;Outgoing Data Object_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_OutgoingDataObject_display: &quot;Outgoing Data Object_display&quot;
+ATTR &quot;Outgoing Data Object_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_OutgoingDataObject_display = &quot;Yes&quot;))
+ATTR &quot;Outgoing Data Object_size&quot;
+ENDGROUP
+
+GROUP &quot;Description&quot;
+ATTR &quot;Description_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_Description_display: &quot;Description_display&quot;
+ATTR &quot;Description_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_Description_display = &quot;Yes&quot;))
+ATTR &quot;Description_size&quot;
+ENDGROUP
+
+CHAPTER &quot;Comment View&quot;
+ATTR &quot;Comment Mode&quot; ctrltype: check checked-value: &quot;No&quot; unchecked-value: &quot;Yes&quot;
+AVAL s_Aktiv: &quot;Comment Mode&quot;
+ATTR &quot;CommentAreaSize&quot;
+ATTR &quot;CommentModellingAreaSize&quot;
+ATTR &quot;CommentModellingDirection&quot;
+
+
+
+
+CHAPTER &quot;Change history&quot;
+ATTR &quot;Change history&quot; lines:30
+
+</ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;87801&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Auditing" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Monitoring" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Process type" type="ENUMERATION">None</ATTRIBUTE>
+<ATTRIBUTE name="Executable" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Closed" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="_GoToAceHp_" type="PROGRAMCALL">ITEM &quot;_GoToAceHp_&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="__GfxThumb__" type="LONGSTRING">iVBORw0KGgoAAAANSUhEUgAAALMAAAEACAIAAAB3X9DLAAAACXBIWXMAAAsTAAALEwEAmpwYAAASuElEQVR4nO3dT4gj150H8G87c8lACOwmGHbX2IeuiqeiyxqSHb3e4LDk4JagqcNQVx0sXkMgtJhELMPWUWCItsPTJaBinKSPKeaglldPPuSPF6ernYsJoVzJvldjMh4IeJzJxdgzNCG1h+pu93heq1t/Wy39PoemWirV70n11aunUqlqJcuyBw8evPPOOyDL4fHjx57nnTnbyv379999992XXnrpypUrv/3tb5+4b2UFwDe/+c2//e1vAP7l2WeHasGv3n7btm0ASqn/+Na3hnrs/PjV229/zbYB/POQT//8y7e/ZgNQ/zfFV+l4XQB49913zxWO3d3du3ffv3v3/V/+8pf3TH7961/fvXs3OzjIDg6yZFtWi7ybiGJRJIkoVsV2lVerIjnQ21WRHMhqkRWLIjnI59/f39/f388OElEEUBXbx3MmsrvNgBOPTWS1yLtdXtwWVfBu/u9BfqPsbvNiVVSLvHugt4tsO9Hdbb6dHBcFwI7+zQ4SUSzy6mHD8gYfFe2KIlDdzquLJJFP3sW2u/kt+WOPn0V2cHD4LIrbcrsqkq7sJrrbFdXq8etwVKsrisV8BtlNsoMDvZ2/YgCKrAgAbLvKq9uya3iV2HbejOToRftsOr8LgEgOZBW8e3B0eyKrRZEcZElXVsGK1ePpo4cfVrn7/t2779/d3d39+c9/np3lCoDHjx8B+N3vfpf3DZ/zpS996dGjx/l0Cktdu+Eixa1bSFPc2lCvbQT7YNc2cOd2Yt3Ee/vRPgopsAoAV69e/WxBRSR3bsfYwJ3bITa8O9+Pitv+BpCmvfyx1264gLoB3EF8LXWu3XDxpnpvP74G584fcAMJbrh4s3dnP9p3KtWqt2H1XjssiuK2b6W9124n1o+xCvvWLRvdxsbt+NqG995+fO2whI3VrdeT8ir0m/0IQD/1LfTu3A5x0//DRm0f4haAtHfndrAPdu3m1vdWTz4L+1aSvYLWy98PcdP/w6sVfL3w3m2kN91bG+q1jbwl8TU42A/7qz5+hPUfA6m2Xnf1jzoAije8r+9H+0XcuR3sAxvfW8dTr9KxtH9iOrW/joK1CoBVt22k6j3E1948nmP95i0AWF1V7yEC/BR45ZX1m9vs9vePl3H16tXHjx6d0U+csLK7u/vcc88BuHLlyu9///un5/jGN77xySef/GuhcLLVrZdfxev/u7V6xtLTe/cArD7//PkbNJr+d19WN89uz2jSe/eGfwpp67v98o+/d54WzeZVSu/d+/jjjwHcv3//PFuTld3d3WePtqDPP//8gwcPnnnmmS984QvPPPMMgC9/+cv3PvggyzIA1196aaim/Pmjj+7fvw/gueee+6evfnWEJzMPjp/Fvw359Idd/lRfpT9/9NEH9+/n0w8+/PBcyciyrNvtTqlBZD6dJxlXAGxsbIRhOJMmkUtjJd9SEPI5Vy66AWROLXwy0taaVYOQXqLKdVQqSaHg1I8n3KSiXC9R5brdrDTigrfj2toCtGqUauAccDyg7NSsUMidsmpWwtjb2ZvSh6C5svhbk/7mSilgjEXwpG8DUEAZ6DVKtYLUjuohrCW+dlQzrAUQ2kcT5To01tfR72vVKIWe9KBs21aNUi0Cl1l7/aKf1fQtfjJM0tZaBea3ftra7JXby9ApnOG8yci/Q8lnpunFmD5jjQ+eaWVlOTuVxXdmRGjFE7NBn02ow1hmC/+plZxq8Dt/UDIGdRh/WhmlLS8M3wONVmi0WuSEMfqMZ38x3PwffmdGhcaptUwGDxXGGGdkn47cpuHMrBA5YYw+IxviAKGxzKzQkpnOOAPUZyw46jOWF40zyCjG6DP+PqsVNrNCS2Z64wzamiyyccYZtDW53KY3zqA+Y5FRn7G8aJxBRjHNPuPTo99dXh3vsMnzFxq/1jK5iHHGo7eAE992jvx96bCFxq9Fjgxa94OSka+AL37787c/vapOPmTkb+GHKjRyrSUz+J0/3lFbJ1fb4FU1ppkVWibTTEYuX20zWFUzK0RG35qQRTfucaBpa61p79XVZq/cLvc2m7brQnU6cOIEHsIwLvg77fXxf9eTttasWsSFAKZbaIlMbX8GAKTa3nHVZjMMYri27TgKKqwFBSF9VzVKUQQoYBIfJG1fa9WshEHBrk+1EDl05pm8zk8LzqWe4AIvvNAyo3EGOcWA1Jx+rxYMYEIKLrQWjHHOACZ0pgUXWjJAaC054zLTgjGh5Yhv8acLPTEhOeNyguWWy+C1P9o4Y9UuAEHYQAS4vu/b6ACurfu9MEhsNwIKGnA8F/1eGEVRBXpvpNw+XUhBA74Xlmpw63A8FyqYWDlywoTyl79XT7mLn3LP5GtNo9ySonEGOcWA1Jju1YIBXEoOLg9HGFxmkgNgQksp8228FgzAE/Nowdmg97pRXk5IqTMphWBcHo489FEJMMYYF1LnfcVh+4YqsqwGr/2RxhlxpwPEjnZ9H0rZ6KsYQBT2LB9NlNtAejij+myeXhhEEQr68MTTQ4ihYJViLvwdVzWVr7P1VQB2AYi42KmXobXWvTAI4SKMwH3arzG+yW4v6FRGi4PGGcSMzp+xvKb6vQlZWLS9IGZnHAcK6jkW1JmDyLP7jONFzMMpLGl6stOD1jt1CcSIPpsQM0oGMaNkEDNKBjGjZBAzSgYxo2QQM0oGOcVohwNdNodHk+fHfUmO/IhzJqSUUh4dlsaEPDxODCw/Qv34aHgAy3Zw6bL0GaphdaCdMEjsOmLEjgLjvg0AyvFc9OFKHxYKQMQYi8JeD1FU0CnCIIQDIBnhaLTLjPaOH+pvrqn6iWvupa2W3tpa4sMGKRnE7Lxbk3n4YpCmJzt9xhofPBMdCrqoJnB8BllUox8HSh3GMhv1U+tUr7A32avq0TX6TjH4bT/GseNTvcLeZK+qR9foG968nnd8sgunM5ebTG2cMdXTgU924XTm8uFRn7G8pjbOoD5joVGfsbymNs6Y6oXvJrtwukbf8Ob1eq20NZm+6Y0zaGuyyKjPWF7T259BfcYioz5jeV3cOGOcK+xN9qp6dI2+4U2nzxj/CntDLfzTvuFCa6MtDUt0jb6ZH5/x6K3Pf3+d/zuRV3yyC396aWMucIGMcdbHp6+KOMFr30124VNt6oIa+6itk++tib/Qk134VJu6cOh4vuVFx4GSUQz72SRtrVm1gtROJ7/YYq9ct3UPyl7fslqbvbKbWKWAS+12Kh13z+2slAIwIX0b6DRKQcSE3ht0XvK034eFXg9lu1PpuDt11WwmcOrtLbRaldpRaSe0woL0XVjW8QzmpaatNasGIb1Eleu21gBUo5MUYqe+l7cflabtu0p1UHaTinK9RNnu1vrif3adwv6MuNOMgxguwiCE64W1xM/WkdpOUunEDIiVdhzPza9hwMTRz0cLnHuuPbi1q5Zaq8D3ba3iKHZ0LwyCCMypb22VgVpeGrYuoOZYFvThDNxtn/Kj0yeuquSFpdCTvu+iESQ6RRgkdt31nU6pEbMIcD0PKgwSvz24lctg6tuLk78X/fxvR8mFOuvbj9MNvvfI4bVmtOBCCwbGpZRSa8E5H/myVU9cWE/yz6Y5wOXxxfQGlMhPbsDz0x/kDwFwdDYEwT+bllNo/+UweP1O6CwJQ3fygz25CXCEcKDCILHdGCgcnddgcAnbSSod+G6qYsSOdpwCQxSrvutKH6rBuH94ZgSoybf/csjo14sn0dbtnJYuGeTYlMYZ4w8FTl/yoCGCzgvni9Unqg8sMr3WXmKD1/7I44wJDAVOM3CIoHuNCFy6roJOe/nZlRzO4sEVptjayytbmHEGDQtm6TIlg0wWfW9CRrEsZ30kT1uccQaZpTP6DNqgLKozT/J3rivsHS+Cphdm+uz1Tl0CMaIRKDGjZBAzSgYxo2QQM0oGMaNkEDNKBjGjZBAzSgYxo2QQM0oGMaNkEDNKBjGjZBAzSgYxo2QQM0oGMaNkEDNKBjGjZBAzSgYxo2QQM0oGMaNkEDNKBjGjZBAzSgYxo2QQM0oGMaNkEDNKBjGjZBAzSgYxo2QQM0oGMaNkEDNKBjGjZBAzSgYxo2QQM0oGMaNkEDNKBjGjZBAzSgYxo2QQM0oGMaNkEDNKBjGjZBAzSgYxo2QQM0oGMaNkEDNKBjGjZBAzSgYxo2QQM0oGMaNkEDNKBjGjZBAzSgYxo2QQM0oGMaNkEDNKBjGjZBAzSgYxo2QQM0oGMaNkEDNKBjGjZBAzSgYxo2QQM0oGMaNkEDNKBjGjZBAzSgYxo2QQM0oGMaNkEDNKBjGjZBAzSgYxo2QQM0oGMaNkEDNKBjGjZBAzSgYxo2QQM0oGMaNkEDNKBjFbpGSkrTWrVhDStQELnYqq+4lVgszqarNXbtvNNVXfs5trqr6DilWLuBBAuY5KBTu+rS0A6FilgHHpo6Hqe+XemlWLwA+XULe1BqAajaRQAODU63az0nH9oFQSOttavdinP2GLlAwAQJx04lrsSS+OEo2YcR/9Xhgkdh1xlOgUcZRouL7WqlkJg4LtxlFU0Ot2Z03VdxADKLiA8uzjFR2rfi8MQrheWAo96fu+jU6jFMCtw/FcqABINLBYyVjJsuyi20Dm0Xn7jJWVFQB5jGh6MabPWOODZ1pZoU5lMZ0ZEVrxxGzQ1oQ6jGW2cJ9NyLkNfucPSgZ1GMuMthfEjMYZxIzGGctrOuOMP62M0pYXhu+BRis0y1ojFLoMxugznv3FcPN/+J0ZFZplrZELzYHBQ4UxxhnZpyO3aTgzKzTjWvNtjD4jezS5ZsxHoRnXumhT259BfcZCoz7j4mpdNBpnzGut+TZGn/H3Wb2IMys041oXbXrjDNqaLLJxxhm0NbncpjfOoD5jkVGfcXG1LhqNM+a11nyjPuPial20CxpnPHrriX+/+O1BMw82VKFZ1hqn0NybwvEZ+cv3ue+mR/4yfdhCs6w1jUIzNPidP8ZRW39aMbxpHr01+eMVZlZoxrUu2tSSAdObZkqv4MwKzbjWHBuYGjoOdInRcaDL66xPGEPTggFcCAYwobXUgnGZZVpIzrjMJAeYEBxc6vwWLTjnXOjhSz1ZUXLGpZZSCsY5Z1zKvA15LcEAcCFHL/NZISk4E1IwJrQWecvzumBCSqnHfkZzYfDaH7XPiIECECQ92La946pW37KV47noq/yuGLGjHcdz0e+FQRCBu+1RzzCxurWjy6voteBCA7B9F40gdOD6OltHa60WO9r1JSuVbKs94jM6UUj3teMpFUZRodeLgxD1ra1VdKxaBOED0PkzYk596zKfTiUb/GP3AXdftnFG2trslduXeV3Nk0VKBhnOwvyuNW2tWbUIABM6PwGXdgFLVSohCv5ee30CBZr2jgsNqE4jcQpxGBe8nToqlcT3nUapFoFLiUbH8evlydWdT5fos8mqXQAixqVvaxUy7kMD6IVRFHEf6djnyUq1veOqZicMYk96HgAgCMKe6/u+DSgAQKzgeY4NPbm6F2bBxhlpa62CnT0aTUzbpUvGHMnPMiml01C2byvVCEMUCoUgdvSe3dxE21VrKikkbruNzU2022itNWoFP3PRX19fR39zpRQzVih4cVCLuMxc9AGlGonto9GIC/5eez1trTVtH5384cr2bViqYYUQ/p6N/jo6m2jXrVRrbVmW1jq/xUW/0yg5frZ1WHpzpRELf69spVprqEajhgiR5Gg40gs7ie+6qtGB74Sl0NN7W6uXaJwxG/loJj9VaLvcy08D2muUagXOnfrRLU2rFPv/hQjcU40aPAnYtu/7AOC60K1GEHuuCy9xEhdp/m8rrEURoPqubQFpqxGAC9+1oRAgilXfOTyrpK0apShCAQBg+65qlPKHw5MAemEECKAPoNUIYq8ONBXalt5UqKtGEHuuE5YCCL2ettby0gEiDqTQTYW6jULEgCiCK30AvmsDgOfYKoyAfEs6zV0pl5EWDGCcMzBxuGsr358mpZBSCwYutRCcMXFxjZTiiV16UnCpD/8OfsjxPFowNnhP3RlbEyxpz7H4zh4qnJnP43lOzk/Tczb9gmBNsH3gVeC6lA+1VMCrwAuCvSHEGwCA/+RSCfZT4DrwgpQPsyzT4qdcPhSsCfyUsSbQZOINzvez8+wdP9mOp2+k6fmY/mu/j2wdrbUXQ++H6HQr+ApnL8L/oY2HqrHL5UOn8ZNQwcFfmOj5iGD9A/BXbW+4KuoAYC96hd9E0VcQ/jGI0G5fp08fS+ivrU1Vbl8f/MGfkkHMLtE+UDJTlIxFpfv9f7QQNRWr2/nfh9qy0PzvjvsDt/OzRgxvZ8PWCsh3/V9fX0fa+p9emYXWT/ayH1AyFpWFzs8qeNFDt5Ic/t2pP+zlx83Ef4kioPfQC3+T+LbT+E3iX19P3+mFfwzxlQL/d9A4g5zm/wEEQfSzEnzQdwAAAABJRU5ErkJggg==</ATTRIBUTE>
+<ATTRIBUTE name="NT Model Attributes" type="LONGSTRING">NOTEBOOK
+CHAPTER &quot;Description&quot;
+#ATTR &quot;Shared&quot;
+ATTR &quot;Model state&quot; enabled:(cond(search (sMfbRegistration, &quot;MFB_VERS&quot;, 0) = -1, 1, 0))
+ATTR &quot;Description&quot;
+ATTR &quot;Show State&quot; ctrltype:check unchecked-value:&quot;No&quot; checked-value:&quot;Yes&quot; 
+ATTR &quot;Last user&quot; write-protected
+ATTR &quot;Date last changed&quot; write-protected
+#CHAPTER &quot;Suggestion for improvement&quot;
+#ATTR &quot;Suggestion for improvement&quot;
+</ATTRIBUTE>
+<ATTRIBUTE name="Model state" type="ENUMERATION">Draft</ATTRIBUTE>
+<ATTRIBUTE name="People-like view" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Action" type="ENUMERATION">Fill in</ATTRIBUTE>
+<ATTRIBUTE name="Keywords" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Description" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Model type" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Show State" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="BAR Display active" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Actor_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="Actor_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Actor_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="Description_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="Description_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Description_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="ModelingAreaSize" type="ENUMERATION">20</ATTRIBUTE>
+<ATTRIBUTE name="Modelling_size" type="ENUMERATION">3</ATTRIBUTE>
+<ATTRIBUTE name="DrawingAreaWidth" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="DrawingAreaHeight" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Reference overview settings" type="LONGSTRING">Responsible for execution|Responsible for execution
+Accountable for approving results|Accountable for approving results
+Cooperation/participation|Cooperation/participation
+To inform|To inform
+Modelling|Modelling
+Knowledge Product|Knowledge Product
+Documents and Resources|Documents and Resources
+#Data Object|Data Object
+Incoming Data Object|Incoming Data Object
+Outgoing Data Object|Outgoing Data Object
+Description|Description</ATTRIBUTE>
+<ATTRIBUTE name="Data Object_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="Data Object_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Data Object_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="Knowledge Product_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="Knowledge Product_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Knowledge Product_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="Documents and Resources_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Documents and Resources_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="Documents and Resources_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="Responsible for execution_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="Responsible for execution_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Responsible for execution_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="Accountable for approving results_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="Accountable for approving results_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Accountable for approving results_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="Cooperation/participation_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="Cooperation/participation_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Cooperation/participation_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="To inform_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="To inform_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="To inform_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="Incoming Data Object_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="Incoming Data Object_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Incoming Data Object_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="Outgoing Data Object_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="Outgoing Data Object_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Outgoing Data Object_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="id_bpmndi_diagram" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="id_bpmndi_plane" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="id_bpmndi_collaboration" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="CommentModellingAreaSize" type="ENUMERATION">3</ATTRIBUTE>
+<ATTRIBUTE name="CommentTypeSize" type="ENUMERATION">8</ATTRIBUTE>
+<ATTRIBUTE name="CommentAreaSize" type="ENUMERATION">2</ATTRIBUTE>
+<ATTRIBUTE name="Comment Mode" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="CommentxCoorTextBox" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="CommentyCoorTextBox" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="CommentModellingDirection" type="ENUMERATION">vertical</ATTRIBUTE>
+</MODELATTRIBUTES>
+<INSTANCE id="obj.16521" class="Document" name="Acquired Competency Barnaby Barnes">
+<ATTRIBUTE name="Position" type="STRING">NODE x:3cm y:2.5cm index:1</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-02] Attribute \&quot;Fontcolor\&quot; (Group) does not exist!  \&quot;fontcolor\&quot; (Document)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<RECORD name="Technical Attributes"></RECORD>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Referenced document" type="PROGRAMCALL">ITEM &quot;&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Dokument</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Display file name" type="INTEGER">0</ATTRIBUTE>
+<RECORD name="CompetencyAndLevel">
+<ROW id="row.16524" number="1">
+<INTERREF name="Competency">
+<IREF type="objectreference" tmodeltype="Competency model" tmodelname="Competency model TitoloUnico" tmodelver="" tclassname="Competency" tobjname="Assessing administrative &amp; procedural regularity"></IREF>
+</INTERREF>
+<ATTRIBUTE name="ACLevel" type="STRING">3</ATTRIBUTE>
+<ATTRIBUTE name="LearningGoal" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Status" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Score" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Updated" type="DATE">2014:01:01</ATTRIBUTE>
+</ROW>
+<ROW id="row.16526" number="2">
+<INTERREF name="Competency">
+<IREF type="objectreference" tmodeltype="Competency model" tmodelname="Competency model TitoloUnico" tmodelver="" tclassname="Competency" tobjname="Managing front-office &amp; external services"></IREF>
+</INTERREF>
+<ATTRIBUTE name="ACLevel" type="STRING">2</ATTRIBUTE>
+<ATTRIBUTE name="LearningGoal" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Status" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Score" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Updated" type="DATE">2014:01:01</ATTRIBUTE>
+</ROW>
+<ROW id="row.16528" number="3">
+<INTERREF name="Competency">
+<IREF type="objectreference" tmodeltype="Competency model" tmodelname="Competency model TitoloUnico" tmodelver="" tclassname="Competency" tobjname="Competent verification of congruency and pertinency"></IREF>
+</INTERREF>
+<ATTRIBUTE name="ACLevel" type="STRING">4</ATTRIBUTE>
+<ATTRIBUTE name="LearningGoal" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Status" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Score" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Updated" type="DATE">2014:01:01</ATTRIBUTE>
+</ROW>
+<ROW id="row.16530" number="4">
+<INTERREF name="Competency">
+<IREF type="objectreference" tmodeltype="Competency model" tmodelname="Competency model TitoloUnico" tmodelver="" tclassname="Competency" tobjname="Manage specific admin procedure"></IREF>
+</INTERREF>
+<ATTRIBUTE name="ACLevel" type="STRING">3</ATTRIBUTE>
+<ATTRIBUTE name="LearningGoal" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Status" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Score" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Updated" type="DATE">2014:01:01</ATTRIBUTE>
+</ROW>
+</RECORD>
+<INTERREF name="Referenced Learning Object"></INTERREF>
+<ATTRIBUTE name="Document Type" type="ENUMERATION">Not Specified</ATTRIBUTE>
+<ATTRIBUTE name="Document Form" type="ENUMERATION">Image</ATTRIBUTE>
+<ATTRIBUTE name="Document Format" type="ENUMERATION">doc</ATTRIBUTE>
+<ATTRIBUTE name="Document Kind" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Document Lifecycle" type="STRING"></ATTRIBUTE>
+<RECORD name="Document Tags"></RECORD>
+<ATTRIBUTE name="Document Version" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16532" class="Group" name="Competency Profiles">
+<ATTRIBUTE name="Position" type="STRING">NODE x:1cm y:1.5cm w:18cm h:4.5cm index:2</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(&quot;&quot;) val:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<RECORD name="Technical Attributes"></RECORD>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Open questions" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Show name" type="ENUMERATION">outside</ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16532&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Cardinality" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Color" type="STRING">white</ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16535" class="Group" name="Learning Objects">
+<ATTRIBUTE name="Position" type="STRING">NODE x:1cm y:7.5cm w:18cm h:4.5cm index:3</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(&quot;&quot;) val:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<RECORD name="Technical Attributes"></RECORD>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Open questions" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Show name" type="ENUMERATION">outside</ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16535&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Cardinality" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Color" type="STRING">white</ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16538" class="Group" name="Business Relevant Documents">
+<ATTRIBUTE name="Position" type="STRING">NODE x:1cm y:23.5cm w:18cm h:4.5cm index:4</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(&quot;&quot;) val:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<RECORD name="Technical Attributes"></RECORD>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Open questions" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Show name" type="ENUMERATION">outside</ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16538&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Cardinality" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Color" type="STRING">white</ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16541" class="Document" name="SCIA Instance">
+<ATTRIBUTE name="Position" type="STRING">NODE x:3cm y:25cm index:5</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-02] Attribute \&quot;Fontcolor\&quot; (Group) does not exist!  \&quot;fontcolor\&quot; (Document)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<RECORD name="Technical Attributes"></RECORD>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Referenced document" type="PROGRAMCALL">ITEM &quot;&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Dokument</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Display file name" type="INTEGER">1</ATTRIBUTE>
+<RECORD name="CompetencyAndLevel"></RECORD>
+<INTERREF name="Referenced Learning Object"></INTERREF>
+<ATTRIBUTE name="Document Type" type="ENUMERATION">Not Specified</ATTRIBUTE>
+<ATTRIBUTE name="Document Form" type="ENUMERATION">Text</ATTRIBUTE>
+<ATTRIBUTE name="Document Format" type="ENUMERATION">doc</ATTRIBUTE>
+<ATTRIBUTE name="Document Kind" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Document Lifecycle" type="STRING"></ATTRIBUTE>
+<RECORD name="Document Tags"></RECORD>
+<ATTRIBUTE name="Document Version" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16544" class="Document" name="Third Party Opinion">
+<ATTRIBUTE name="Position" type="STRING">NODE x:7cm y:25cm index:6</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-02] Attribute \&quot;Fontcolor\&quot; (Group) does not exist!  \&quot;fontcolor\&quot; (Document)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<RECORD name="Technical Attributes"></RECORD>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING">Opinion on an inssue</ATTRIBUTE>
+<ATTRIBUTE name="Referenced document" type="PROGRAMCALL">ITEM &quot;&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Dokument</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Display file name" type="INTEGER">0</ATTRIBUTE>
+<RECORD name="CompetencyAndLevel"></RECORD>
+<INTERREF name="Referenced Learning Object"></INTERREF>
+<ATTRIBUTE name="Document Type" type="ENUMERATION">Not Specified</ATTRIBUTE>
+<ATTRIBUTE name="Document Form" type="ENUMERATION">Text</ATTRIBUTE>
+<ATTRIBUTE name="Document Format" type="ENUMERATION">doc</ATTRIBUTE>
+<ATTRIBUTE name="Document Kind" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Document Lifecycle" type="STRING"></ATTRIBUTE>
+<RECORD name="Document Tags"></RECORD>
+<ATTRIBUTE name="Document Version" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16547" class="Document" name="Titolo Unico Authorization Document">
+<ATTRIBUTE name="Position" type="STRING">NODE x:11cm y:25cm index:7</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-02] Attribute \&quot;Fontcolor\&quot; (Group) does not exist!  \&quot;fontcolor\&quot; (Document)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<RECORD name="Technical Attributes"></RECORD>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Referenced document" type="PROGRAMCALL">ITEM &quot;&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Dokument</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Display file name" type="INTEGER">0</ATTRIBUTE>
+<RECORD name="CompetencyAndLevel"></RECORD>
+<INTERREF name="Referenced Learning Object"></INTERREF>
+<ATTRIBUTE name="Document Type" type="ENUMERATION">Not Specified</ATTRIBUTE>
+<ATTRIBUTE name="Document Form" type="ENUMERATION">Text</ATTRIBUTE>
+<ATTRIBUTE name="Document Format" type="ENUMERATION">doc</ATTRIBUTE>
+<ATTRIBUTE name="Document Kind" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Document Lifecycle" type="STRING"></ATTRIBUTE>
+<RECORD name="Document Tags"></RECORD>
+<ATTRIBUTE name="Document Version" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16550" class="Document" name="Required Compentency SUAP Officer">
+<ATTRIBUTE name="Position" type="STRING">NODE x:7cm y:2.5cm index:8</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-02] Attribute \&quot;Fontcolor\&quot; (Group) does not exist!  \&quot;fontcolor\&quot; (Document)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<RECORD name="Technical Attributes"></RECORD>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Referenced document" type="PROGRAMCALL">ITEM &quot;&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Dokument</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Display file name" type="INTEGER">0</ATTRIBUTE>
+<RECORD name="CompetencyAndLevel">
+<ROW id="row.16553" number="1">
+<INTERREF name="Competency">
+<IREF type="objectreference" tmodeltype="Competency model" tmodelname="Competency model TitoloUnico" tmodelver="" tclassname="Competency" tobjname="Assessing administrative &amp; procedural regularity"></IREF>
+</INTERREF>
+<ATTRIBUTE name="ACLevel" type="STRING">4</ATTRIBUTE>
+<ATTRIBUTE name="LearningGoal" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Status" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Score" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Updated" type="DATE">2014:01:01</ATTRIBUTE>
+</ROW>
+<ROW id="row.16555" number="2">
+<INTERREF name="Competency">
+<IREF type="objectreference" tmodeltype="Competency model" tmodelname="Competency model TitoloUnico" tmodelver="" tclassname="Competency" tobjname="Managing front-office &amp; external services"></IREF>
+</INTERREF>
+<ATTRIBUTE name="ACLevel" type="STRING">4</ATTRIBUTE>
+<ATTRIBUTE name="LearningGoal" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Status" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Score" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Updated" type="DATE">2014:01:01</ATTRIBUTE>
+</ROW>
+<ROW id="row.16557" number="3">
+<INTERREF name="Competency">
+<IREF type="objectreference" tmodeltype="Competency model" tmodelname="Competency model TitoloUnico" tmodelver="" tclassname="Competency" tobjname="Competent verification of congruency and pertinency"></IREF>
+</INTERREF>
+<ATTRIBUTE name="ACLevel" type="STRING">4</ATTRIBUTE>
+<ATTRIBUTE name="LearningGoal" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Status" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Score" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Updated" type="DATE">2014:01:01</ATTRIBUTE>
+</ROW>
+<ROW id="row.16559" number="4">
+<INTERREF name="Competency">
+<IREF type="objectreference" tmodeltype="Competency model" tmodelname="Competency model TitoloUnico" tmodelver="" tclassname="Competency" tobjname="Manage specific admin procedure"></IREF>
+</INTERREF>
+<ATTRIBUTE name="ACLevel" type="STRING">4</ATTRIBUTE>
+<ATTRIBUTE name="LearningGoal" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Status" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Score" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Updated" type="DATE">2014:01:01</ATTRIBUTE>
+</ROW>
+</RECORD>
+<INTERREF name="Referenced Learning Object"></INTERREF>
+<ATTRIBUTE name="Document Type" type="ENUMERATION">Not Specified</ATTRIBUTE>
+<ATTRIBUTE name="Document Form" type="ENUMERATION">Image</ATTRIBUTE>
+<ATTRIBUTE name="Document Format" type="ENUMERATION">doc</ATTRIBUTE>
+<ATTRIBUTE name="Document Kind" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Document Lifecycle" type="STRING"></ATTRIBUTE>
+<RECORD name="Document Tags"></RECORD>
+<ATTRIBUTE name="Document Version" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16561" class="Document" name="Book: Managing Service Conference">
+<ATTRIBUTE name="Position" type="STRING">NODE x:3cm y:8.5cm index:9</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-02] Attribute \&quot;Fontcolor\&quot; (Group) does not exist!  \&quot;fontcolor\&quot; (Document)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<RECORD name="Technical Attributes"></RECORD>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Referenced document" type="PROGRAMCALL">ITEM &quot;&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Dokument</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Display file name" type="INTEGER">1</ATTRIBUTE>
+<RECORD name="CompetencyAndLevel"></RECORD>
+<INTERREF name="Referenced Learning Object"></INTERREF>
+<ATTRIBUTE name="Document Type" type="ENUMERATION">Not Specified</ATTRIBUTE>
+<ATTRIBUTE name="Document Form" type="ENUMERATION">Text</ATTRIBUTE>
+<ATTRIBUTE name="Document Format" type="ENUMERATION">doc</ATTRIBUTE>
+<ATTRIBUTE name="Document Kind" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Document Lifecycle" type="STRING"></ATTRIBUTE>
+<RECORD name="Document Tags"></RECORD>
+<ATTRIBUTE name="Document Version" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16564" class="Document" name="Video: Service Conference Management">
+<ATTRIBUTE name="Position" type="STRING">NODE x:6.5cm y:8.5cm index:10</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-02] Attribute \&quot;Fontcolor\&quot; (Group) does not exist!  \&quot;fontcolor\&quot; (Document)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<RECORD name="Technical Attributes"></RECORD>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Referenced document" type="PROGRAMCALL">ITEM &quot;&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Dokument</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Display file name" type="INTEGER">0</ATTRIBUTE>
+<RECORD name="CompetencyAndLevel"></RECORD>
+<INTERREF name="Referenced Learning Object"></INTERREF>
+<ATTRIBUTE name="Document Type" type="ENUMERATION">Not Specified</ATTRIBUTE>
+<ATTRIBUTE name="Document Form" type="ENUMERATION">Text</ATTRIBUTE>
+<ATTRIBUTE name="Document Format" type="ENUMERATION">doc</ATTRIBUTE>
+<ATTRIBUTE name="Document Kind" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Document Lifecycle" type="STRING"></ATTRIBUTE>
+<RECORD name="Document Tags"></RECORD>
+<ATTRIBUTE name="Document Version" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16567" class="Document" name="Course Note: Managing Service Conference">
+<ATTRIBUTE name="Position" type="STRING">NODE x:9.5cm y:8.5cm index:11</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-02] Attribute \&quot;Fontcolor\&quot; (Group) does not exist!  \&quot;fontcolor\&quot; (Document)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<RECORD name="Technical Attributes"></RECORD>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Referenced document" type="PROGRAMCALL">ITEM &quot;&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Dokument</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Display file name" type="INTEGER">0</ATTRIBUTE>
+<RECORD name="CompetencyAndLevel"></RECORD>
+<INTERREF name="Referenced Learning Object"></INTERREF>
+<ATTRIBUTE name="Document Type" type="ENUMERATION">Not Specified</ATTRIBUTE>
+<ATTRIBUTE name="Document Form" type="ENUMERATION">Text</ATTRIBUTE>
+<ATTRIBUTE name="Document Format" type="ENUMERATION">doc</ATTRIBUTE>
+<ATTRIBUTE name="Document Kind" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Document Lifecycle" type="STRING"></ATTRIBUTE>
+<RECORD name="Document Tags"></RECORD>
+<ATTRIBUTE name="Document Version" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<CONNECTOR id="con.16570" class="Is inside">
+<FROM instance="Acquired Competency Barnaby Barnes" class="Document"></FROM>
+<TO instance="Competency Profiles" class="Group"></TO>
+<ATTRIBUTE name="AutoConnect" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16571" class="Is inside">
+<FROM instance="SCIA Instance" class="Document"></FROM>
+<TO instance="Business Relevant Documents" class="Group"></TO>
+<ATTRIBUTE name="AutoConnect" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16572" class="Is inside">
+<FROM instance="Third Party Opinion" class="Document"></FROM>
+<TO instance="Business Relevant Documents" class="Group"></TO>
+<ATTRIBUTE name="AutoConnect" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16573" class="Is inside">
+<FROM instance="Titolo Unico Authorization Document" class="Document"></FROM>
+<TO instance="Business Relevant Documents" class="Group"></TO>
+<ATTRIBUTE name="AutoConnect" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16574" class="Is inside">
+<FROM instance="Required Compentency SUAP Officer" class="Document"></FROM>
+<TO instance="Competency Profiles" class="Group"></TO>
+<ATTRIBUTE name="AutoConnect" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16575" class="Is inside">
+<FROM instance="Book: Managing Service Conference" class="Document"></FROM>
+<TO instance="Learning Objects" class="Group"></TO>
+<ATTRIBUTE name="AutoConnect" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16576" class="Is inside">
+<FROM instance="Video: Service Conference Management" class="Document"></FROM>
+<TO instance="Learning Objects" class="Group"></TO>
+<ATTRIBUTE name="AutoConnect" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16577" class="Is inside">
+<FROM instance="Course Note: Managing Service Conference" class="Document"></FROM>
+<TO instance="Learning Objects" class="Group"></TO>
+<ATTRIBUTE name="AutoConnect" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+</MODEL>
+<MODEL id="mod.16488" name="BMM TitoloUnico" version="" modeltype="BMM" libtype="bp" applib="LearnPAd Prototype Dynamic Library 0.21">
+<MODELATTRIBUTES>
+<ATTRIBUTE name="Keywords" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Model type" type="ENUMERATION">Current model</ATTRIBUTE>
+<ATTRIBUTE name="State" type="ENUMERATION">In process</ATTRIBUTE>
+<ATTRIBUTE name="Reviewed on" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Reviewed by" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Author" type="STRING">barbara</ATTRIBUTE>
+<ATTRIBUTE name="Creation date" type="STRING">13.08.2015, 12:22</ATTRIBUTE>
+<ATTRIBUTE name="Last user" type="STRING">congyu</ATTRIBUTE>
+<ATTRIBUTE name="Date last changed" type="STRING">03.09.2015, 08:10:39</ATTRIBUTE>
+<ATTRIBUTE name="Number of objects and relations" type="INTEGER">10</ATTRIBUTE>
+<ATTRIBUTE name="Context of version" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Position" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-01] Internal error!  \&quot;fontcolor\&quot; (BPModel)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<RECORD name="Technical Attributes"></RECORD>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Keine Modellbezeichnung vergeben</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Pool Term" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="ParticipantType" type="ENUMERATION">Role</ATTRIBUTE>
+<ATTRIBUTE name="Role" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Entity" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="BoundaryVisible" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="BPD Model Attributes" type="STRING">NOTEBOOK
+
+CHAPTER &quot;Business Process Diagram Attributes&quot;
+ATTR &quot;Name&quot; write-protected
+ATTR &quot;Contact person&quot;
+ATTR &quot;Author&quot; write-protected
+ATTR &quot;Language (BPMN)&quot;
+ATTR &quot;ExpressionLanguage&quot;
+ATTR &quot;QueryLanguage&quot;
+ATTR &quot;Creation date&quot; write-protected
+ATTR &quot;Date last changed&quot; write-protected
+ATTR &quot;Documentation (Model)&quot;
+ATTR &quot;State&quot;
+
+GROUP &quot;Copyright&quot;
+ATTR &quot;Copyright info&quot; 
+ATTR &quot;Copyright info position&quot; 
+ENDGROUP
+
+CHAPTER &quot;Process Attributes&quot;
+ATTR &quot;Name&quot; write-protected
+ATTR &quot;Process Term&quot;
+ATTR &quot;ProcessType&quot;
+ATTR &quot;Status&quot;
+ATTR &quot;Assignments&quot; lines:5
+ATTR &quot;Properties (BPMN)&quot; lines:5
+ATTR &quot;AdHoc&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+GROUP &quot;AdHoc = True&quot;
+ATTR &quot;AdHocOrdering&quot;
+ATTR &quot;AdHocCompletionCondition&quot;
+ENDGROUP
+ATTR &quot;SuppressJoinFailure&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ATTR &quot;EnableInstanceCompensation&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ATTR &quot;Categories (Process)&quot;
+ATTR &quot;Documentation (Process)&quot;
+
+CHAPTER &quot;Pool Attributes&quot;
+GROUP &quot;Common Graphical Object Attributes&quot;
+ATTR &quot;Name&quot; write-protected
+ATTR &quot;Categories (Pool)&quot;
+ATTR &quot;Documentation (Pool)&quot;
+ENDGROUP
+GROUP &quot;Common Swimlane Attributes&quot;
+ATTR &quot;Pool Term&quot;
+ENDGROUP
+GROUP &quot;Pool Attributes&quot;
+ATTR &quot;ParticipantType&quot;
+ATTR &quot;Role&quot;
+ATTR &quot;Entity&quot;
+ATTR &quot;BoundaryVisible&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot; write-protected
+ENDGROUP</ATTRIBUTE>
+<ATTRIBUTE name="Language" type="ENUMERATION">System</ATTRIBUTE>
+<ATTRIBUTE name="ExpressionLanguage" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="QueryLanguage" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Process Term" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="BPD Term" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="ProcessType" type="ENUMERATION">None</ATTRIBUTE>
+<ATTRIBUTE name="Status" type="ENUMERATION">None</ATTRIBUTE>
+<RECORD name="Assignments"></RECORD>
+<ATTRIBUTE name="AdHoc" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="AdHocOrdering" type="ENUMERATION">None</ATTRIBUTE>
+<ATTRIBUTE name="AdHocCompletionCondition" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="EnableInstanceCompensation" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Categories (Process)" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation (Process)" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation (Pool)" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Categories (Pool)" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="SuppressJoinFailure" type="ENUMERATION">No</ATTRIBUTE>
+<RECORD name="Change history"></RECORD>
+<ATTRIBUTE name="RACI/DEMI visualisation" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Modelling direction" type="ENUMERATION">vertical</ATTRIBUTE>
+<ATTRIBUTE name="IT systems" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Responsible role" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Input/Output" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Products" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Use cases" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Products color" type="STRING">whitesmoke</ATTRIBUTE>
+<ATTRIBUTE name="RACI/DEMI color" type="STRING">whitesmoke</ATTRIBUTE>
+<ATTRIBUTE name="Responsible role color" type="STRING">whitesmoke</ATTRIBUTE>
+<ATTRIBUTE name="Input/Output color" type="STRING">whitesmoke</ATTRIBUTE>
+<ATTRIBUTE name="Use cases color" type="STRING">whitesmoke</ATTRIBUTE>
+<ATTRIBUTE name="IT systems color" type="STRING">whitesmoke</ATTRIBUTE>
+<ATTRIBUTE name="Contact person" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="_ToggleModelInfo_" type="PROGRAMCALL">ITEM &quot;_ToggleModelInfo_&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Display modelling information" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Documentation (Model)" type="STRING"></ATTRIBUTE>
+<RECORD name="Properties (BPMN)"></RECORD>
+<ATTRIBUTE name="CreationDate" type="EXPRESSION">EXPR val:&quot;13.08.2015, 12:22&quot;</ATTRIBUTE>
+<ATTRIBUTE name="ModificationDate" type="EXPRESSION">EXPR val:&quot;14.08.2015, 14:50:47&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Language (BPMN)" type="STRING">English</ATTRIBUTE>
+<ATTRIBUTE name="BPMN20 Model Attributes" type="LONGSTRING">NOTEBOOK
+# TODO AVAL sMfbRegistration:&quot;_MFB-Registration_&quot;
+CHAPTER &quot;Description&quot;
+ATTR &quot;Contact person&quot;
+ATTR &quot;Keywords&quot; lines:2
+ATTR &quot;Description&quot; lines:3
+ATTR &quot;Comment&quot; lines:3
+
+GROUP &quot;Copyright&quot;
+ATTR &quot;Copyright info&quot; 
+ATTR &quot;Copyright info position&quot; 
+ENDGROUP
+ATTR &quot;Name&quot; write-protected
+ATTR &quot;Id&quot; write-protected
+
+
+
+#---------------------------------------------
+CHAPTER &quot;Process properties&quot;
+#---------------------------------------------
+GROUP &quot;Process attributes&quot;
+ATTR &quot;Process type&quot; #None, Private, Public 
+ATTR &quot;Executable&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ATTR &quot;Closed&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ENDGROUP
+
+GROUP &quot;Process relevance&quot;
+ATTR &quot;Auditing&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ATTR &quot;Monitoring&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ENDGROUP
+
+CHAPTER &quot;User attributes&quot;
+ATTR &quot;Model type&quot;
+ATTR &quot;State&quot;
+ATTR &quot;Reviewed on&quot;
+ATTR &quot;Reviewed by&quot;
+
+CHAPTER &quot;System attributes&quot;
+ATTR &quot;Author&quot; write-protected
+ATTR &quot;Creation date&quot; write-protected
+ATTR &quot;Last user&quot; write-protected
+# ATTR &quot;Date last changed from&quot; write-protected
+ATTR &quot;Date last changed&quot; write-protected
+ATTR &quot;Number of objects and relations&quot; write-protected
+ATTR &quot;Context of version&quot; write-protected
+
+CHAPTER &quot;People-like view&quot;
+ATTR &quot;Action&quot;
+ATTR &quot;People-like view&quot;
+
+CHAPTER &quot;BAR Display&quot;
+ATTR &quot;BAR Display active&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot;
+AVAL s_Aktiv: &quot;BAR Display active&quot;
+ATTR &quot;Modelling direction&quot; ctrltype: radio enabled: (s_Aktiv = &quot;Yes&quot;)
+ATTR &quot;Modelling_size&quot;
+
+GROUP &quot;Responsible for execution&quot;
+ATTR &quot;Responsible for execution_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_Responsible_for_execution_display: &quot;Responsible for execution_display&quot;
+ATTR &quot;Responsible for execution_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_Responsible_for_execution_display = &quot;Yes&quot;))
+ATTR &quot;Responsible for execution_size&quot;
+ENDGROUP
+
+GROUP &quot;Accountable for approving results&quot;
+ATTR &quot;Accountable for approving results_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_Accountableforapprovingresults_display: &quot;Actor_display&quot;
+ATTR &quot;Accountable for approving results_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_Accountableforapprovingresults_display = &quot;Yes&quot;))
+ATTR &quot;Accountable for approving results_size&quot;
+ENDGROUP
+
+GROUP &quot;Cooperation/participation&quot;
+ATTR &quot;Cooperation/participation_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_Cooperationparticipation_display: &quot;Cooperation/participation_display&quot;
+ATTR &quot;Cooperation/participation_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_Cooperationparticipation_display = &quot;Yes&quot;))
+ATTR &quot;Cooperation/participation_size&quot;
+ENDGROUP
+
+GROUP &quot;To inform&quot;
+ATTR &quot;To inform_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_Toinform_display: &quot;To inform_display&quot;
+ATTR &quot;To inform_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_Toinform_display = &quot;Yes&quot;))
+ATTR &quot;To inform_size&quot;
+ENDGROUP
+
+GROUP &quot;Knowledge Product&quot;
+ATTR &quot;Knowledge Product_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_KnowledgeProduct_display: &quot;Knowledge Product_display&quot;
+ATTR &quot;Knowledge Product_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_KnowledgeProduct_display = &quot;Yes&quot;))
+ATTR &quot;Knowledge Product_size&quot;
+ENDGROUP
+
+GROUP &quot;Documents and Resources&quot;
+ATTR &quot;Documents and Resources_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_DocumentsandResources_display: &quot;Documents and Resources_display&quot;
+ATTR &quot;Documents and Resources_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_DocumentsandResources_display = &quot;Yes&quot;))
+ATTR &quot;Documents and Resources_size&quot;
+ENDGROUP
+
+GROUP &quot;Incoming Data Object&quot;
+ATTR &quot;Incoming Data Object_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_IncomingDataObject_display: &quot;Incoming Data Object_display&quot;
+ATTR &quot;Incoming Data Object_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_IncomingDataObject_display = &quot;Yes&quot;))
+ATTR &quot;Incoming Data Object_size&quot;
+ENDGROUP
+
+GROUP &quot;Outgoing Data Object&quot;
+ATTR &quot;Outgoing Data Object_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_OutgoingDataObject_display: &quot;Outgoing Data Object_display&quot;
+ATTR &quot;Outgoing Data Object_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_OutgoingDataObject_display = &quot;Yes&quot;))
+ATTR &quot;Outgoing Data Object_size&quot;
+ENDGROUP
+
+GROUP &quot;Description&quot;
+ATTR &quot;Description_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_Description_display: &quot;Description_display&quot;
+ATTR &quot;Description_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_Description_display = &quot;Yes&quot;))
+ATTR &quot;Description_size&quot;
+ENDGROUP
+
+CHAPTER &quot;Comment View&quot;
+ATTR &quot;Comment Mode&quot; ctrltype: check checked-value: &quot;No&quot; unchecked-value: &quot;Yes&quot;
+AVAL s_Aktiv: &quot;Comment Mode&quot;
+ATTR &quot;CommentAreaSize&quot;
+ATTR &quot;CommentModellingAreaSize&quot;
+ATTR &quot;CommentModellingDirection&quot;
+
+
+
+
+CHAPTER &quot;Change history&quot;
+ATTR &quot;Change history&quot; lines:30
+
+</ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;87007&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Auditing" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Monitoring" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Process type" type="ENUMERATION">None</ATTRIBUTE>
+<ATTRIBUTE name="Executable" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Closed" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Copyright info" type="STRING">Edit the model attributes to display your copyright info</ATTRIBUTE>
+<ATTRIBUTE name="Copyright info position" type="ENUMERATION">Bottom right</ATTRIBUTE>
+<ATTRIBUTE name="_GoToAceHp_" type="PROGRAMCALL">ITEM &quot;_GoToAceHp_&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="__GfxThumb__" type="LONGSTRING">iVBORw0KGgoAAAANSUhEUgAAALMAAAEACAIAAAB3X9DLAAAACXBIWXMAAAsTAAALEwEAmpwYAAAJ2UlEQVR4nO3dsWsb5x/H8Y/gh/+CkK0Bg3UBkSlDh8ek2UpsZdAQMmTxkHIpXVwKHkw8pmRICycKBYcWkg4ZSgcR0KOxhOKOncyR3CMI7ViSfyDL/YaTFTf62jlJJ1uW369JVe3HT3Qfvs/37h5JtTzPBYz432lPAHOKZMBGMmAjGbCRDNhIBmwkAzaSAVupZNRqteKC2OEHknh8Jh6X+WHjoH/0GugwDVhU5iE+7qjPdyb67XbYjDqrD3Tlyv5j7Xitd1qh0dlIGzsNKUrXO6281al1Wl7rD/aTnad68Ch6OvyBprKuUjW31A1Rut5pea13GonU3G12V+vpTr5bb7fDZrPe6250or1Wp9Zphf31+hWf766p12tnWdRU1tWvafS0kYWmOt3mbhSK5zsb6f6Vxk5Dna+/fuzzfO20X6/jjR7rs5yMe91mK613GklDkqJIWRZJmSQp2tys93pByg49eVgUqZNFW5trare7w9+NoubamtrtrhRtbq712u16NPgTH/xMrxeyTJE6HTUagxGL5yWFurJHmYrn01/Trb3dlRN6WSY0XjLOit692oNG2Ns80Re/3+tpba3Enyz9g3NmEZKBWTju3GS+VxNUafRYcz0DNqoCbNQM2OgzINFnoDyqAmxla0Zx96Vaw1AyuDn4LMYvXwjG6DMe/vVuqkn91/bVpcP/yeDm4NWOPzr4EH0GyjouGbQg58fosR63ZvT3nvVX79x4++yrl9d+vPDLUno9bby4+yTo08+3Lyro9W//Lv/8me5+93r74f2VvWf91Wsrr/64m1560Xix9ETPH96/weDzNPiRJrue0X9z6ZvVT/qvrn9/8Z/+m+VbN5clBUlavnVRvZcqnlm5oN7bv58/eX3rpn7Q9S/0U5A+OksGP/nBp9ifUavVyrdCr75d+n05/fLOcbeet68uMfjxg481/gSDHzZeBzpxn3H5/rvLk/0mg5/S4NP3GTgvxlhNKv/bDH784LMYv/xqcnb3gaJKxrHOKxASJ5cksZxzkmKfB+9DFSMPBpdin/tYkktCHpI4mW70YszhVJNYLgkhcc45l4Q8z71T7POQuNjP18xHxo99PphnSJymme4HqAqwsT8D0riryfH/92AR8UURdu8rp3PvF5fY5yFMWECLOi+pKPIhcS72ifdFTZ54WJOP5eLKVsD80OQHdX64cnmf55UtK8N1ZNplZPRYUxVg43oGbPQZkKruMz5Q+VLtk8R7n8SH2pcZrdYhDFuBWaj8lRmiz8CJo8/AEcaqMEcLiXMudq7iC6CHVVWTi4VjeGod+9zHLvahmHZInEuCj10Sch9Pu74Ui2BxXXX6mj/DmY8ea+6bQFrUz8/ATExV3vL8v1cqD04i4qLqV3gDqfLTh8EV1YOa7Jx0cL2yWLOmX0re/6GDV6byc5+QOM3ovIfVBBLvN0F5VAUcofoFqkon08TkB31MJX2Aj4tXdnD2WHQBxSllCMEPb0FXOv/q0WdAos/AGE65Zp2mwQ5QFydhuDPUVb4n6KxivYCN/RmQ6DNQHlWh0LtXeyD/dPcMfkD4jJAM2OgzIM14H+hZVFyUlEvCwbXLGd0UnXejx5qqABvnJrDRZ0jqt1c3ftWVneK70vLdOf/Os1ng8zNgYx8oyqLPwBHGOpNZLMOPCtJwZ1BS5Zsiz5LRY02fAYk+A+Wd5z6j317dSHduaz1t5VvZvUfRVqtTX3+s2Ofn9/R1iNUEEvszUB5VQVK/vfoo2tvK7nWbuyf77fJzjGTAxn0TSPQZKI+qIKnf76u7Uf/6z9if7zPVw0gGbPQZkNgHOmLwmWix94krdoOex9tpOftAUR7nJrB9JBnF93hRVxbYUYe41GoybE8Oj8LjxXh85EGnHsBEnwEbyYCNZMBGMmAjGbCRDNhIBmylknH4Stf8XKLhccnHk13v+viVLu7FLzzzEC/2+0367XZoRlm3k6baV2tvK3u/STx6VOu0ircchUYWmsq6StXcUjdE6Xqn5bXeaSRK0/3H2sl36+122GzWe92NTlR8zkbYX69fWdxNYIvfZ6ysNZWpoYaydle3G1k7RFubK9JuUK+/thvUC5kUlCra2lxRW5laSSOTkkYURVIjkaSVSN1+6KyntxO11UoaWWgkSaS+tAjvQ+B9rbCRDJTFPlDYFr/PQBnjvROJgnGeTbheFBdJKjTBNCqfwwTTmIc5zMjkfcbDv95VNYntq0uT/WKFc5h4GvMwh1mgz4BEn4HypqkZ/b1n/dU7N94+++rltR8v/LKUXk8bL+4+Cfr08+2LCnr927/LP3+mu9+93n54f2XvWX/12sqrP+6ml140Xiw90fOH929U8U+Yh2nMwxymMloFpr+e0X9z6ZvVT/qvrn9/8Z/+m+VbN5clBUlavnVRvZcqnlm5oN7bv58/eX3rpn7Q9S/0U5AqfDnmYRrzMIfKTHhHrVarley8Xn279Pty+uWd424ubF9dmuzcpHz3N6NpzMMcKnEKfcbl++8uTz/K1OZhGvMwh/I4N4E07rsXj19NqpwXV7qmmMOMLPbOHZQ13ierjG/wQSXOxT4P3sdu8IV1g2dO6vvWh19CMPgGglgu9j6Ek/zUlHmYwxhGk0BVgI39GTjCWBWmHB+7OB6U0OK7UE+mhPrYOSdJxVqWxHJJCIlzzrkk5HnunWKfh8SdzNexntbrMInRY01VgMQ+UJRHn4EjjLX2jKM4TzvdVXUe5jA/0zjO6LGmKkCiz8AYxqowH1OcK0qDk0MNTyD9SX8P6vu/nji5xIdwYiergwnMzUsxIe6bQGIfKMZwuiVrBkLiXOyTuLiZd+iqaOKKEwQf6ySXlbOK1QQ29nRBos9AeawXsHHfBDb6DEj0GSiP9QI2+gzY6DMg0WegPNYL2OgzII27muA8oyrAVrZmnPrXt/B4po+NI07NgIk+AzaSARvJgI1kwEYyYCMZsJEM2EgGbCQDNpIBG8mAjWTARjJgIxmwkQzYSAZsJAM2kgEbyYCNZMBGMmAjGbCRDNhIBmwkAzaSARvJgI1kwEYyYCMZsJEM2EgGbCQDNpIBG8mAjWTARjJgIxmwkQzYSAZsJAM2kgEbyYCNZMBGMmAjGbCRDNhIBmwkAzaSARvJgI1kwEYyYCMZsJEM2EgGbCQDNpIBG8mAjWTARjJgIxmwkQzYSAZsJAM2kgEbyYCNZMBGMmAjGbCRDNhIBmwkAzaSARvJgI1kwEYyYCMZsJEM2EgGbCQDNpIBG8mAjWTARjJgIxmwkQzYSAZsJAM2kgEbyYCNZMBGMmAjGbCRDNhIBmwkAzaSARvJgI1kwEYyYCMZsJEM2EgGbCQDNpIBG8mAjWTARjJgIxmwkQzYSAZs/wdRTP6NVpyYmgAAAABJRU5ErkJggg==</ATTRIBUTE>
+<ATTRIBUTE name="NT Model Attributes" type="LONGSTRING">NOTEBOOK
+CHAPTER &quot;Description&quot;
+#ATTR &quot;Shared&quot;
+ATTR &quot;Model state&quot; enabled:(cond(search (sMfbRegistration, &quot;MFB_VERS&quot;, 0) = -1, 1, 0))
+ATTR &quot;Description&quot;
+ATTR &quot;Show State&quot; ctrltype:check unchecked-value:&quot;No&quot; checked-value:&quot;Yes&quot; 
+ATTR &quot;Last user&quot; write-protected
+ATTR &quot;Date last changed&quot; write-protected
+#CHAPTER &quot;Suggestion for improvement&quot;
+#ATTR &quot;Suggestion for improvement&quot;
+</ATTRIBUTE>
+<ATTRIBUTE name="Model state" type="ENUMERATION">Draft</ATTRIBUTE>
+<ATTRIBUTE name="People-like view" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Action" type="ENUMERATION">Fill in</ATTRIBUTE>
+<ATTRIBUTE name="Keywords" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Description" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Model type" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Show State" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="BAR Display active" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Actor_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="Actor_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Actor_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="Description_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="Description_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Description_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="ModelingAreaSize" type="ENUMERATION">20</ATTRIBUTE>
+<ATTRIBUTE name="Modelling_size" type="ENUMERATION">3</ATTRIBUTE>
+<ATTRIBUTE name="DrawingAreaWidth" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="DrawingAreaHeight" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Reference overview settings" type="LONGSTRING">Responsible for execution|Responsible for execution
+Accountable for approving results|Accountable for approving results
+Cooperation/participation|Cooperation/participation
+To inform|To inform
+Modelling|Modelling
+Knowledge Product|Knowledge Product
+Documents and Resources|Documents and Resources
+#Data Object|Data Object
+Incoming Data Object|Incoming Data Object
+Outgoing Data Object|Outgoing Data Object
+Description|Description</ATTRIBUTE>
+<ATTRIBUTE name="Data Object_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="Data Object_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Data Object_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="Knowledge Product_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="Knowledge Product_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Knowledge Product_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="Documents and Resources_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Documents and Resources_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="Documents and Resources_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="Responsible for execution_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="Responsible for execution_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Responsible for execution_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="Accountable for approving results_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="Accountable for approving results_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Accountable for approving results_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="Cooperation/participation_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="Cooperation/participation_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Cooperation/participation_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="To inform_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="To inform_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="To inform_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="Incoming Data Object_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="Incoming Data Object_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Incoming Data Object_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="Outgoing Data Object_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="Outgoing Data Object_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Outgoing Data Object_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="id_bpmndi_diagram" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="id_bpmndi_plane" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="id_bpmndi_collaboration" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="CommentModellingAreaSize" type="ENUMERATION">3</ATTRIBUTE>
+<ATTRIBUTE name="CommentTypeSize" type="ENUMERATION">8</ATTRIBUTE>
+<ATTRIBUTE name="CommentAreaSize" type="ENUMERATION">2</ATTRIBUTE>
+<ATTRIBUTE name="Comment Mode" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="CommentxCoorTextBox" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="CommentyCoorTextBox" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="CommentModellingDirection" type="ENUMERATION">vertical</ATTRIBUTE>
+</MODELATTRIBUTES>
+<INSTANCE id="obj.16489" class="Learning Goal" name="Proper management of user requests">
+<ATTRIBUTE name="Position" type="STRING">NODE x:3cm y:3cm w:3cm h:1cm index:1</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<RECORD name="Technical Attributes"></RECORD>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Show name" type="ENUMERATION">Yes</ATTRIBUTE>
+<INTERREF name="Referenced Strategic Goal"></INTERREF>
+<INTERREF name="Referenced Operational Goal"></INTERREF>
+<ATTRIBUTE name="Line Length" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Color" type="STRING">lightskyblue</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Cognitive Process Dimension" type="ENUMERATION">Remember</ATTRIBUTE>
+<ATTRIBUTE name="Knowledge Dimension" type="ENUMERATION">Factual</ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16492" class="Learning Goal" name="Confident check of regularity">
+<ATTRIBUTE name="Position" type="STRING">NODE x:3.5cm y:12cm w:3cm h:1cm index:2</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<RECORD name="Technical Attributes"></RECORD>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Show name" type="ENUMERATION">Yes</ATTRIBUTE>
+<INTERREF name="Referenced Strategic Goal"></INTERREF>
+<INTERREF name="Referenced Operational Goal"></INTERREF>
+<ATTRIBUTE name="Line Length" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Color" type="STRING">lightskyblue</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING">check regularity/irregularity of an request</ATTRIBUTE>
+<ATTRIBUTE name="Cognitive Process Dimension" type="ENUMERATION">Remember</ATTRIBUTE>
+<ATTRIBUTE name="Knowledge Dimension" type="ENUMERATION">Factual</ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16495" class="Group (BMM)" name="Organisation Related Goals (Role/Unit)">
+<ATTRIBUTE name="Position" type="STRING">NODE x:1cm y:1cm w:18.5cm h:8.5cm index:3</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<RECORD name="Technical Attributes"></RECORD>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Show name" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Name InOut" type="ENUMERATION">inside</ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16498" class="Group (BMM)" name="Process Related Goals">
+<ATTRIBUTE name="Position" type="STRING">NODE x:1cm y:10.5cm w:18.5cm h:5.5cm index:4</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<RECORD name="Technical Attributes"></RECORD>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Show name" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Name InOut" type="ENUMERATION">inside</ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16501" class="Learning Goal" name="Properly coordination of admin procedure">
+<ATTRIBUTE name="Position" type="STRING">NODE x:8.5cm y:12cm w:3cm h:1cm index:5</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<RECORD name="Technical Attributes"></RECORD>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Show name" type="ENUMERATION">Yes</ATTRIBUTE>
+<INTERREF name="Referenced Strategic Goal"></INTERREF>
+<INTERREF name="Referenced Operational Goal"></INTERREF>
+<ATTRIBUTE name="Line Length" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Color" type="STRING">lightskyblue</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING">Coordination of the administrative procedure in respect of timing and modality provided by the norms</ATTRIBUTE>
+<ATTRIBUTE name="Cognitive Process Dimension" type="ENUMERATION">Remember</ATTRIBUTE>
+<ATTRIBUTE name="Knowledge Dimension" type="ENUMERATION">Factual</ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16504" class="Learning Goal" name="Properly check of regularity">
+<ATTRIBUTE name="Position" type="STRING">NODE x:13.5cm y:12cm w:3cm h:1cm index:6</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<RECORD name="Technical Attributes"></RECORD>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Show name" type="ENUMERATION">Yes</ATTRIBUTE>
+<INTERREF name="Referenced Strategic Goal"></INTERREF>
+<INTERREF name="Referenced Operational Goal"></INTERREF>
+<ATTRIBUTE name="Line Length" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Color" type="STRING">lightskyblue</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Cognitive Process Dimension" type="ENUMERATION">Remember</ATTRIBUTE>
+<ATTRIBUTE name="Knowledge Dimension" type="ENUMERATION">Factual</ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16507" class="Learning Goal" name="Check regularity/irregularity of the requests">
+<ATTRIBUTE name="Position" type="STRING">NODE x:6.5cm y:3cm w:3cm h:1cm index:7</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<RECORD name="Technical Attributes"></RECORD>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Show name" type="ENUMERATION">Yes</ATTRIBUTE>
+<INTERREF name="Referenced Strategic Goal"></INTERREF>
+<INTERREF name="Referenced Operational Goal"></INTERREF>
+<ATTRIBUTE name="Line Length" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Color" type="STRING">lightskyblue</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Cognitive Process Dimension" type="ENUMERATION">Remember</ATTRIBUTE>
+<ATTRIBUTE name="Knowledge Dimension" type="ENUMERATION">Factual</ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16510" class="Learning Goal" name="Coordination of the administrative procedure in respect of timeing and modality provided by the norms">
+<ATTRIBUTE name="Position" type="STRING">NODE x:10cm y:3cm w:3cm h:1cm index:8</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<RECORD name="Technical Attributes"></RECORD>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Show name" type="ENUMERATION">Yes</ATTRIBUTE>
+<INTERREF name="Referenced Strategic Goal"></INTERREF>
+<INTERREF name="Referenced Operational Goal"></INTERREF>
+<ATTRIBUTE name="Line Length" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Color" type="STRING">lightskyblue</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Cognitive Process Dimension" type="ENUMERATION">Remember</ATTRIBUTE>
+<ATTRIBUTE name="Knowledge Dimension" type="ENUMERATION">Factual</ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16513" class="Learning Goal" name="Check regularity of data and declarations">
+<ATTRIBUTE name="Position" type="STRING">NODE x:13.5cm y:3cm w:3cm h:1cm index:9</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<RECORD name="Technical Attributes"></RECORD>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Show name" type="ENUMERATION">Yes</ATTRIBUTE>
+<INTERREF name="Referenced Strategic Goal"></INTERREF>
+<INTERREF name="Referenced Operational Goal"></INTERREF>
+<ATTRIBUTE name="Line Length" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Color" type="STRING">lightskyblue</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Cognitive Process Dimension" type="ENUMERATION">Remember</ATTRIBUTE>
+<ATTRIBUTE name="Knowledge Dimension" type="ENUMERATION">Factual</ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16516" class="Learning Goal" name="Draw up an administrative act">
+<ATTRIBUTE name="Position" type="STRING">NODE x:17cm y:3cm w:3cm h:1cm index:10</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<RECORD name="Technical Attributes"></RECORD>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Show name" type="ENUMERATION">Yes</ATTRIBUTE>
+<INTERREF name="Referenced Strategic Goal"></INTERREF>
+<INTERREF name="Referenced Operational Goal"></INTERREF>
+<ATTRIBUTE name="Line Length" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Color" type="STRING">lightskyblue</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Cognitive Process Dimension" type="ENUMERATION">Remember</ATTRIBUTE>
+<ATTRIBUTE name="Knowledge Dimension" type="ENUMERATION">Factual</ATTRIBUTE>
+</INSTANCE>
+</MODEL>
+<MODEL id="mod.16471" name="Competency model TitoloUnico" version="" modeltype="Competency model" libtype="bp" applib="LearnPAd Prototype Dynamic Library 0.21">
+<MODELATTRIBUTES>
+<ATTRIBUTE name="Contact person" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Keywords" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Copyright info" type="STRING">Edit the model attributes to display your copyright info</ATTRIBUTE>
+<ATTRIBUTE name="Copyright info position" type="ENUMERATION">Bottom right</ATTRIBUTE>
+<ATTRIBUTE name="Model type" type="ENUMERATION">Current model</ATTRIBUTE>
+<ATTRIBUTE name="State" type="ENUMERATION">In process</ATTRIBUTE>
+<ATTRIBUTE name="Reviewed on" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Reviewed by" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Author" type="STRING">barbara</ATTRIBUTE>
+<ATTRIBUTE name="Creation date" type="STRING">13.08.2015, 12:20</ATTRIBUTE>
+<ATTRIBUTE name="Last user" type="STRING">congyu</ATTRIBUTE>
+<ATTRIBUTE name="Date last changed" type="STRING">07.09.2015, 09:50:02</ATTRIBUTE>
+<ATTRIBUTE name="Number of objects and relations" type="INTEGER">5</ATTRIBUTE>
+<ATTRIBUTE name="Context of version" type="STRING"></ATTRIBUTE>
+<RECORD name="Change history"></RECORD>
+<ATTRIBUTE name="Position" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-01] Internal error!  \&quot;fontcolor\&quot; (BPModel)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<RECORD name="Technical Attributes"></RECORD>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Keine Modellbezeichnung vergeben</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Pool Term" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="ParticipantType" type="ENUMERATION">Role</ATTRIBUTE>
+<ATTRIBUTE name="Role" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Entity" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="BoundaryVisible" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="BPD Model Attributes" type="STRING">NOTEBOOK
+
+CHAPTER &quot;Business Process Diagram Attributes&quot;
+ATTR &quot;Name&quot; write-protected
+ATTR &quot;Contact person&quot;
+ATTR &quot;Author&quot; write-protected
+ATTR &quot;Language (BPMN)&quot;
+ATTR &quot;ExpressionLanguage&quot;
+ATTR &quot;QueryLanguage&quot;
+ATTR &quot;Creation date&quot; write-protected
+ATTR &quot;Date last changed&quot; write-protected
+ATTR &quot;Documentation (Model)&quot;
+ATTR &quot;State&quot;
+
+GROUP &quot;Copyright&quot;
+ATTR &quot;Copyright info&quot; 
+ATTR &quot;Copyright info position&quot; 
+ENDGROUP
+
+CHAPTER &quot;Process Attributes&quot;
+ATTR &quot;Name&quot; write-protected
+ATTR &quot;Process Term&quot;
+ATTR &quot;ProcessType&quot;
+ATTR &quot;Status&quot;
+ATTR &quot;Assignments&quot; lines:5
+ATTR &quot;Properties (BPMN)&quot; lines:5
+ATTR &quot;AdHoc&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+GROUP &quot;AdHoc = True&quot;
+ATTR &quot;AdHocOrdering&quot;
+ATTR &quot;AdHocCompletionCondition&quot;
+ENDGROUP
+ATTR &quot;SuppressJoinFailure&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ATTR &quot;EnableInstanceCompensation&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ATTR &quot;Categories (Process)&quot;
+ATTR &quot;Documentation (Process)&quot;
+
+CHAPTER &quot;Pool Attributes&quot;
+GROUP &quot;Common Graphical Object Attributes&quot;
+ATTR &quot;Name&quot; write-protected
+ATTR &quot;Categories (Pool)&quot;
+ATTR &quot;Documentation (Pool)&quot;
+ENDGROUP
+GROUP &quot;Common Swimlane Attributes&quot;
+ATTR &quot;Pool Term&quot;
+ENDGROUP
+GROUP &quot;Pool Attributes&quot;
+ATTR &quot;ParticipantType&quot;
+ATTR &quot;Role&quot;
+ATTR &quot;Entity&quot;
+ATTR &quot;BoundaryVisible&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot; write-protected
+ENDGROUP</ATTRIBUTE>
+<ATTRIBUTE name="Language" type="ENUMERATION">System</ATTRIBUTE>
+<ATTRIBUTE name="ExpressionLanguage" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="QueryLanguage" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Process Term" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="BPD Term" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="ProcessType" type="ENUMERATION">None</ATTRIBUTE>
+<ATTRIBUTE name="Status" type="ENUMERATION">None</ATTRIBUTE>
+<RECORD name="Assignments"></RECORD>
+<ATTRIBUTE name="AdHoc" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="AdHocOrdering" type="ENUMERATION">None</ATTRIBUTE>
+<ATTRIBUTE name="AdHocCompletionCondition" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="EnableInstanceCompensation" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Categories (Process)" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation (Process)" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation (Pool)" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Categories (Pool)" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="SuppressJoinFailure" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="RACI/DEMI visualisation" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Modelling direction" type="ENUMERATION">vertical</ATTRIBUTE>
+<ATTRIBUTE name="IT systems" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Responsible role" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Input/Output" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Products" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Use cases" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Products color" type="STRING">whitesmoke</ATTRIBUTE>
+<ATTRIBUTE name="RACI/DEMI color" type="STRING">whitesmoke</ATTRIBUTE>
+<ATTRIBUTE name="Responsible role color" type="STRING">whitesmoke</ATTRIBUTE>
+<ATTRIBUTE name="Input/Output color" type="STRING">whitesmoke</ATTRIBUTE>
+<ATTRIBUTE name="Use cases color" type="STRING">whitesmoke</ATTRIBUTE>
+<ATTRIBUTE name="IT systems color" type="STRING">whitesmoke</ATTRIBUTE>
+<ATTRIBUTE name="_ToggleModelInfo_" type="PROGRAMCALL">ITEM &quot;_ToggleModelInfo_&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Display modelling information" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Documentation (Model)" type="STRING"></ATTRIBUTE>
+<RECORD name="Properties (BPMN)"></RECORD>
+<ATTRIBUTE name="CreationDate" type="EXPRESSION">EXPR val:&quot;13.08.2015, 12:20&quot;</ATTRIBUTE>
+<ATTRIBUTE name="ModificationDate" type="EXPRESSION">EXPR val:&quot;14.08.2015, 14:38:12&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Language (BPMN)" type="STRING">English</ATTRIBUTE>
+<ATTRIBUTE name="BPMN20 Model Attributes" type="LONGSTRING">NOTEBOOK
+# TODO AVAL sMfbRegistration:&quot;_MFB-Registration_&quot;
+CHAPTER &quot;Description&quot;
+ATTR &quot;Contact person&quot;
+ATTR &quot;Keywords&quot; lines:2
+ATTR &quot;Description&quot; lines:3
+ATTR &quot;Comment&quot; lines:3
+
+GROUP &quot;Copyright&quot;
+ATTR &quot;Copyright info&quot; 
+ATTR &quot;Copyright info position&quot; 
+ENDGROUP
+ATTR &quot;Name&quot; write-protected
+ATTR &quot;Id&quot; write-protected
+
+
+
+#---------------------------------------------
+CHAPTER &quot;Process properties&quot;
+#---------------------------------------------
+GROUP &quot;Process attributes&quot;
+ATTR &quot;Process type&quot; #None, Private, Public 
+ATTR &quot;Executable&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ATTR &quot;Closed&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ENDGROUP
+
+GROUP &quot;Process relevance&quot;
+ATTR &quot;Auditing&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ATTR &quot;Monitoring&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ENDGROUP
+
+CHAPTER &quot;User attributes&quot;
+ATTR &quot;Model type&quot;
+ATTR &quot;State&quot;
+ATTR &quot;Reviewed on&quot;
+ATTR &quot;Reviewed by&quot;
+
+CHAPTER &quot;System attributes&quot;
+ATTR &quot;Author&quot; write-protected
+ATTR &quot;Creation date&quot; write-protected
+ATTR &quot;Last user&quot; write-protected
+# ATTR &quot;Date last changed from&quot; write-protected
+ATTR &quot;Date last changed&quot; write-protected
+ATTR &quot;Number of objects and relations&quot; write-protected
+ATTR &quot;Context of version&quot; write-protected
+
+CHAPTER &quot;People-like view&quot;
+ATTR &quot;Action&quot;
+ATTR &quot;People-like view&quot;
+
+CHAPTER &quot;BAR Display&quot;
+ATTR &quot;BAR Display active&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot;
+AVAL s_Aktiv: &quot;BAR Display active&quot;
+ATTR &quot;Modelling direction&quot; ctrltype: radio enabled: (s_Aktiv = &quot;Yes&quot;)
+ATTR &quot;Modelling_size&quot;
+
+GROUP &quot;Responsible for execution&quot;
+ATTR &quot;Responsible for execution_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_Responsible_for_execution_display: &quot;Responsible for execution_display&quot;
+ATTR &quot;Responsible for execution_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_Responsible_for_execution_display = &quot;Yes&quot;))
+ATTR &quot;Responsible for execution_size&quot;
+ENDGROUP
+
+GROUP &quot;Accountable for approving results&quot;
+ATTR &quot;Accountable for approving results_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_Accountableforapprovingresults_display: &quot;Actor_display&quot;
+ATTR &quot;Accountable for approving results_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_Accountableforapprovingresults_display = &quot;Yes&quot;))
+ATTR &quot;Accountable for approving results_size&quot;
+ENDGROUP
+
+GROUP &quot;Cooperation/participation&quot;
+ATTR &quot;Cooperation/participation_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_Cooperationparticipation_display: &quot;Cooperation/participation_display&quot;
+ATTR &quot;Cooperation/participation_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_Cooperationparticipation_display = &quot;Yes&quot;))
+ATTR &quot;Cooperation/participation_size&quot;
+ENDGROUP
+
+GROUP &quot;To inform&quot;
+ATTR &quot;To inform_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_Toinform_display: &quot;To inform_display&quot;
+ATTR &quot;To inform_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_Toinform_display = &quot;Yes&quot;))
+ATTR &quot;To inform_size&quot;
+ENDGROUP
+
+GROUP &quot;Knowledge Product&quot;
+ATTR &quot;Knowledge Product_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_KnowledgeProduct_display: &quot;Knowledge Product_display&quot;
+ATTR &quot;Knowledge Product_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_KnowledgeProduct_display = &quot;Yes&quot;))
+ATTR &quot;Knowledge Product_size&quot;
+ENDGROUP
+
+GROUP &quot;Documents and Resources&quot;
+ATTR &quot;Documents and Resources_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_DocumentsandResources_display: &quot;Documents and Resources_display&quot;
+ATTR &quot;Documents and Resources_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_DocumentsandResources_display = &quot;Yes&quot;))
+ATTR &quot;Documents and Resources_size&quot;
+ENDGROUP
+
+GROUP &quot;Incoming Data Object&quot;
+ATTR &quot;Incoming Data Object_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_IncomingDataObject_display: &quot;Incoming Data Object_display&quot;
+ATTR &quot;Incoming Data Object_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_IncomingDataObject_display = &quot;Yes&quot;))
+ATTR &quot;Incoming Data Object_size&quot;
+ENDGROUP
+
+GROUP &quot;Outgoing Data Object&quot;
+ATTR &quot;Outgoing Data Object_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_OutgoingDataObject_display: &quot;Outgoing Data Object_display&quot;
+ATTR &quot;Outgoing Data Object_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_OutgoingDataObject_display = &quot;Yes&quot;))
+ATTR &quot;Outgoing Data Object_size&quot;
+ENDGROUP
+
+GROUP &quot;Description&quot;
+ATTR &quot;Description_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_Description_display: &quot;Description_display&quot;
+ATTR &quot;Description_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_Description_display = &quot;Yes&quot;))
+ATTR &quot;Description_size&quot;
+ENDGROUP
+
+CHAPTER &quot;Comment View&quot;
+ATTR &quot;Comment Mode&quot; ctrltype: check checked-value: &quot;No&quot; unchecked-value: &quot;Yes&quot;
+AVAL s_Aktiv: &quot;Comment Mode&quot;
+ATTR &quot;CommentAreaSize&quot;
+ATTR &quot;CommentModellingAreaSize&quot;
+ATTR &quot;CommentModellingDirection&quot;
+
+
+
+
+CHAPTER &quot;Change history&quot;
+ATTR &quot;Change history&quot; lines:30
+
+</ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;87001&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Auditing" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Monitoring" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Process type" type="ENUMERATION">None</ATTRIBUTE>
+<ATTRIBUTE name="Executable" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Closed" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="_GoToAceHp_" type="PROGRAMCALL">ITEM &quot;_GoToAceHp_&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="__GfxThumb__" type="LONGSTRING">iVBORw0KGgoAAAANSUhEUgAAALMAAAEACAIAAAB3X9DLAAAACXBIWXMAAAsTAAALEwEAmpwYAAASGklEQVR4nO3cfWwc5Z0H8O86fskLudSNeSmE5gjeqTPZggBRspNyDdU1xXbPGvXQquo/loo7jqpSW2lXaqT5465atXf1uRqXXqXdCxz+q+ooldar28dQXkJTPA5qSIEuA51nEkjdu1wCCW2DL8F2vPfH7BqTPGnzZgbo9/PHamZn5pnf2t99dtfr+SWq1eqxY8f27dsH+qA5ffp0JpNZosETU1NTBw4cuP322xsbG5999tl3bUskAHzqU5+am5sDsO7aay9q6Kd++UtN0wAEQfDZu+++cjVfot8fPRotXOwDueDxjwFAorrumiUZv36WowvLBw4cWMJwjI2NHTx46ODBQ08++eRhlT179hw8eKg6M1Odman6w6IvbZV8J512fN9J9znDfVZfn+PPyOE+x58RfWkjnXb8mWj/ycnJycnJ6ozvpIH0sBjuc3zfSaetvsULJSs9LIbTRjptlaJxSqLki1KpvsNZg0ebgL5hURquHTvsy+G+hU3GcEmUfFmvrVb8zMzBgwerMzPvrqckSr4slZxaSX1O/VxWqeSk0/Vi/OrMjByOHjuAtJEGAGO4z+obFqWzxp8RfemFsmunA4xhP1o2hkvRPY4/I/pglc45xC+Jvvohi5ejsxyKfmMHx8bGfvrTn1aXRiOA06dPAXj++eejueEsq1evPnXqVLQcIhlsvM9EiJ07EYbY2RN8r6cwCWNjD3bv8pM78NKkN4lUCLQDwMqVKwEA7domYNfuHCaBHnvnTg0SIbDzPrfnm+jZod8ng92THoZtPFrevcvFDhs/QOcOrbZnWN69y0VPpj64hvaBh/zudshHw9qxm8bLL+1yscN+uWdwEs5OAGF5967CJIyNOwYeaI/qP3W69kC0nX71Xox85psudtgv39+LTamXdiHcYe7sCb7XEz2QykbomHTH2238AJ0/BkKZfMiUPygCSN+X2TTpTaaxe1dhEuh5oDMav/6D6tyxEwhlcqMWAhh/56cZhtompJLtAIy+YQ1h8BIqGx8dR/u7Drm3PXipfkj7vZ07StZLPUjWHsXp+lmWVGJsbOzGG28E0NjY+OKLL567x5133jn91vRtn0wtui8c+cz9eOgXA+1/YfTw8GEA7evXKzeef5Bw5Gvj3T9+4C8Nf9F+Xanclkr95f0utZhLGv+i/bpSiRampqaW7tUkMTY2dm39dXf9+vXHjh1raGhYtmxZQ0MDgDVr1hz+3e8wXwVw1x23X9TQ//P661NTUwBuvPHG66+++kpXftGePXAgWrjr9ot7IO+T8SP76mcBcOzo0SVMRrVaLZVKSzE0vQeWLhmNAHp6elzXXYrR6YMrUa1W466B3o8a4y6A3qeYDFJjMkiNySA1JoPUmAxSYzJIjckgNSaD1JgMUmMySI3JIDUmg9SYDFKLMxk3PfDzVx/cVlvZcw3uORZjMXSW2P4/Y93XHlve1HDy1NzRQif2bgCA+VlsncKpV7HiplhKosVimzO+lL6huP/IM9+5e/3XHzv85WnMrcLWKQBoasPeDUg/h6bWuGojxDhntH6lvHZ18/x89VD0gjI/g4ZmAPBuQ6uBmRO49SexFEaR2OaMhgYASCQSN3/j8TPz86/96PO1Ddd+EctWIbE8rsIoElsyVrY0ArhqeeML378HAJ7+GLYewdPXY/WtmP4tAHQMx1UbIcZkrFnRdHr2zPTbc3Nnqo3LEth6BHs3INGE5Tdg+mXcxSuwYxZbMq5vbQmPTv9herZjxxP7v7v1I6uaZhrXJebfxpu/QUNbU8t1cRVGkdjegd6Sferk6blXH9x29VfFfBXHd3UB2L9/f0tLS0dHR1NTUyxV0YJ45ozW+8ttq5ujP3OFP9x2x7f3RPfn8/lEIlEoFGKpihaLIRlvTs+2XdUsnc9Fq2tWvFPD9u3bhRDvfUl0Ll6jRmr8Ro3UmAxSYzLoPC6+gZN0LEcKyxJVYcESUlhGtAzAcIQQYuEew3EswzKwsJuIVh0pLMMwDMsyDEdGI1alY1hi4QRSCAuGIxzLkdIxDMsyEI0jpLAWjpKOAUsIyxL1QSzDMBx55fpV/bW6lDlD0/3eImwzDCqo6FLXMybGgwpgOLYGAIGeMTEOU9hIJkfRm0QliHZDkNF1wC0nR0dHgXJvslApj8Mt+FoWrlfASLazuxyt5gpIOYFb8LWsadsIiga8SiBNDUHF82WI2iapFZM5XZTdggsTbsHzkJK1RmF0ya7kZ5Px/i1BdmKh79ZZq/TBwk+tpMZ3oKTGZJAak0FqTAapMRmkxmSQGpNBakwGqTEZpMZkkBqTQWpMBqmxSwKpsUsCqbFLAqmxSwKpsUsCqbFLAqmxSwKpsUsCqbFLAqmxSwKpsUsCqfF6E1LjN2qkxmSQGpNB53EhF8xH/Qui3gQLHQqiZgTCMhwpo84IAKL+BMICYFhCOIZhWVZ9B8ASwjIcKSzDAqIeCjAsIYSMehzUzyUdw3CktABLLPRQsBxZFRZgOUIIx7CsqEeDEI5hOY5lGPUeDUIIIes1RAewa8JFu5A5I5TaqBn0FyseZIh6hwLPQ6q2Cg0I9JRlZUwNQBhUAHiVAKZtawggASDQLcsPgorny6SegeEB0PSMg8GuICuDXMHX8mgPy65XwJBj25osuwCC8YX2B76WRQXwBnO6sG0TuYKrS1ODZptBrstLCaEhyHW5GWFrMqgAVsaEVkGXlswv0fPqw+wKpiyaTq6EaM64ImdfmIzo4vBTK6nxHSipMRmkxmSQGpNBakwGqTEZpMZkkBqTQWpMBqkxGaTGZJAak0FqTAapMRmkxmSQGpNBanEmIzw63X7tqtrKc924oxxjMXSW2P6n65qvjv/NysbZuerhf9+Gp9aicQ3mTuKzr8dSDJ0rtjljdn4ewCc/vvrmgccPfrEZqNZi8at78NbLuOd/4yqMIrEl45/+sWPsuSPPH/7Thuta0fr3mH2jtuHOPfjF3+IXH8dnfhdXbYQYk/HPP3vlo1c1L29qWP/RZVtLg09vr7+O7N2Aa/4BWBZXYRSJLRktTcsA6OtWb7vlmjtvbsWL9+Kzr+PRBFasw9GfAQlsdOKqjRBjMtZe1Xx69syvDr5Zym4GAPwrnlqLlRuAKhKNmDkeV2EUie2zyaZvPfX27BkAJ96aOfFQNwDs+RgaGoEEEo34u0OxVEULYpszeu647ife7197cFty8PGuf5kU306/sPaJ2dlZADOzs0ZcZVFdbMnYve+/33xrBsDGG1a/8NqfANx6y6be3l4Ao6OjcVVFC+JJRvvA4386NffH//wCgFJ2c/vA49H9zc3NiUQilpLoLPEk44//N/v6f3QtXo0WCoXCyZMnYymJzsIrnkmN37WSGpNBakwGqV1+MsKR/nK36Q8hbxYTRVOaxd6iOWEWE10FGI4cxVC5O68NbQmyo+jtxehEd7l/yIeezWqyXMz5QEUfnRhox3h/oqtgWMLWczk/ldKzpp/sgqjmO8ORLb0YHfWTSYhqNugvd+e7y/29biVl2yYAoNgV7XnZj4bqrsCcoel+bxG2GQYVVHSp6xkT40EFMBxbk+Vc1F/L8yVM24YcL7uFggdDN22tOzuK3mShUg4HBnBudy/XsGyEADTbxjltuzwPCKC7XW7GAZC6/EdCiy1do6dzGmddSvetyzuQLh0/tZIa34GSGpNBakwGqTEZpMZkkBqTQWpMBqkxGaTGZJAak0FqTAapsUsCqbFLAqmxSwKpsUsCqbFLAqmxSwKpsUsCqbFLAqmxSwKpsUsCqbFLAqmxSwKp8XoTUuN3raTGZJAak0Hncf5LXqVjAIYjHMuR0jEMy1q8IKz6JmEBhiOrQojo0mTpGIYlLMASjuXIqrAAw3KElLX9DUtUpbN4kOrCJkTnNAxLCCGkdAzDeGd/IaQQUliwRG0cYRmWENEl0dIxgOhcQliGYSw+nWE4UgheN32h/syc0a6lgIKbgweYdr1zAeyM2zUIM6tngsAt+FoWumVU0I5OWUwMerBk1OYAuhME7qALM1MBAA0yanCQ0TMmomYH2dFRlHsHo64HLsyMnrKsjKkBto1cVy4jMq7nwbHr+9sYQnf23e0YvIq+0H/Bg+U4OjQg0FMoFHyZRe10nuf1Qk68J0+3D4WLTNKSNyw4p7fCu89uKTdeSFXnO5bU+KmV1PgOlNSYDFJjMkiNySA1JoPUmAxSYzJIjckgNSaD1JgMUmMySI3JIDUmg9SYDFJjMkiNySC1OJNx0wM/f/XBbbWVPdfgnmMxFkNnie1/utZ97bHlTQ0nT80dLXRi7wYAmJ/F1imcehUrboqlJFostjnjS+kbivuPPPOdu9d//bHDX57G3CpsnQKApjbs3YD0c2hqjas2QoxzRutXymtXN8/PVw9FLyjzM2hoBgDvNrQamDmBW38SS2EUiW3OaGgAgEQicfM3Hj8zP//ajz5f23DtF7FsFRLL4yqMIrElY2VLI4Crlje+8P17AODpj2HrETx9PVbfiunfAkDHcFy1EWJMxpoVTadnz0y/PTd3ptq4LIGtR7B3AxJNWH4Dpl/GXfviKowisSXj+taW8Oj0H6ZnO3Y8sf+7Wz+yqmmmcV1i/m28+Rs0tDW1XBdXYRSJ7R3oLdmnTp6ee/XBbVd/VcxXcXxXF4D9+/e3tLR0dHQ0NTXFUhUtiGfOaL2/3La6OfozV/jDbXd8e090fz6fTyQShUIhlqposRiS8eb0bNtVzdL5XLS6ZsU7NWzfvl0I8d6XROfida2kxm/USI3JIDUmg87jcppvSMew6h2YhBBCWAAcETU9EgYQtTKJGiYZgOE4QkgpohunvsNCTyYBAFatgZNVa7xkWLU2TvWOTcIxAMt6Vw8nSwjUT0dXxOXMGaHURs1gqAivUpa2BkA3DEcLhtCdB6QHoBwODCCoeBU9AAB0o9jbi8xoPlnuHfQMx5Yh2juztZ5MumU5pgnIMOq3ZGrRsbU2TrWOTe6gZzi2CciwXGsHlTERFABfAu2X+1ShyBX/bBKO9Je78wMX8AsKR7b0YnTiQnal9x4/tZIa34GSGpNBakwGqTEZpMZkkBqTQWpMBqkxGaTGZJAak0FqTAapMRmkxmSQGpNBakwGqTEZpMZkkBqTQWpMBqkxGaTGZJAak0FqTAapMRmkxmSQGpNBakwGqTEZpMZkkBqTQWpMBqkxGaTGZJAak0FqTAapMRmkxmSQGpNBakwGqTEZpMZkkBqTQWpMBqkxGaTGZJAak0FqTAapMRmkxmSQGpNBakwGqTEZpMZkkBqTQWpMBqkxGaTGZJAak0FqTAapMRmkxmSQGpNBakwGqTEZpMZkkBqTQWpMBqkxGaTGZJAak3HpwpEtycGUEHou0GwtCHKui1QqVajockIb6kfeDLYEfso383n09yOfx8iW3GDKrpoY7+zsxHh/oqtiGKlUplIY9CxRNTEOBEHO12zkcpWUPZHvDEe2DGk2itHhgWZrSAa5pAvHntAw3oliP/LZZCilTCaTUsroHhPjxVyXblcHaqfuT+Qqjj3RnQyllAhyuUGkxKhZTOZ0kXGLvm2aQa4IW3e73IycGGhnMi5ZWHY9WJkgN4iMADTNtm0AME3IkVyhkjFNZHzdNxFGqyPuoOcBwbipJYFwJFeA5dimhgAFeJVgXHe73IywbS3IdXkeUgAAzTaDXFd0ODICQNn1AAcYBzCSK1QyWWAoQD4p+wNkg1yhkjF1t6sAR3aGI1uiUxfgWUAIORQgqyHlGbAhYQobgG1qAJDRtcD1gAwAoEofPMKxHCEXrwpZu/3zhyzsIx3DcM6/d7VaTVSr1ViecfQ+x1eTD4cTI1seHsSnReaNoPsTmlybxPFy8bfIGuj1kAG6v6ANPVI0t+i5CYxu0eRaAJ2dHw1HHhnSevTcw4Nem2G84XkwnI6U35bPb2YyPiQ0+yvVToxsecaFYfulXrSlKq9AGqb9iSA35msGKm9UdOh4wy2vteGh+wvACan1mIFXBGB0ZFLPeF4b3FcKHvL5zXw1+St0YqQ/6M5vbv+zOzEZpMZXE1JjMj6s5Pj42iS8ocDIatHtcZlMYujfiua3zOIjuQoyoz2aDAANCIDNnZ0IR/6r3G24yYcnqt9iMj6skig+0ouODEq9fu12NHu8XEFFl3rlDc8Dyscz7jO+rem5Z3x7c2e4r+y+4qItZX0afJ9B5/P/llRt7rN/xUsAAAAASUVORK5CYII=</ATTRIBUTE>
+<ATTRIBUTE name="NT Model Attributes" type="LONGSTRING">NOTEBOOK
+CHAPTER &quot;Description&quot;
+#ATTR &quot;Shared&quot;
+ATTR &quot;Model state&quot; enabled:(cond(search (sMfbRegistration, &quot;MFB_VERS&quot;, 0) = -1, 1, 0))
+ATTR &quot;Description&quot;
+ATTR &quot;Show State&quot; ctrltype:check unchecked-value:&quot;No&quot; checked-value:&quot;Yes&quot; 
+ATTR &quot;Last user&quot; write-protected
+ATTR &quot;Date last changed&quot; write-protected
+#CHAPTER &quot;Suggestion for improvement&quot;
+#ATTR &quot;Suggestion for improvement&quot;
+</ATTRIBUTE>
+<ATTRIBUTE name="Model state" type="ENUMERATION">Draft</ATTRIBUTE>
+<ATTRIBUTE name="People-like view" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Action" type="ENUMERATION">Fill in</ATTRIBUTE>
+<ATTRIBUTE name="Keywords" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Description" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Model type" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Show State" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="BAR Display active" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Actor_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="Actor_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Actor_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="Description_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="Description_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Description_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="ModelingAreaSize" type="ENUMERATION">20</ATTRIBUTE>
+<ATTRIBUTE name="Modelling_size" type="ENUMERATION">3</ATTRIBUTE>
+<ATTRIBUTE name="DrawingAreaWidth" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="DrawingAreaHeight" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Reference overview settings" type="LONGSTRING">Responsible for execution|Responsible for execution
+Accountable for approving results|Accountable for approving results
+Cooperation/participation|Cooperation/participation
+To inform|To inform
+Modelling|Modelling
+Knowledge Product|Knowledge Product
+Documents and Resources|Documents and Resources
+#Data Object|Data Object
+Incoming Data Object|Incoming Data Object
+Outgoing Data Object|Outgoing Data Object
+Description|Description</ATTRIBUTE>
+<ATTRIBUTE name="Data Object_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="Data Object_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Data Object_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="Knowledge Product_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="Knowledge Product_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Knowledge Product_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="Documents and Resources_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Documents and Resources_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="Documents and Resources_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="Responsible for execution_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="Responsible for execution_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Responsible for execution_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="Accountable for approving results_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="Accountable for approving results_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Accountable for approving results_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="Cooperation/participation_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="Cooperation/participation_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Cooperation/participation_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="To inform_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="To inform_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="To inform_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="Incoming Data Object_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="Incoming Data Object_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Incoming Data Object_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="Outgoing Data Object_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="Outgoing Data Object_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Outgoing Data Object_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="id_bpmndi_diagram" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="id_bpmndi_plane" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="id_bpmndi_collaboration" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="CommentModellingAreaSize" type="ENUMERATION">3</ATTRIBUTE>
+<ATTRIBUTE name="CommentTypeSize" type="ENUMERATION">8</ATTRIBUTE>
+<ATTRIBUTE name="CommentAreaSize" type="ENUMERATION">2</ATTRIBUTE>
+<ATTRIBUTE name="Comment Mode" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="CommentxCoorTextBox" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="CommentyCoorTextBox" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="CommentModellingDirection" type="ENUMERATION">vertical</ATTRIBUTE>
+</MODELATTRIBUTES>
+<INSTANCE id="obj.16472" class="Competency" name="Managing front-office &amp; external services">
+<ATTRIBUTE name="Position" type="STRING">NODE x:5cm y:3.5cm index:1</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<RECORD name="Technical Attributes"></RECORD>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Competency Statement" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Competency Class" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Model Source" type="PROGRAMCALL">ITEM &quot;&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Competency Level" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Knowledge Concept" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Knowledge Product" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16475" class="Competency" name="Assessing administrative &amp; procedural regularity">
+<ATTRIBUTE name="Position" type="STRING">NODE x:5cm y:7cm index:2</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<RECORD name="Technical Attributes"></RECORD>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Competency Statement" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Competency Class" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Model Source" type="PROGRAMCALL">ITEM &quot;&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Competency Level" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Knowledge Concept" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Knowledge Product" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16478" class="Competency" name="Manage specific admin procedure">
+<ATTRIBUTE name="Position" type="STRING">NODE x:5cm y:11cm index:3</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<RECORD name="Technical Attributes"></RECORD>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Competency Statement" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Competency Class" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Model Source" type="PROGRAMCALL">ITEM &quot;&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Competency Level" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Knowledge Concept" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Knowledge Product" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16481" class="Competency" name="Competent verification of congruency and pertinency">
+<ATTRIBUTE name="Position" type="STRING">NODE x:5cm y:14.5cm index:4</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<RECORD name="Technical Attributes"></RECORD>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Competency Statement" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Competency Class" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Model Source" type="PROGRAMCALL">ITEM &quot;&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Competency Level" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Knowledge Concept" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Knowledge Product" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16484" class="Competency" name="Ability to draw up formal documents">
+<ATTRIBUTE name="Position" type="STRING">NODE x:5cm y:18.5cm index:5</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:&quot;black&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<RECORD name="Technical Attributes"></RECORD>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Competency Statement" type="STRING">Ability to draw up formal documents at the end of the administrative procedure</ATTRIBUTE>
+<ATTRIBUTE name="Competency Class" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Model Source" type="PROGRAMCALL">ITEM &quot;&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Competency Level" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Knowledge Concept" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Knowledge Product" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+</MODEL>
+<MODEL id="mod.16437" name="TitoloUnico_MonitAzzurrSUB_4" version="" modeltype="Business process diagram (BPMN 2.0)" libtype="bp" applib="LearnPAd Prototype Dynamic Library 0.21">
+<MODELATTRIBUTES>
+<ATTRIBUTE name="Contact person" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Keywords" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Copyright info" type="STRING">Edit the model attributes to display your copyright info</ATTRIBUTE>
+<ATTRIBUTE name="Copyright info position" type="ENUMERATION">Bottom right</ATTRIBUTE>
+<ATTRIBUTE name="Name" type="STRING">TitoloUnico_MonitAzzurrSUB_4</ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;86612&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Process type" type="ENUMERATION">None</ATTRIBUTE>
+<ATTRIBUTE name="Executable" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Closed" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Auditing" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Monitoring" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Model type" type="ENUMERATION">Current model</ATTRIBUTE>
+<ATTRIBUTE name="State" type="ENUMERATION">In process</ATTRIBUTE>
+<ATTRIBUTE name="Reviewed on" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Reviewed by" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Author" type="STRING">barbara</ATTRIBUTE>
+<ATTRIBUTE name="Creation date" type="STRING">11.08.2015, 15:48</ATTRIBUTE>
+<ATTRIBUTE name="Last user" type="STRING">congyu</ATTRIBUTE>
+<ATTRIBUTE name="Date last changed" type="STRING">08.09.2015, 02:19:44</ATTRIBUTE>
+<ATTRIBUTE name="Number of objects and relations" type="INTEGER">18</ATTRIBUTE>
+<ATTRIBUTE name="Context of version" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Action" type="ENUMERATION">Fill in</ATTRIBUTE>
+<ATTRIBUTE name="People-like view" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="BAR Display active" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Modelling direction" type="ENUMERATION">vertical</ATTRIBUTE>
+<ATTRIBUTE name="Modelling_size" type="ENUMERATION">3</ATTRIBUTE>
+<ATTRIBUTE name="Responsible for execution_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Responsible for execution_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="Responsible for execution_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="Accountable for approving results_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Accountable for approving results_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="Accountable for approving results_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="Cooperation/participation_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Cooperation/participation_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="Cooperation/participation_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="To inform_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="To inform_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="To inform_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="Knowledge Product_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Knowledge Product_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="Knowledge Product_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="Documents and Resources_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Documents and Resources_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="Documents and Resources_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="Incoming Data Object_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Incoming Data Object_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="Incoming Data Object_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="Outgoing Data Object_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Outgoing Data Object_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="Outgoing Data Object_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="Description_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Description_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="Description_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="Comment Mode" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="CommentAreaSize" type="ENUMERATION">2</ATTRIBUTE>
+<ATTRIBUTE name="CommentModellingAreaSize" type="ENUMERATION">3</ATTRIBUTE>
+<ATTRIBUTE name="CommentModellingDirection" type="ENUMERATION">vertical</ATTRIBUTE>
+<RECORD name="Change history"></RECORD>
+<ATTRIBUTE name="Position" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-01] Internal error!  \&quot;fontcolor\&quot; (BPModel)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<RECORD name="Technical Attributes"></RECORD>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Keine Modellbezeichnung vergeben</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Pool Term" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="ParticipantType" type="ENUMERATION">Role</ATTRIBUTE>
+<ATTRIBUTE name="Role" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Entity" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="BoundaryVisible" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="BPD Model Attributes" type="STRING">NOTEBOOK
+
+CHAPTER &quot;Business Process Diagram Attributes&quot;
+ATTR &quot;Name&quot; write-protected
+ATTR &quot;Contact person&quot;
+ATTR &quot;Author&quot; write-protected
+ATTR &quot;Language (BPMN)&quot;
+ATTR &quot;ExpressionLanguage&quot;
+ATTR &quot;QueryLanguage&quot;
+ATTR &quot;Creation date&quot; write-protected
+ATTR &quot;Date last changed&quot; write-protected
+ATTR &quot;Documentation (Model)&quot;
+ATTR &quot;State&quot;
+
+GROUP &quot;Copyright&quot;
+ATTR &quot;Copyright info&quot; 
+ATTR &quot;Copyright info position&quot; 
+ENDGROUP
+
+CHAPTER &quot;Process Attributes&quot;
+ATTR &quot;Name&quot; write-protected
+ATTR &quot;Process Term&quot;
+ATTR &quot;ProcessType&quot;
+ATTR &quot;Status&quot;
+ATTR &quot;Assignments&quot; lines:5
+ATTR &quot;Properties (BPMN)&quot; lines:5
+ATTR &quot;AdHoc&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+GROUP &quot;AdHoc = True&quot;
+ATTR &quot;AdHocOrdering&quot;
+ATTR &quot;AdHocCompletionCondition&quot;
+ENDGROUP
+ATTR &quot;SuppressJoinFailure&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ATTR &quot;EnableInstanceCompensation&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ATTR &quot;Categories (Process)&quot;
+ATTR &quot;Documentation (Process)&quot;
+
+CHAPTER &quot;Pool Attributes&quot;
+GROUP &quot;Common Graphical Object Attributes&quot;
+ATTR &quot;Name&quot; write-protected
+ATTR &quot;Categories (Pool)&quot;
+ATTR &quot;Documentation (Pool)&quot;
+ENDGROUP
+GROUP &quot;Common Swimlane Attributes&quot;
+ATTR &quot;Pool Term&quot;
+ENDGROUP
+GROUP &quot;Pool Attributes&quot;
+ATTR &quot;ParticipantType&quot;
+ATTR &quot;Role&quot;
+ATTR &quot;Entity&quot;
+ATTR &quot;BoundaryVisible&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot; write-protected
+ENDGROUP</ATTRIBUTE>
+<ATTRIBUTE name="Language" type="ENUMERATION">System</ATTRIBUTE>
+<ATTRIBUTE name="ExpressionLanguage" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="QueryLanguage" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Process Term" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="BPD Term" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="ProcessType" type="ENUMERATION">None</ATTRIBUTE>
+<ATTRIBUTE name="Status" type="ENUMERATION">None</ATTRIBUTE>
+<RECORD name="Assignments"></RECORD>
+<ATTRIBUTE name="AdHoc" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="AdHocOrdering" type="ENUMERATION">None</ATTRIBUTE>
+<ATTRIBUTE name="AdHocCompletionCondition" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="EnableInstanceCompensation" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Categories (Process)" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation (Process)" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation (Pool)" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Categories (Pool)" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="SuppressJoinFailure" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="RACI/DEMI visualisation" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="IT systems" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Responsible role" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Input/Output" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Products" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Use cases" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Products color" type="STRING">whitesmoke</ATTRIBUTE>
+<ATTRIBUTE name="RACI/DEMI color" type="STRING">whitesmoke</ATTRIBUTE>
+<ATTRIBUTE name="Responsible role color" type="STRING">whitesmoke</ATTRIBUTE>
+<ATTRIBUTE name="Input/Output color" type="STRING">whitesmoke</ATTRIBUTE>
+<ATTRIBUTE name="Use cases color" type="STRING">whitesmoke</ATTRIBUTE>
+<ATTRIBUTE name="IT systems color" type="STRING">whitesmoke</ATTRIBUTE>
+<ATTRIBUTE name="_ToggleModelInfo_" type="PROGRAMCALL">ITEM &quot;_ToggleModelInfo_&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Display modelling information" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Documentation (Model)" type="STRING"></ATTRIBUTE>
+<RECORD name="Properties (BPMN)"></RECORD>
+<ATTRIBUTE name="CreationDate" type="EXPRESSION">EXPR val:&quot;11.08.2015, 15:48&quot;</ATTRIBUTE>
+<ATTRIBUTE name="ModificationDate" type="EXPRESSION">EXPR val:&quot;20.08.2015, 15:12:47&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Language (BPMN)" type="STRING">English</ATTRIBUTE>
+<ATTRIBUTE name="BPMN20 Model Attributes" type="LONGSTRING">NOTEBOOK
+# TODO AVAL sMfbRegistration:&quot;_MFB-Registration_&quot;
+CHAPTER &quot;Description&quot;
+ATTR &quot;Contact person&quot;
+ATTR &quot;Keywords&quot; lines:2
+ATTR &quot;Description&quot; lines:3
+ATTR &quot;Comment&quot; lines:3
+
+GROUP &quot;Copyright&quot;
+ATTR &quot;Copyright info&quot; 
+ATTR &quot;Copyright info position&quot; 
+ENDGROUP
+ATTR &quot;Name&quot; write-protected
+ATTR &quot;Id&quot; write-protected
+
+
+
+#---------------------------------------------
+CHAPTER &quot;Process properties&quot;
+#---------------------------------------------
+GROUP &quot;Process attributes&quot;
+ATTR &quot;Process type&quot; #None, Private, Public 
+ATTR &quot;Executable&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ATTR &quot;Closed&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ENDGROUP
+
+GROUP &quot;Process relevance&quot;
+ATTR &quot;Auditing&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ATTR &quot;Monitoring&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ENDGROUP
+
+CHAPTER &quot;User attributes&quot;
+ATTR &quot;Model type&quot;
+ATTR &quot;State&quot;
+ATTR &quot;Reviewed on&quot;
+ATTR &quot;Reviewed by&quot;
+
+CHAPTER &quot;System attributes&quot;
+ATTR &quot;Author&quot; write-protected
+ATTR &quot;Creation date&quot; write-protected
+ATTR &quot;Last user&quot; write-protected
+# ATTR &quot;Date last changed from&quot; write-protected
+ATTR &quot;Date last changed&quot; write-protected
+ATTR &quot;Number of objects and relations&quot; write-protected
+ATTR &quot;Context of version&quot; write-protected
+
+CHAPTER &quot;People-like view&quot;
+ATTR &quot;Action&quot;
+ATTR &quot;People-like view&quot;
+
+CHAPTER &quot;BAR Display&quot;
+ATTR &quot;BAR Display active&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot;
+AVAL s_Aktiv: &quot;BAR Display active&quot;
+ATTR &quot;Modelling direction&quot; ctrltype: radio enabled: (s_Aktiv = &quot;Yes&quot;)
+ATTR &quot;Modelling_size&quot;
+
+GROUP &quot;Responsible for execution&quot;
+ATTR &quot;Responsible for execution_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_Responsible_for_execution_display: &quot;Responsible for execution_display&quot;
+ATTR &quot;Responsible for execution_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_Responsible_for_execution_display = &quot;Yes&quot;))
+ATTR &quot;Responsible for execution_size&quot;
+ENDGROUP
+
+GROUP &quot;Accountable for approving results&quot;
+ATTR &quot;Accountable for approving results_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_Accountableforapprovingresults_display: &quot;Actor_display&quot;
+ATTR &quot;Accountable for approving results_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_Accountableforapprovingresults_display = &quot;Yes&quot;))
+ATTR &quot;Accountable for approving results_size&quot;
+ENDGROUP
+
+GROUP &quot;Cooperation/participation&quot;
+ATTR &quot;Cooperation/participation_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_Cooperationparticipation_display: &quot;Cooperation/participation_display&quot;
+ATTR &quot;Cooperation/participation_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_Cooperationparticipation_display = &quot;Yes&quot;))
+ATTR &quot;Cooperation/participation_size&quot;
+ENDGROUP
+
+GROUP &quot;To inform&quot;
+ATTR &quot;To inform_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_Toinform_display: &quot;To inform_display&quot;
+ATTR &quot;To inform_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_Toinform_display = &quot;Yes&quot;))
+ATTR &quot;To inform_size&quot;
+ENDGROUP
+
+GROUP &quot;Knowledge Product&quot;
+ATTR &quot;Knowledge Product_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_KnowledgeProduct_display: &quot;Knowledge Product_display&quot;
+ATTR &quot;Knowledge Product_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_KnowledgeProduct_display = &quot;Yes&quot;))
+ATTR &quot;Knowledge Product_size&quot;
+ENDGROUP
+
+GROUP &quot;Documents and Resources&quot;
+ATTR &quot;Documents and Resources_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_DocumentsandResources_display: &quot;Documents and Resources_display&quot;
+ATTR &quot;Documents and Resources_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_DocumentsandResources_display = &quot;Yes&quot;))
+ATTR &quot;Documents and Resources_size&quot;
+ENDGROUP
+
+GROUP &quot;Incoming Data Object&quot;
+ATTR &quot;Incoming Data Object_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_IncomingDataObject_display: &quot;Incoming Data Object_display&quot;
+ATTR &quot;Incoming Data Object_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_IncomingDataObject_display = &quot;Yes&quot;))
+ATTR &quot;Incoming Data Object_size&quot;
+ENDGROUP
+
+GROUP &quot;Outgoing Data Object&quot;
+ATTR &quot;Outgoing Data Object_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_OutgoingDataObject_display: &quot;Outgoing Data Object_display&quot;
+ATTR &quot;Outgoing Data Object_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_OutgoingDataObject_display = &quot;Yes&quot;))
+ATTR &quot;Outgoing Data Object_size&quot;
+ENDGROUP
+
+GROUP &quot;Description&quot;
+ATTR &quot;Description_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_Description_display: &quot;Description_display&quot;
+ATTR &quot;Description_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_Description_display = &quot;Yes&quot;))
+ATTR &quot;Description_size&quot;
+ENDGROUP
+
+CHAPTER &quot;Comment View&quot;
+ATTR &quot;Comment Mode&quot; ctrltype: check checked-value: &quot;No&quot; unchecked-value: &quot;Yes&quot;
+AVAL s_Aktiv: &quot;Comment Mode&quot;
+ATTR &quot;CommentAreaSize&quot;
+ATTR &quot;CommentModellingAreaSize&quot;
+ATTR &quot;CommentModellingDirection&quot;
+
+
+
+
+CHAPTER &quot;Change history&quot;
+ATTR &quot;Change history&quot; lines:30
+
+</ATTRIBUTE>
+<ATTRIBUTE name="_GoToAceHp_" type="PROGRAMCALL">ITEM &quot;_GoToAceHp_&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="__GfxThumb__" type="LONGSTRING">iVBORw0KGgoAAAANSUhEUgAAANoAAAEACAIAAABarf9xAAAACXBIWXMAAAsTAAALEwEAmpwYAAAR60lEQVR4nO3db3Aj9X3H8Y8OTx4wkwlTSC9DOA5SaeEW9UHJJDnJR/gTLmEtYtT0WGgyU6egkdqkROYuCr1Bk2FSkcRRTSVoCFLvCJ4mUyzoIAskQThCCGeZdDpAGd1CdtcHF0+Z4YA8SRPAh/Xrg7V9d/5z2DrZ/tr5vB7cSLK0+sr71u7qLMs+pdTRo0efe+450Hrz7rvvmqa51lN0km9iYuL555+/9NJLu7q6fvWrX530NZ8PwKc//en3338fwHmbNy9r0T9/9llN0wDYtn3VZZd1buY2rfQ8P3/2WU27CD5l/3oFH+/sowDw/PPPb7QiR0ZGxscPj48ffuqpp44s5Omnnx4fP6wmJ9XkpLIGa7FQvGLlQqGcZeVCsdxgLB6L5axJZzCWsyZrsVA4FMpZk971x8bGxsbG1KSVCwGxwVplMB4arA3Gctb0EmoVS1UG48eXOb0cNTmpJq1cbNCpxOKVSWcwFA6F4hVrZgkhAPGKlQshXrFqlUqtUsmFAHj3YqnKYDgExCpq8sQFnjzP9CSVWsVyKpVcLDb7iLwHEq9UcqGQd4VaxVKTk86gNyeAUDgEAOHBWDw2WKsssPzwYCUXQnjQmr47HD/tfQlAzpqsxRCvTKrJyVosdPysVanFZm5iVZzBWDg0fTXvXsYPj48fHh8ZGRkeHlYbSBeAd999B8CLL77obQXn+PCHP/zOO+94p10E7G27onCxdy9cF3t77e/1FscQ3taLh/dZgd04NNYYQ9AF/ABw5plnAgD8yf1WxA/ncVff5dgP7ythG8bGUEf6Zd13KBbftSuKemZsDPXH8fC+EnYnb/ED0La93FdButetPjzWGIul4QIBfZeDwN4wemcntL/XW9pVSe8dDPfuaRyCDb3nUCwONA45LvxOYJs2dx5oey11DfKX7ylhd/rlm/twSfDQPri7o3t77e/1eg+kuQ06xkp1fxp3wbgXcJ3A/qhzVxlAaJd5yVhjLISH9xXHgN5bDJz0eLVLEAz4p+dz68e/m647+6VwbFCDax9Cc9vjdfiN3XsxfdbFNdcYuyvxQ70I+OGHE9hmXlKJXDO9jDPPPPPdmTWywfhGRka2bNkCoKur66WXXpp/jU996lO//7/f/8WfB0+4zM1ffjP2P5P0z7/6SdwjRwD4t25d5lSPJz7UW4xV1L3XfPB1l7OctuZx81+rR+695YMea9vLXzb3yJHf/e53ACYmJjbYzto3MjKyeeagcOvWrUePHt20adMZZ5yxadMmAB/5yEeO/OY3aCkAn/nkpcta9OtvvjkxMQFgy5Yt5370o52efNlWep7Vebyvv/nmbyYmvNNH33hjo+WolKpUKms9BrVpg+XYBaC3t7dUKq31JETwKaXWegaiaV1rPQDRccyRBGGOJAhzJEGmcywWi2s7B/0ROuuss+b8L9XxrWM8Hl/1eeiP14JbQO6sSRDmSIIwRxKEOZIgzJEEYY4kCHMkQZgjCcIcSRDmSIIwxxO5+byTTBpuPlGNpLRsoAe1nG4DWgSZrDZaMODmE9VIIel383knosGxM2VtSC/3WbqJfiuqCoF8d1YbipazZUBPpZDts/ShFPpOvvlaP1CpmONc9XzC1lJJP/J6zUG5GkmhWq3C1O06jICjpZJ+AH5Nc2CXMzBNuwrd1KFpNc2Am4ep21Vb16NaxPAjr5s65t+cFjb9ywnFYpFvoaDVVCwWT/WOHqI1xxxJEOZIgjBHEoQ5kiDMkQRhjiQIcyRBmCMJwhxJEOZIgjBHEuR4jvxclBWVSCQKhcJaTyHddI7xeJwfgLvSzjrrrNW/0xtuuGF4eHj177c9/PTbVeLzrc23eq3utz3radb1y2tifZWxJvhSZpV4f1GPTo3P11XCnfVScOtIgqynpw5teNw6kiDMcZXw2HEpmCMJsp6eOrThcetIgjDHVcJjx6VgjiTIenrq0IbHrSMJwhxXCY8dl4I5kiDr6alDGx63jiQIc1wlPHZcii7+AuGqWatvtbRVPP8zmI8rFAqqozq+QNpICoXC8PDwYl/lzpoEYY6rhMeOS8EcSRDmuErWahO1jjaNYI4kCnNcJWtyDDf7WQPrZRvJHDc4pdQ6+gAM5riRqfX2wUDrKUffzodWYrHqyevbvu2yRlr6lU9npHVt3eTo2/nQ5OPXtxSmWmgptBSmFFqtmRMKrda8E4td+eQr+HY+1N7q9+186PePXjfVml6yAnxdH1p8JLUKI613q5HjwMBJxy633dbmvqNTLbZOvsLpuPmmr/7ymWdef/31j33sY1dcedW//ttP13yk47M9uBnATf/xp96J/Te+0ZnlAujcOp1jxXMcGPDt2fM/wHvApFLvAZMDA772pu9Ui7NX9q5wOhqNxs6dOycmJi688MKfPXlAwkiemx/c/IPeg9+q7PDO3mE8cvODmztVZAfX6Rwrm+P8uZV679ZbS+1N39kWZ698OrZ/ZvuBAwf+8Ic/NJvNK676nISRMLNd/FZlx53XPjHVOtZSx+6o/6V3+ekX2dl1OscK5rjg3N6//f372ph+JVqcap3WY7xv/0/eV0p5C4dPwkhei57bH/vC/K+eTpEdX6dzeDm6+e4szKaljabs7qw2pJf7LN1Ef6mZS48mDdTzCWh6psdKO3omYKUd3a4C0KxSphk0h1KoOsmksdDyF5jbu7CNWWdXofvD7nv9owk78eQXos7f9fx6W+3vjYCqBZ40auou+4prrdeuTrWSgbsuqpX85YNX6T+/onTB/nS3Cpz7anbYxXk3FXq3dOhA7YyuTS20fICC76QW3fuNwHeRu6/XOvy51Pk/CvzDy/HdSf2uv+nHl+PfiBd2bVm0xU4dO36n57GWOjaljrXUsTuf+EpnFgp0dp3OMbN1NAErqGtuFaZuV6GbOoCcqQOAm8/0FxvhcK42aiBv1woG8jYA2Lpp6lrSj/y85Q4M+Pbs+a/F5lbqvWRy4AOfTN7/3w4PD3vv1pzZnLjj/qHP24kfPVJ8RUV7rsu10j2Hv+aol+H4sfNavPZo8fAnUlsBvFL+yStFtdW5AP3nbw20XnPGasXaC7jmqkLrvONbrGVZZKT5m2r/BduAfy/dh0arFf28P7fbj/NbiH45t2Mn1Dha551qI9r2PLObxu/0PPbt2rUAbv/CT+984iupq4vZA/H+K3O5p/uXvoGcs/COrNMPuMdCoRCPx9u+/XzFYjEejw8M+PbsObjY3N6/d9/97dtuW8bPDIaHhz9rmJ3aIc6euDH1EA4s8ubk9TbS8PDwE61bANxhPDK7XUxdXWypY4NPff2WK35wzy++BeD+vz7a3sK/9KWPL2WdnmIhxWLxFO8GX8Fjx1PPPbttV0ot9idtbrjhBgAn/lmUk1f8/B1iLv9F67UrU69eHmj92LnsZ33PXD1qHk4Mu9hyU6H3/AVWvLcpOsUMyxzJO+EORQLf/+946g6oqwvdBxK/vDL16uWB83/hbBnHua/2fbeKC74++o0dC7e4rJHmz+PxWpxqTXotTrWOAWipYx/4PT/1wpe4Ttu2UjnedpsaGPDdemt5sbnvvjsz+zRa7Llimqb3XTNN07fzof/9z+s/cIf42qPFV7dGXeDCFo78mdmt6mO1YvUFGJ8rtLYssOJn94yL/vbG8kaaXmYLwCdx+NGi+kRq6tHigZaugKlxfBzOaLVx6IX4jS13SvkXbHFZI504j3fJEw/eAuCfHl/gtj985nbM/Adkewtf+jptz2yObj7vRDQ4dqY8/VJmKGoFylHlvbiJlrOZZjE48yIG0JLJQD3RV0YQ0UJhwZcxwGJzK/XeEuc78bs2f8V3Z9VLA7M7RKPVQuurySmF1rhqKUx9NtlSuHSH+uIiGyFvp7lcpx6ppTDV8n95RN2oMKUKrRZan1V/pdDqS7YUppT/0svUdYvso9sbacGw/nHnj2c2kMem1KR34r5n7zidBzvjdNfpKczm6Nc0B3Y5A9OcfinjGAUH9br34sbWo6OFVL3u2Cfc2NbNqAbbdmH45y/a20D29++bP/c992TbeBp18ODsxFudDoEj7b/xjZsf3Pz9J/8WQP+VOa9Fb7uI0/7ZTMfX6RzHd9aGYcAwRk/+smH4DcNY7GwymQRgLLppnJ4+mfyXjsy9Eit+ua+s5Y+EmSK919HeJfEdtxcP3tmRn8p0dp3OseI/JPSmn3NJe4taiRXfxs5a+Eger8jZs51q0dPBdTrHaryFolOzrsSKP81NkcCRZnX2PRNzdGqdzrFu3mCmnrxe2vsd5Y3k5rsD/Y14LgdECpFqImtBT6U0pwpE7EwfhkaTCxzkC7JucoTIN6VKG0lLO46d7SsVg1oKpWKxgXg0pSGCcqC/gbgDMEdaLX7DAIzCaLIAAIZKzn7FUKqwZmMtHXMkQZjjBuDmuwP9yNVMy46ktGxfOWoWe0rxMJpAMBjUUwUt6+tpxnPpVMTu6yshmB5d/CcXa4k5bgB+LQgUSxk0gKipm1Foes7UNC0KADYc124CgAanWmo0GvE0XJlHkcxxIzAKJx4aGvB+qHHS2enjSOPEA0p5mCMJwhxJEOZIgjBHEoQ5kiDMkQRhjiRIF1bg745I+0MmtF74lv5LdESdstgvjq2nz6KkDY/HjiQIcyRBmCMJwhxJEOZIgjBHEoQ5kiDMkQRhjiQIcyRBmCMJwhxJEOZIgjBHEoQ5kiDMkQRhjiQIcyRBmCMJwhxJEOZIgjBHEoQ5kiDMkQRhjiQIcyRBmCMJwhxJEOZIgjBHEoQ5kiDMkQRhjiQIcyRBmCMJwhxJEOZIgjBHEoQ5kiDMkQRhjiQIcyRBmCMJwhxJEOZIgjBHEoQ5kiDMkQRhjiQIcyRBmCMJwhxJEOZIgjBHEoQ5kiDMkQRhjiQIcyRBmCMJwhxJEOZIgjBHEoQ5kiDMkQRhjiQIcyRBmCMJwhxJEOZIgjBHEoQ5kiDMkQRhjiQIcyRBmCMJwhxJEOZIgjBHEoQ5kiDMkQRhjiQIcyRBmCMJwhxJEOZIgjBHEoQ5kiDMkQRhjiQIcyRBmCMJwhxJEOZIgjBHEoQ5kiDMkQRhjiQIcyRBmCMJwhxJEOZIgjBHEoQ5kiDMkQRhjiQIcyRBmCMJwhxJEOZIgjBHEoQ5kiDMkQRhjiQIcyRBmCMJwhxJEOZIgjBHEoQ5kiDMkQRhjiQIcyRBmCMJwhxJEOZIgjBHEoQ5kiDMkQRhjiQIcyRBmCMJwhxJEOZIgjBHEoQ5kiDMkQRhjiQIcyRBmCMJwhzXGTffHegP1mp6xtbSmm1nSiUEg8FiU3dGtWwChajdbVtBK1ooIJFAoYB8d6Y/mFZR1A3DQD3h62mGw8Gg2Sz2N+I1FUUdsO2MpaWRyTSD6dGC4ea7s1oaZe/mtpbWELAzgRJy6VENdQPlBAqpgOs4TiAQcBzHuySKejnTo6dVcvquE75MM5cejQRcx3FgZzL9CNaGouVARq+ZpbKVjkbtTBlpvdRTMp3RpJ85ri9utdRA3LQz/TBrgKal02kAiEbh5DPFphmNwrR0KwrXO5sv9TcagF2PagHAzWeKiOfSUQ02img07bpe6imZtXRaszM9jQaCAAAtHbUzPd7NYdYAVEsNIAfUAeQzxaaZArI2CgEnYSNlZ4pNM6qXeorIOYab7/buuohGHHDhZG2kNAQbYaThIFpLA0hHNQAwdc0uNQATAHxKqbX5xtI6U88nbC2VNPyzZxEpoJpApDBz2cI30eysdx03392HodHkItcGcyRRuLOmtv02331/P3bUzLfsyEWac3YAb1fLv0YqjL4GTCByrZZ9oBzt1jOjGOrWnLMBGMafuPkHslqvnrm/v3FOOPxWo4Fw7uKgdU6hsJ05Uvu09E3KQL77YAnhtFXpwznB5itwwtH0RXZmxNLCaL7V1KHjrVL17DQaiFwL/NbReqN2owwgfLEZPNhonIPSK8UGCoXt3FnT6vhtPmFHCtsXP24EeOxIonBnTYIwR+ogp14/O4BG1g6nNO/ft51AANl/Lke/GS0/kGnCHOrVHBvQABvYbhhw849VI+FS4P5R9U3mSB0UQPmBPlxsotJnTf87lHq72kRTd/TmW40GUH3bLB200pqeOWiltxvuc9XSKyWcE4zvAI8dSZT/B652uOx4s6bxAAAAAElFTkSuQmCC</ATTRIBUTE>
+<ATTRIBUTE name="NT Model Attributes" type="LONGSTRING">NOTEBOOK
+CHAPTER &quot;Description&quot;
+#ATTR &quot;Shared&quot;
+ATTR &quot;Model state&quot; enabled:(cond(search (sMfbRegistration, &quot;MFB_VERS&quot;, 0) = -1, 1, 0))
+ATTR &quot;Description&quot;
+ATTR &quot;Show State&quot; ctrltype:check unchecked-value:&quot;No&quot; checked-value:&quot;Yes&quot; 
+ATTR &quot;Last user&quot; write-protected
+ATTR &quot;Date last changed&quot; write-protected
+#CHAPTER &quot;Suggestion for improvement&quot;
+#ATTR &quot;Suggestion for improvement&quot;
+</ATTRIBUTE>
+<ATTRIBUTE name="Model state" type="ENUMERATION">Draft</ATTRIBUTE>
+<ATTRIBUTE name="Keywords" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Description" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Model type" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Show State" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Actor_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="Actor_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Actor_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="ModelingAreaSize" type="ENUMERATION">20</ATTRIBUTE>
+<ATTRIBUTE name="DrawingAreaWidth" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="DrawingAreaHeight" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Reference overview settings" type="LONGSTRING">Responsible for execution|Responsible for execution
+Accountable for approving results|Accountable for approving results
+Cooperation/participation|Cooperation/participation
+To inform|To inform
+Modelling|Modelling
+Knowledge Product|Knowledge Product
+Documents and Resources|Documents and Resources
+#Data Object|Data Object
+Incoming Data Object|Incoming Data Object
+Outgoing Data Object|Outgoing Data Object
+Description|Description</ATTRIBUTE>
+<ATTRIBUTE name="Data Object_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="Data Object_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Data Object_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="id_bpmndi_diagram" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="id_bpmndi_plane" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="id_bpmndi_collaboration" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="CommentTypeSize" type="ENUMERATION">8</ATTRIBUTE>
+<ATTRIBUTE name="CommentxCoorTextBox" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="CommentyCoorTextBox" type="STRING"></ATTRIBUTE>
+</MODELATTRIBUTES>
+<INSTANCE id="obj.16438" class="Pool" name="Monti Azzurri Consorsium">
+<ATTRIBUTE name="Position" type="STRING">NODE x:0cm y:7cm w:23.5cm h:4.5cm index:1</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(&quot;&quot;) val:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<RECORD name="Technical Attributes"></RECORD>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="ParticipantType" type="ENUMERATION">Role</ATTRIBUTE>
+<ATTRIBUTE name="Role" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Entity" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="BoundaryVisible" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Process Term" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="ProcessType" type="ENUMERATION">None</ATTRIBUTE>
+<ATTRIBUTE name="Status" type="ENUMERATION">None</ATTRIBUTE>
+<RECORD name="Assignments"></RECORD>
+<RECORD name="Properties"></RECORD>
+<ATTRIBUTE name="AdHoc" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="AdHocOrdering" type="ENUMERATION">None</ATTRIBUTE>
+<ATTRIBUTE name="AdHocCompletionCondition" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="EnableInstanceCompensation" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Categories (Process)" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation (Process)" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="SuppressJoinFailure" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Open questions" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16438&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Color" type="STRING">white</ATTRIBUTE>
+<ATTRIBUTE name="Orientation" type="ENUMERATION">horizontal</ATTRIBUTE>
+<ATTRIBUTE name="Boundary visible" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Auditing" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Monitoring" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Process type" type="ENUMERATION">None</ATTRIBUTE>
+<ATTRIBUTE name="Executable" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Closed" type="ENUMERATION">No</ATTRIBUTE>
+<INTERREF name="Referenced Organizational Unit">
+<IREF type="objectreference" tmodeltype="Organizational structure" tmodelname="Org Model Monti Azzurri" tmodelver="" tclassname="Organizational unit" tobjname="Monti Azzurri"></IREF>
+</INTERREF>
+</INSTANCE>
+<INSTANCE id="obj.16441" class="Start Event" name="Start Event-83232">
+<ATTRIBUTE name="Position" type="STRING">NODE x:4cm y:9cm index:2</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Process calendar" type="LONGSTRING">D@Working day@b@32400-43200@U900;1800@45000-59400@U900;1800@Free day@c@@@$cbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbcbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbcbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbcccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbccbbccb</ATTRIBUTE>
+<ATTRIBUTE name="Quantity" type="EXPRESSION">EXPR expr:(0) val:0</ATTRIBUTE>
+<ATTRIBUTE name="Time period" type="ENUMERATION">Per year</ATTRIBUTE>
+<ATTRIBUTE name="Abandon after tolerance waiting time" type="ENUMERATION">no</ATTRIBUTE>
+<ATTRIBUTE name="Tolerance waiting time" type="TIME">00:000:00:00:00</ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-02] Attribute \&quot;Fontcolor\&quot; (Pool) does not exist!  \&quot;fontcolor\&quot; (Start Event)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<RECORD name="Technical Attributes"></RECORD>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<INTERREF name="Actor"></INTERREF>
+<RECORD name="Assignments"></RECORD>
+<ATTRIBUTE name="Term" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Trigger" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Result" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Aggregated execution time" type="TIME">00:000:00:00:00</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated waiting time" type="TIME">00:000:00:00:00</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated resting time" type="TIME">00:000:00:00:00</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated transport time" type="TIME">00:000:00:00:00</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated cycle time" type="TIME">00:000:00:00:00</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Info on results" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Cost driver" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Cost driver quantity" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated personnel costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="External documentation" type="PROGRAMCALL">ITEM &quot;&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Prozeßstart</ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Open questions" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Modelling direction" type="EXPRESSION">EXPR val:&quot;vertical&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Implementing control" type="ENUMERATION">no</ATTRIBUTE>
+<ATTRIBUTE name="Show name" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16441&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Type" type="ENUMERATION">Top-level</ATTRIBUTE>
+<ATTRIBUTE name="Message" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Timer" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Conditional" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Signal" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Escalation" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Error" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Compensation" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Parallel" type="ENUMERATION">No</ATTRIBUTE>
+<RECORD name="Properties"></RECORD>
+<ATTRIBUTE name="Auditing" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Monitoring" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Collection" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Object type" type="ENUMERATION">Information</ATTRIBUTE>
+<ATTRIBUTE name="Cardinality" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Details" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Timer type" type="ENUMERATION">Date</ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16444" class="Task" name="Activate Service Conference">
+<ATTRIBUTE name="Position" type="STRING">NODE x:8cm y:9cm w:3.36cm h:1.8cm index:3</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Performer" type="EXPRESSION">EXPR expr:(&quot;&quot;) val:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Execution time" type="TIME">00:000:00:00:00</ATTRIBUTE>
+<ATTRIBUTE name="Waiting time" type="TIME">00:000:00:00:00</ATTRIBUTE>
+<ATTRIBUTE name="Resting time" type="TIME">00:000:00:00:00</ATTRIBUTE>
+<ATTRIBUTE name="Transport time" type="TIME">00:000:00:00:00</ATTRIBUTE>
+<ATTRIBUTE name="Priority" type="INTEGER">10</ATTRIBUTE>
+<ATTRIBUTE name="Done by" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Continuous execution" type="ENUMERATION">no</ATTRIBUTE>
+<ATTRIBUTE name="Max. resource waiting time" type="TIME">00:000:00:05:00</ATTRIBUTE>
+<ATTRIBUTE name="Cooperative" type="ENUMERATION">no</ATTRIBUTE>
+<ATTRIBUTE name="Cooperation mode" type="ENUMERATION">synchron</ATTRIBUTE>
+<ATTRIBUTE name="Average number of participants" type="INTEGER">1</ATTRIBUTE>
+<ATTRIBUTE name="Min. quota of presence" type="INTEGER">100</ATTRIBUTE>
+<ATTRIBUTE name="Max. start period" type="TIME">00:001:00:00:00</ATTRIBUTE>
+<ATTRIBUTE name="Execution interruptable" type="ENUMERATION">yes</ATTRIBUTE>
+<ATTRIBUTE name="Task stack" type="ENUMERATION">personal</ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-02] Attribute \&quot;Fontcolor\&quot; (Pool) does not exist!  \&quot;fontcolor\&quot; (Task)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<RECORD name="Technical Attributes"></RECORD>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<INTERREF name="Actor"></INTERREF>
+<RECORD name="Assignments"></RECORD>
+<ATTRIBUTE name="Term" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Status" type="ENUMERATION">None</ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING">Orig.Name = Manage Service Conference</ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="External documentation" type="PROGRAMCALL">ITEM &quot;&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Info on results" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Number" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated execution time" type="TIME">00:000:00:00:00</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated waiting time" type="TIME">00:000:00:00:00</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated resting time" type="TIME">00:000:00:00:00</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated transport time" type="TIME">00:000:00:00:00</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated personnel costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Classification" type="ENUMERATIONLIST"></ATTRIBUTE>
+<ATTRIBUTE name="EDP transaction costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="EDP batch costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Printing costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Postal costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Aktivität</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Open questions" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Type" type="ENUMERATION">Standard</ATTRIBUTE>
+<INTERREF name="referenced subprocess"></INTERREF>
+<ATTRIBUTE name="Display responsible role" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Subprocessname" type="EXPRESSION">EXPR val:&quot;Bezeichnung&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Modelling direction" type="EXPRESSION">EXPR val:&quot;vertical&quot;</ATTRIBUTE>
+<RECORD name="Properties"></RECORD>
+<ATTRIBUTE name="Show name" type="ENUMERATION">center</ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16444&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Task type" type="ENUMERATION">Not specified</ATTRIBUTE>
+<ATTRIBUTE name="Global task" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Auditing" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Monitoring" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="For compensation" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Loop type" type="ENUMERATION">Not specified</ATTRIBUTE>
+<INTERREF name="Call activity"></INTERREF>
+<ATTRIBUTE name="Sequential execution" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Cardinality" type="STRING"></ATTRIBUTE>
+<INTERREF name="Referenced data input"></INTERREF>
+<INTERREF name="Referenced data output"></INTERREF>
+<ATTRIBUTE name="Instantiate" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Collection" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Object type" type="ENUMERATION">Information</ATTRIBUTE>
+<ATTRIBUTE name="Completion condition" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Loop condition (standard)" type="STRING"></ATTRIBUTE>
+<INTERREF name="Referenced message"></INTERREF>
+<ATTRIBUTE name="People-like_view_Expression" type="EXPRESSION">EXPR expr:(maval(&quot;People-like view&quot;)) val:&quot;No&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Action" type="ENUMERATION">Fill in</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Actor_" type="EXPRESSION">EXPR expr:(maval(&quot;Actor_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Description_" type="EXPRESSION">EXPR expr:(maval(&quot;Description_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_Modelling_direction_" type="EXPRESSION">EXPR expr:(maval(&quot;Modelling direction&quot;)) val:&quot;vertical&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Modelling_" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="_REFERENCE_OVERVIEW_SETTINGS_" type="EXPRESSION">EXPR expr:(maval(&quot;Reference overview settings&quot;)) val:&quot;Responsible for execution|Responsible for execution\nAccountable for approving results|Accountable for approving results\nCooperation/participation|Cooperation/participation\nTo inform|To inform\nModelling|Modelling\nKnowledge Product|Knowledge Product\nDocuments and Resources|Documents and Resources\n#Data Object|Data Object\nIncoming Data Object|Incoming Data Object\nOutgoing Data Object|Outgoing Data Object\nDescription|Description&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Actor_" type="EXPRESSION">EXPR expr:(maval(&quot;Actor_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Description_" type="EXPRESSION">EXPR expr:(maval(&quot;Description_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Modelling_" type="EXPRESSION">EXPR expr:(maval(&quot;Modelling_size&quot;)) val:&quot;3&quot;</ATTRIBUTE>
+<ATTRIBUTE name="BoolBarDisplayActive" type="EXPRESSION">EXPR expr:(maval(&quot;BAR Display active&quot;)) val:&quot;No&quot;</ATTRIBUTE>
+<INTERREF name="Data Object"></INTERREF>
+<INTERREF name="Knowledge Product"></INTERREF>
+<INTERREF name="Documents and Resources"></INTERREF>
+<ATTRIBUTE name="_disp_Knowledge Product_" type="EXPRESSION">EXPR expr:(maval(&quot;Knowledge Product_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Data Object_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Documents and Resources_" type="EXPRESSION">EXPR expr:(maval(&quot;Documents and Resources_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Data Object_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Documents and Resources_" type="EXPRESSION">EXPR expr:(maval(&quot;Documents and Resources_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Knowledge Product_" type="EXPRESSION">EXPR expr:(maval(&quot;Knowledge Product_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Responsible for execution_" type="EXPRESSION">EXPR expr:(maval(&quot;Responsible for execution_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Responsible for execution_" type="EXPRESSION">EXPR expr:(maval(&quot;Responsible for execution_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Accountable for approving results_" type="EXPRESSION">EXPR expr:(maval(&quot;Accountable for approving results_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Accountable for approving results_" type="EXPRESSION">EXPR expr:(maval(&quot;Accountable for approving results_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Cooperation/participation_" type="EXPRESSION">EXPR expr:(maval(&quot;Cooperation/participation_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Cooperation/participation_" type="EXPRESSION">EXPR expr:(maval(&quot;Cooperation/participation_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_To inform_" type="EXPRESSION">EXPR expr:(maval(&quot;To inform_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_To inform_" type="EXPRESSION">EXPR expr:(maval(&quot;To inform_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<INTERREF name="Responsible for execution"></INTERREF>
+<INTERREF name="To inform"></INTERREF>
+<INTERREF name="Cooperation/participation"></INTERREF>
+<INTERREF name="Accountable for approving results"></INTERREF>
+<INTERREF name="Incoming Data Object"></INTERREF>
+<INTERREF name="Outgoing Data Object"></INTERREF>
+<ATTRIBUTE name="_size_Outgoing Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Outgoing Data Object_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Outgoing Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Outgoing Data Object_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Incoming Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Incoming Data Object_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Incoming Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Incoming Data Object_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Commentboxcomment" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="CommentAreaSizeExp" type="EXPRESSION">EXPR expr:(maval(&quot;CommentAreaSize&quot;)) val:&quot;2&quot;</ATTRIBUTE>
+<ATTRIBUTE name="CommentBool" type="ENUMERATION">0</ATTRIBUTE>
+<ATTRIBUTE name="CommentBox" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="CommentInfo" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="CommentMode" type="EXPRESSION">EXPR expr:(maval(&quot;Comment Mode&quot;)) val:&quot;No&quot;</ATTRIBUTE>
+<RECORD name="CommentTable"></RECORD>
+<ATTRIBUTE name="WriteComment" type="PROGRAMCALL">ITEM &quot;Add Comment&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="ClearComment" type="PROGRAMCALL">ITEM &quot;Clear Comment&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="CommentModellingAreaSizeExp" type="EXPRESSION">EXPR expr:(maval(&quot;CommentModellingAreaSize&quot;)) val:&quot;3&quot;</ATTRIBUTE>
+<ATTRIBUTE name="BoolCommentModeActive" type="EXPRESSION">EXPR expr:(maval(&quot;Comment Mode&quot;)) val:&quot;No&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Comment Model Direction" type="EXPRESSION">EXPR expr:(maval(&quot;CommentModellingDirection&quot;)) val:&quot;vertical&quot;</ATTRIBUTE>
+<INTERREF name="Decision"></INTERREF>
+<INTERREF name="Referenced documents"></INTERREF>
+<ATTRIBUTE name="Left border" type="EXPRESSION">EXPR
+ val:6.32</ATTRIBUTE>
+<INTERREF name="Referenced Planning Table"></INTERREF>
+<ATTRIBUTE name="Right border" type="EXPRESSION">EXPR
+ val:9.68</ATTRIBUTE>
+<ATTRIBUTE name="Show or Hide" type="ENUMERATION">Shown</ATTRIBUTE>
+<ATTRIBUTE name="Top border" type="EXPRESSION">EXPR
+ val:8.1</ATTRIBUTE>
+<ATTRIBUTE name="Bottom border" type="EXPRESSION">EXPR
+ val:9.9</ATTRIBUTE>
+<ATTRIBUTE name="X" type="EXPRESSION">EXPR
+ val:8</ATTRIBUTE>
+<ATTRIBUTE name="Y" type="EXPRESSION">EXPR
+ val:9</ATTRIBUTE>
+<ATTRIBUTE name="Change Visibility" type="PROGRAMCALL">ITEM &quot;Change Visibility&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Planning Table" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Bounding box" type="EXPRESSION">EXPR
+ val:&quot;[8.1,9.9,6.32,9.68,8,9]&quot;</ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16447" class="Task" name="Confirm Decision">
+<ATTRIBUTE name="Position" type="STRING">NODE x:13.5cm y:9cm w:3.36cm h:1.8cm index:4</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Performer" type="EXPRESSION">EXPR expr:(&quot;&quot;) val:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Execution time" type="TIME">00:000:00:00:00</ATTRIBUTE>
+<ATTRIBUTE name="Waiting time" type="TIME">00:000:00:00:00</ATTRIBUTE>
+<ATTRIBUTE name="Resting time" type="TIME">00:000:00:00:00</ATTRIBUTE>
+<ATTRIBUTE name="Transport time" type="TIME">00:000:00:00:00</ATTRIBUTE>
+<ATTRIBUTE name="Priority" type="INTEGER">10</ATTRIBUTE>
+<ATTRIBUTE name="Done by" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Continuous execution" type="ENUMERATION">no</ATTRIBUTE>
+<ATTRIBUTE name="Max. resource waiting time" type="TIME">00:000:00:05:00</ATTRIBUTE>
+<ATTRIBUTE name="Cooperative" type="ENUMERATION">no</ATTRIBUTE>
+<ATTRIBUTE name="Cooperation mode" type="ENUMERATION">synchron</ATTRIBUTE>
+<ATTRIBUTE name="Average number of participants" type="INTEGER">1</ATTRIBUTE>
+<ATTRIBUTE name="Min. quota of presence" type="INTEGER">100</ATTRIBUTE>
+<ATTRIBUTE name="Max. start period" type="TIME">00:001:00:00:00</ATTRIBUTE>
+<ATTRIBUTE name="Execution interruptable" type="ENUMERATION">yes</ATTRIBUTE>
+<ATTRIBUTE name="Task stack" type="ENUMERATION">personal</ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-02] Attribute \&quot;Fontcolor\&quot; (Pool) does not exist!  \&quot;fontcolor\&quot; (Task)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<RECORD name="Technical Attributes"></RECORD>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<INTERREF name="Actor"></INTERREF>
+<RECORD name="Assignments"></RECORD>
+<ATTRIBUTE name="Term" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Status" type="ENUMERATION">None</ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING">Orig.Name = Ask for Service Conference Opinion</ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="External documentation" type="PROGRAMCALL">ITEM &quot;&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Info on results" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Number" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated execution time" type="TIME">00:000:00:00:00</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated waiting time" type="TIME">00:000:00:00:00</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated resting time" type="TIME">00:000:00:00:00</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated transport time" type="TIME">00:000:00:00:00</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated personnel costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Classification" type="ENUMERATIONLIST"></ATTRIBUTE>
+<ATTRIBUTE name="EDP transaction costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="EDP batch costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Printing costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Postal costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Aktivität</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Open questions" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Type" type="ENUMERATION">Standard</ATTRIBUTE>
+<INTERREF name="referenced subprocess"></INTERREF>
+<ATTRIBUTE name="Display responsible role" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Subprocessname" type="EXPRESSION">EXPR val:&quot;Bezeichnung&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Modelling direction" type="EXPRESSION">EXPR val:&quot;vertical&quot;</ATTRIBUTE>
+<RECORD name="Properties"></RECORD>
+<ATTRIBUTE name="Show name" type="ENUMERATION">center</ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16447&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Task type" type="ENUMERATION">Send</ATTRIBUTE>
+<ATTRIBUTE name="Global task" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Auditing" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Monitoring" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="For compensation" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Loop type" type="ENUMERATION">Not specified</ATTRIBUTE>
+<INTERREF name="Call activity"></INTERREF>
+<ATTRIBUTE name="Sequential execution" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Cardinality" type="STRING"></ATTRIBUTE>
+<INTERREF name="Referenced data input"></INTERREF>
+<INTERREF name="Referenced data output"></INTERREF>
+<ATTRIBUTE name="Instantiate" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Collection" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Object type" type="ENUMERATION">Information</ATTRIBUTE>
+<ATTRIBUTE name="Completion condition" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Loop condition (standard)" type="STRING"></ATTRIBUTE>
+<INTERREF name="Referenced message"></INTERREF>
+<ATTRIBUTE name="People-like_view_Expression" type="EXPRESSION">EXPR expr:(maval(&quot;People-like view&quot;)) val:&quot;No&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Action" type="ENUMERATION">Fill in</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Actor_" type="EXPRESSION">EXPR expr:(maval(&quot;Actor_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Description_" type="EXPRESSION">EXPR expr:(maval(&quot;Description_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_Modelling_direction_" type="EXPRESSION">EXPR expr:(maval(&quot;Modelling direction&quot;)) val:&quot;vertical&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Modelling_" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="_REFERENCE_OVERVIEW_SETTINGS_" type="EXPRESSION">EXPR expr:(maval(&quot;Reference overview settings&quot;)) val:&quot;Responsible for execution|Responsible for execution\nAccountable for approving results|Accountable for approving results\nCooperation/participation|Cooperation/participation\nTo inform|To inform\nModelling|Modelling\nKnowledge Product|Knowledge Product\nDocuments and Resources|Documents and Resources\n#Data Object|Data Object\nIncoming Data Object|Incoming Data Object\nOutgoing Data Object|Outgoing Data Object\nDescription|Description&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Actor_" type="EXPRESSION">EXPR expr:(maval(&quot;Actor_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Description_" type="EXPRESSION">EXPR expr:(maval(&quot;Description_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Modelling_" type="EXPRESSION">EXPR expr:(maval(&quot;Modelling_size&quot;)) val:&quot;3&quot;</ATTRIBUTE>
+<ATTRIBUTE name="BoolBarDisplayActive" type="EXPRESSION">EXPR expr:(maval(&quot;BAR Display active&quot;)) val:&quot;No&quot;</ATTRIBUTE>
+<INTERREF name="Data Object"></INTERREF>
+<INTERREF name="Knowledge Product"></INTERREF>
+<INTERREF name="Documents and Resources"></INTERREF>
+<ATTRIBUTE name="_disp_Knowledge Product_" type="EXPRESSION">EXPR expr:(maval(&quot;Knowledge Product_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Data Object_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Documents and Resources_" type="EXPRESSION">EXPR expr:(maval(&quot;Documents and Resources_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Data Object_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Documents and Resources_" type="EXPRESSION">EXPR expr:(maval(&quot;Documents and Resources_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Knowledge Product_" type="EXPRESSION">EXPR expr:(maval(&quot;Knowledge Product_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Responsible for execution_" type="EXPRESSION">EXPR expr:(maval(&quot;Responsible for execution_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Responsible for execution_" type="EXPRESSION">EXPR expr:(maval(&quot;Responsible for execution_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Accountable for approving results_" type="EXPRESSION">EXPR expr:(maval(&quot;Accountable for approving results_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Accountable for approving results_" type="EXPRESSION">EXPR expr:(maval(&quot;Accountable for approving results_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Cooperation/participation_" type="EXPRESSION">EXPR expr:(maval(&quot;Cooperation/participation_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Cooperation/participation_" type="EXPRESSION">EXPR expr:(maval(&quot;Cooperation/participation_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_To inform_" type="EXPRESSION">EXPR expr:(maval(&quot;To inform_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_To inform_" type="EXPRESSION">EXPR expr:(maval(&quot;To inform_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<INTERREF name="Responsible for execution"></INTERREF>
+<INTERREF name="To inform"></INTERREF>
+<INTERREF name="Cooperation/participation"></INTERREF>
+<INTERREF name="Accountable for approving results"></INTERREF>
+<INTERREF name="Incoming Data Object"></INTERREF>
+<INTERREF name="Outgoing Data Object"></INTERREF>
+<ATTRIBUTE name="_size_Outgoing Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Outgoing Data Object_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Outgoing Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Outgoing Data Object_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Incoming Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Incoming Data Object_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Incoming Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Incoming Data Object_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Commentboxcomment" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="CommentAreaSizeExp" type="EXPRESSION">EXPR expr:(maval(&quot;CommentAreaSize&quot;)) val:&quot;2&quot;</ATTRIBUTE>
+<ATTRIBUTE name="CommentBool" type="ENUMERATION">0</ATTRIBUTE>
+<ATTRIBUTE name="CommentBox" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="CommentInfo" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="CommentMode" type="EXPRESSION">EXPR expr:(maval(&quot;Comment Mode&quot;)) val:&quot;No&quot;</ATTRIBUTE>
+<RECORD name="CommentTable"></RECORD>
+<ATTRIBUTE name="WriteComment" type="PROGRAMCALL">ITEM &quot;Add Comment&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="ClearComment" type="PROGRAMCALL">ITEM &quot;Clear Comment&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="CommentModellingAreaSizeExp" type="EXPRESSION">EXPR expr:(maval(&quot;CommentModellingAreaSize&quot;)) val:&quot;3&quot;</ATTRIBUTE>
+<ATTRIBUTE name="BoolCommentModeActive" type="EXPRESSION">EXPR expr:(maval(&quot;Comment Mode&quot;)) val:&quot;No&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Comment Model Direction" type="EXPRESSION">EXPR expr:(maval(&quot;CommentModellingDirection&quot;)) val:&quot;vertical&quot;</ATTRIBUTE>
+<INTERREF name="Decision"></INTERREF>
+<INTERREF name="Referenced documents"></INTERREF>
+<ATTRIBUTE name="Left border" type="EXPRESSION">EXPR
+ val:11.82</ATTRIBUTE>
+<INTERREF name="Referenced Planning Table"></INTERREF>
+<ATTRIBUTE name="Right border" type="EXPRESSION">EXPR
+ val:15.18</ATTRIBUTE>
+<ATTRIBUTE name="Show or Hide" type="ENUMERATION">Shown</ATTRIBUTE>
+<ATTRIBUTE name="Top border" type="EXPRESSION">EXPR
+ val:8.1</ATTRIBUTE>
+<ATTRIBUTE name="Bottom border" type="EXPRESSION">EXPR
+ val:9.9</ATTRIBUTE>
+<ATTRIBUTE name="X" type="EXPRESSION">EXPR
+ val:13.5</ATTRIBUTE>
+<ATTRIBUTE name="Y" type="EXPRESSION">EXPR
+ val:9</ATTRIBUTE>
+<ATTRIBUTE name="Change Visibility" type="PROGRAMCALL">ITEM &quot;Change Visibility&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Planning Table" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Bounding box" type="EXPRESSION">EXPR
+ val:&quot;[8.1,9.9,11.82,15.18,13.5,9]&quot;</ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16450" class="Intermediate Event (sequence flow)" name="Receive Confirmation">
+<ATTRIBUTE name="Position" type="STRING">NODE x:18cm y:9cm index:5</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(&quot;&quot;) val:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<RECORD name="Technical Attributes"></RECORD>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<INTERREF name="Actor"></INTERREF>
+<RECORD name="Assignments"></RECORD>
+<ATTRIBUTE name="Term" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="External documentation" type="PROGRAMCALL">ITEM &quot;&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Open questions" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Auslöser</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<INTERREF name="Referenced trigger"></INTERREF>
+<ATTRIBUTE name="Modelling direction" type="EXPRESSION">EXPR val:&quot;vertical&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Type" type="ENUMERATION">catching</ATTRIBUTE>
+<ATTRIBUTE name="Show name" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16450&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Message" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Timer" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Conditional" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Signal" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Escalation" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Compensation" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Parallel" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Link" type="ENUMERATION">No</ATTRIBUTE>
+<RECORD name="Properties"></RECORD>
+<ATTRIBUTE name="Auditing" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Monitoring" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Collection" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Object type" type="ENUMERATION">Information</ATTRIBUTE>
+<ATTRIBUTE name="Cardinality" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Details" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Timer type" type="ENUMERATION">Date</ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16453" class="End Event" name="End Event-83248">
+<ATTRIBUTE name="Position" type="STRING">NODE x:21.5cm y:9cm index:6</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Type" type="ENUMERATION">local</ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-02] Attribute \&quot;Fontcolor\&quot; (Pool) does not exist!  \&quot;fontcolor\&quot; (End Event)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<RECORD name="Technical Attributes"></RECORD>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<INTERREF name="Actor"></INTERREF>
+<ATTRIBUTE name="Representation" type="ENUMERATION">without name</ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Ende</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Show name" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Open questions" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16453&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Message" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Signal" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Escalation" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Error" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Compensation" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Terminate" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Cancel" type="ENUMERATION">No</ATTRIBUTE>
+<RECORD name="Properties"></RECORD>
+<ATTRIBUTE name="Auditing" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Monitoring" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Collection" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Object type" type="ENUMERATION">Information</ATTRIBUTE>
+<ATTRIBUTE name="Cardinality" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Details" type="LONGSTRING"></ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16456" class="Pool (collapsed)" name="Service Conforence">
+<ATTRIBUTE name="Position" type="STRING">NODE x:12cm y:3cm w:23.5cm h:3cm index:11</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(&quot;&quot;) val:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<RECORD name="Technical Attributes"></RECORD>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="ParticipantType" type="ENUMERATION">Role</ATTRIBUTE>
+<ATTRIBUTE name="Role" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Entity" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="BoundaryVisible" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Process Term" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="ProcessType" type="ENUMERATION">None</ATTRIBUTE>
+<ATTRIBUTE name="Status" type="ENUMERATION">None</ATTRIBUTE>
+<RECORD name="Assignments"></RECORD>
+<RECORD name="Properties"></RECORD>
+<ATTRIBUTE name="AdHoc" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="AdHocOrdering" type="ENUMERATION">None</ATTRIBUTE>
+<ATTRIBUTE name="AdHocCompletionCondition" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="EnableInstanceCompensation" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Categories (Process)" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation (Process)" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="SuppressJoinFailure" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Open questions" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16456&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Color" type="STRING">white</ATTRIBUTE>
+<ATTRIBUTE name="Orientation" type="ENUMERATION">horizontal</ATTRIBUTE>
+<ATTRIBUTE name="Boundary visible" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Auditing" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Monitoring" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Process type" type="ENUMERATION">None</ATTRIBUTE>
+<ATTRIBUTE name="Executable" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Closed" type="ENUMERATION">No</ATTRIBUTE>
+<INTERREF name="Referenced Organizational Unit"></INTERREF>
+<INTERREF name="Referenced process"></INTERREF>
+<ATTRIBUTE name="Cardinality" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<CONNECTOR id="con.16459" class="Is inside">
+<FROM instance="Start Event-83232" class="Start Event"></FROM>
+<TO instance="Monti Azzurri Consorsium" class="Pool"></TO>
+<ATTRIBUTE name="AutoConnect" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16460" class="Subsequent">
+<FROM instance="Start Event-83232" class="Start Event"></FROM>
+<TO instance="Activate Service Conference" class="Task"></TO>
+<ATTRIBUTE name="Transition condition" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Transition probability" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualized values" type="ENUMERATION">Denomination</ATTRIBUTE>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 0 index:7</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">1</ATTRIBUTE>
+<ATTRIBUTE name="Representation" type="ENUMERATION">above/below</ATTRIBUTE>
+<ATTRIBUTE name="Font colour" type="ENUMERATION">black</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Info zur Übergangsbedingung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Nachfolger</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Denomination" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Description" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Auditing" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Monitoring" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Default" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Immediate" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Category" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16460&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Color" type="STRING">black</ATTRIBUTE>
+<ATTRIBUTE name="Doku" type="STRING">NOTEBOOK
+
+#-----------------------
+LANG &quot;en&quot;
+#-----------------------
+CHAPTER &quot;Description&quot;
+ATTR &quot;Denomination&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+
+
+CHAPTER &quot;Details (BPMN)&quot;
+
+ATTR &quot;Auditing&quot; 
+ATTR &quot;Monitoring&quot; 
+
+ATTR &quot;Default&quot; 
+ATTR &quot;Immediate&quot; 
+ATTR &quot;Category&quot;
+ATTR &quot;Id&quot; 
+
+
+CHAPTER &quot;Details (Simulation)&quot;
+
+ATTR &quot;Transition condition&quot; dialog:transcond
+
+ATTR &quot;Transition probability&quot;
+
+</ATTRIBUTE>
+<ATTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;Task&quot;</ATTRIBUTE>
+<ATTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Start Event&quot;</ATTRIBUTE>
+<ATTRIBUTE name="ModelTypeExp" type="EXPRESSION">EXPR val:&quot;Business process diagram (BPMN 2.0)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16461" class="Is inside">
+<FROM instance="Activate Service Conference" class="Task"></FROM>
+<TO instance="Monti Azzurri Consorsium" class="Pool"></TO>
+<ATTRIBUTE name="AutoConnect" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16462" class="Subsequent">
+<FROM instance="Activate Service Conference" class="Task"></FROM>
+<TO instance="Confirm Decision" class="Task"></TO>
+<ATTRIBUTE name="Transition condition" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Transition probability" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualized values" type="ENUMERATION">Denomination</ATTRIBUTE>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 0 index:8</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">2</ATTRIBUTE>
+<ATTRIBUTE name="Representation" type="ENUMERATION">above/below</ATTRIBUTE>
+<ATTRIBUTE name="Font colour" type="ENUMERATION">black</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Info zur Übergangsbedingung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Nachfolger</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Denomination" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Description" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Auditing" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Monitoring" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Default" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Immediate" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Category" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16462&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Color" type="STRING">black</ATTRIBUTE>
+<ATTRIBUTE name="Doku" type="STRING">NOTEBOOK
+
+#-----------------------
+LANG &quot;en&quot;
+#-----------------------
+CHAPTER &quot;Description&quot;
+ATTR &quot;Denomination&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+
+
+CHAPTER &quot;Details (BPMN)&quot;
+
+ATTR &quot;Auditing&quot; 
+ATTR &quot;Monitoring&quot; 
+
+ATTR &quot;Default&quot; 
+ATTR &quot;Immediate&quot; 
+ATTR &quot;Category&quot;
+ATTR &quot;Id&quot; 
+
+
+CHAPTER &quot;Details (Simulation)&quot;
+
+ATTR &quot;Transition condition&quot; dialog:transcond
+
+ATTR &quot;Transition probability&quot;
+
+</ATTRIBUTE>
+<ATTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;Task&quot;</ATTRIBUTE>
+<ATTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Task&quot;</ATTRIBUTE>
+<ATTRIBUTE name="ModelTypeExp" type="EXPRESSION">EXPR val:&quot;Business process diagram (BPMN 2.0)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16463" class="Is inside">
+<FROM instance="Confirm Decision" class="Task"></FROM>
+<TO instance="Monti Azzurri Consorsium" class="Pool"></TO>
+<ATTRIBUTE name="AutoConnect" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16464" class="Subsequent">
+<FROM instance="Confirm Decision" class="Task"></FROM>
+<TO instance="Receive Confirmation" class="Intermediate Event (sequence flow)"></TO>
+<ATTRIBUTE name="Transition condition" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Transition probability" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualized values" type="ENUMERATION">Denomination</ATTRIBUTE>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 0 index:9</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">3</ATTRIBUTE>
+<ATTRIBUTE name="Representation" type="ENUMERATION">above/below</ATTRIBUTE>
+<ATTRIBUTE name="Font colour" type="ENUMERATION">black</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Info zur Übergangsbedingung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Nachfolger</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Denomination" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Description" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Auditing" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Monitoring" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Default" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Immediate" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Category" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16464&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Color" type="STRING">black</ATTRIBUTE>
+<ATTRIBUTE name="Doku" type="STRING">NOTEBOOK
+
+#-----------------------
+LANG &quot;en&quot;
+#-----------------------
+CHAPTER &quot;Description&quot;
+ATTR &quot;Denomination&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+
+
+CHAPTER &quot;Details (BPMN)&quot;
+
+ATTR &quot;Auditing&quot; 
+ATTR &quot;Monitoring&quot; 
+
+ATTR &quot;Default&quot; 
+ATTR &quot;Immediate&quot; 
+ATTR &quot;Category&quot;
+ATTR &quot;Id&quot; 
+
+
+CHAPTER &quot;Details (Simulation)&quot;
+
+ATTR &quot;Transition condition&quot; dialog:transcond
+
+ATTR &quot;Transition probability&quot;
+
+</ATTRIBUTE>
+<ATTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;Intermediate Event (sequence flow)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Task&quot;</ATTRIBUTE>
+<ATTRIBUTE name="ModelTypeExp" type="EXPRESSION">EXPR val:&quot;Business process diagram (BPMN 2.0)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16465" class="Message Flow">
+<FROM instance="Confirm Decision" class="Task"></FROM>
+<TO instance="Service Conforence" class="Pool (collapsed)"></TO>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 1 x1:13.5cm y1:5cm index:12</ATTRIBUTE>
+<ATTRIBUTE name="Message Name" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="ParticipantType (from)" type="ENUMERATION">Role</ATTRIBUTE>
+<ATTRIBUTE name="Role (from)" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Entity (from)" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="ParticipantType (to)" type="ENUMERATION">Role</ATTRIBUTE>
+<ATTRIBUTE name="Role (to)" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Entity (to)" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Name" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Message Properties" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;Pool (collapsed)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Task&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Number" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Show Name" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Show Number" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Representation" type="ENUMERATION">above/below</ATTRIBUTE>
+<ATTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Description" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Show name" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Doku" type="STRING">NOTEBOOK
+
+#-----------------------
+CHAPTER &quot;Description&quot;
+#-----------------------
+ATTR &quot;Name&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+ATTR &quot;Id&quot; </ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16465&quot;</ATTRIBUTE>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16466" class="Is inside">
+<FROM instance="Receive Confirmation" class="Intermediate Event (sequence flow)"></FROM>
+<TO instance="Monti Azzurri Consorsium" class="Pool"></TO>
+<ATTRIBUTE name="AutoConnect" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16467" class="Subsequent">
+<FROM instance="Receive Confirmation" class="Intermediate Event (sequence flow)"></FROM>
+<TO instance="End Event-83248" class="End Event"></TO>
+<ATTRIBUTE name="Transition condition" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Transition probability" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualized values" type="ENUMERATION">Denomination</ATTRIBUTE>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 0 index:10</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">4</ATTRIBUTE>
+<ATTRIBUTE name="Representation" type="ENUMERATION">above/below</ATTRIBUTE>
+<ATTRIBUTE name="Font colour" type="ENUMERATION">black</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Info zur Übergangsbedingung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Nachfolger</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Denomination" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Description" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Auditing" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Monitoring" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Default" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Immediate" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Category" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16467&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Color" type="STRING">black</ATTRIBUTE>
+<ATTRIBUTE name="Doku" type="STRING">NOTEBOOK
+
+#-----------------------
+LANG &quot;en&quot;
+#-----------------------
+CHAPTER &quot;Description&quot;
+ATTR &quot;Denomination&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+
+
+CHAPTER &quot;Details (BPMN)&quot;
+
+ATTR &quot;Auditing&quot; 
+ATTR &quot;Monitoring&quot; 
+
+ATTR &quot;Default&quot; 
+ATTR &quot;Immediate&quot; 
+ATTR &quot;Category&quot;
+ATTR &quot;Id&quot; 
+
+
+CHAPTER &quot;Details (Simulation)&quot;
+
+ATTR &quot;Transition condition&quot; dialog:transcond
+
+ATTR &quot;Transition probability&quot;
+
+</ATTRIBUTE>
+<ATTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;End Event&quot;</ATTRIBUTE>
+<ATTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Intermediate Event (sequence flow)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="ModelTypeExp" type="EXPRESSION">EXPR val:&quot;Business process diagram (BPMN 2.0)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16468" class="Is inside">
+<FROM instance="End Event-83248" class="End Event"></FROM>
+<TO instance="Monti Azzurri Consorsium" class="Pool"></TO>
+<ATTRIBUTE name="AutoConnect" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16469" class="Message Flow">
+<FROM instance="Service Conforence" class="Pool (collapsed)"></FROM>
+<TO instance="Receive Confirmation" class="Intermediate Event (sequence flow)"></TO>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 1 x1:18cm y1:6cm index:13</ATTRIBUTE>
+<ATTRIBUTE name="Message Name" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="ParticipantType (from)" type="ENUMERATION">Role</ATTRIBUTE>
+<ATTRIBUTE name="Role (from)" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Entity (from)" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="ParticipantType (to)" type="ENUMERATION">Role</ATTRIBUTE>
+<ATTRIBUTE name="Role (to)" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Entity (to)" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Name" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Message Properties" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;Intermediate Event (sequence flow)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Pool (collapsed)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Number" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Show Name" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Show Number" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Representation" type="ENUMERATION">above/below</ATTRIBUTE>
+<ATTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Description" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Show name" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Doku" type="STRING">NOTEBOOK
+
+#-----------------------
+CHAPTER &quot;Description&quot;
+#-----------------------
+ATTR &quot;Name&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+ATTR &quot;Id&quot; </ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16469&quot;</ATTRIBUTE>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+</CONNECTOR>
+</MODEL>
+<MODEL id="mod.16350" name="TitoloUnico_MontiAzzurrSUB_3" version="" modeltype="Business process diagram (BPMN 2.0)" libtype="bp" applib="LearnPAd Prototype Dynamic Library 0.21">
+<MODELATTRIBUTES>
+<ATTRIBUTE name="Contact person" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Keywords" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Copyright info" type="STRING">Edit the model attributes to display your copyright info</ATTRIBUTE>
+<ATTRIBUTE name="Copyright info position" type="ENUMERATION">Bottom right</ATTRIBUTE>
+<ATTRIBUTE name="Name" type="STRING">TitoloUnico_MontiAzzurrSUB_3</ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;86524&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Process type" type="ENUMERATION">None</ATTRIBUTE>
+<ATTRIBUTE name="Executable" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Closed" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Auditing" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Monitoring" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Model type" type="ENUMERATION">Current model</ATTRIBUTE>
+<ATTRIBUTE name="State" type="ENUMERATION">In process</ATTRIBUTE>
+<ATTRIBUTE name="Reviewed on" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Reviewed by" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Author" type="STRING">barbara</ATTRIBUTE>
+<ATTRIBUTE name="Creation date" type="STRING">11.08.2015, 15:15</ATTRIBUTE>
+<ATTRIBUTE name="Last user" type="STRING">barbara</ATTRIBUTE>
+<ATTRIBUTE name="Date last changed" type="STRING">20.08.2015, 15:12:47</ATTRIBUTE>
+<ATTRIBUTE name="Number of objects and relations" type="INTEGER">55</ATTRIBUTE>
+<ATTRIBUTE name="Context of version" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Action" type="ENUMERATION">Fill in</ATTRIBUTE>
+<ATTRIBUTE name="People-like view" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="BAR Display active" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Modelling direction" type="ENUMERATION">vertical</ATTRIBUTE>
+<ATTRIBUTE name="Modelling_size" type="ENUMERATION">3</ATTRIBUTE>
+<ATTRIBUTE name="Responsible for execution_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Responsible for execution_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="Responsible for execution_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="Accountable for approving results_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Accountable for approving results_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="Accountable for approving results_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="Cooperation/participation_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Cooperation/participation_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="Cooperation/participation_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="To inform_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="To inform_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="To inform_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="Knowledge Product_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Knowledge Product_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="Knowledge Product_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="Documents and Resources_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Documents and Resources_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="Documents and Resources_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="Incoming Data Object_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Incoming Data Object_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="Incoming Data Object_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="Outgoing Data Object_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Outgoing Data Object_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="Outgoing Data Object_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="Description_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Description_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="Description_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="Comment Mode" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="CommentAreaSize" type="ENUMERATION">2</ATTRIBUTE>
+<ATTRIBUTE name="CommentModellingAreaSize" type="ENUMERATION">3</ATTRIBUTE>
+<ATTRIBUTE name="CommentModellingDirection" type="ENUMERATION">vertical</ATTRIBUTE>
+<RECORD name="Change history"></RECORD>
+<ATTRIBUTE name="Position" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-01] Internal error!  \&quot;fontcolor\&quot; (BPModel)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<RECORD name="Technical Attributes"></RECORD>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Keine Modellbezeichnung vergeben</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Pool Term" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="ParticipantType" type="ENUMERATION">Role</ATTRIBUTE>
+<ATTRIBUTE name="Role" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Entity" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="BoundaryVisible" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="BPD Model Attributes" type="STRING">NOTEBOOK
+
+CHAPTER &quot;Business Process Diagram Attributes&quot;
+ATTR &quot;Name&quot; write-protected
+ATTR &quot;Contact person&quot;
+ATTR &quot;Author&quot; write-protected
+ATTR &quot;Language (BPMN)&quot;
+ATTR &quot;ExpressionLanguage&quot;
+ATTR &quot;QueryLanguage&quot;
+ATTR &quot;Creation date&quot; write-protected
+ATTR &quot;Date last changed&quot; write-protected
+ATTR &quot;Documentation (Model)&quot;
+ATTR &quot;State&quot;
+
+GROUP &quot;Copyright&quot;
+ATTR &quot;Copyright info&quot; 
+ATTR &quot;Copyright info position&quot; 
+ENDGROUP
+
+CHAPTER &quot;Process Attributes&quot;
+ATTR &quot;Name&quot; write-protected
+ATTR &quot;Process Term&quot;
+ATTR &quot;ProcessType&quot;
+ATTR &quot;Status&quot;
+ATTR &quot;Assignments&quot; lines:5
+ATTR &quot;Properties (BPMN)&quot; lines:5
+ATTR &quot;AdHoc&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+GROUP &quot;AdHoc = True&quot;
+ATTR &quot;AdHocOrdering&quot;
+ATTR &quot;AdHocCompletionCondition&quot;
+ENDGROUP
+ATTR &quot;SuppressJoinFailure&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ATTR &quot;EnableInstanceCompensation&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ATTR &quot;Categories (Process)&quot;
+ATTR &quot;Documentation (Process)&quot;
+
+CHAPTER &quot;Pool Attributes&quot;
+GROUP &quot;Common Graphical Object Attributes&quot;
+ATTR &quot;Name&quot; write-protected
+ATTR &quot;Categories (Pool)&quot;
+ATTR &quot;Documentation (Pool)&quot;
+ENDGROUP
+GROUP &quot;Common Swimlane Attributes&quot;
+ATTR &quot;Pool Term&quot;
+ENDGROUP
+GROUP &quot;Pool Attributes&quot;
+ATTR &quot;ParticipantType&quot;
+ATTR &quot;Role&quot;
+ATTR &quot;Entity&quot;
+ATTR &quot;BoundaryVisible&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot; write-protected
+ENDGROUP</ATTRIBUTE>
+<ATTRIBUTE name="Language" type="ENUMERATION">System</ATTRIBUTE>
+<ATTRIBUTE name="ExpressionLanguage" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="QueryLanguage" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Process Term" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="BPD Term" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="ProcessType" type="ENUMERATION">None</ATTRIBUTE>
+<ATTRIBUTE name="Status" type="ENUMERATION">None</ATTRIBUTE>
+<RECORD name="Assignments"></RECORD>
+<ATTRIBUTE name="AdHoc" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="AdHocOrdering" type="ENUMERATION">None</ATTRIBUTE>
+<ATTRIBUTE name="AdHocCompletionCondition" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="EnableInstanceCompensation" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Categories (Process)" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation (Process)" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation (Pool)" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Categories (Pool)" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="SuppressJoinFailure" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="RACI/DEMI visualisation" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="IT systems" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Responsible role" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Input/Output" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Products" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Use cases" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Products color" type="STRING">whitesmoke</ATTRIBUTE>
+<ATTRIBUTE name="RACI/DEMI color" type="STRING">whitesmoke</ATTRIBUTE>
+<ATTRIBUTE name="Responsible role color" type="STRING">whitesmoke</ATTRIBUTE>
+<ATTRIBUTE name="Input/Output color" type="STRING">whitesmoke</ATTRIBUTE>
+<ATTRIBUTE name="Use cases color" type="STRING">whitesmoke</ATTRIBUTE>
+<ATTRIBUTE name="IT systems color" type="STRING">whitesmoke</ATTRIBUTE>
+<ATTRIBUTE name="_ToggleModelInfo_" type="PROGRAMCALL">ITEM &quot;_ToggleModelInfo_&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Display modelling information" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Documentation (Model)" type="STRING"></ATTRIBUTE>
+<RECORD name="Properties (BPMN)"></RECORD>
+<ATTRIBUTE name="CreationDate" type="EXPRESSION">EXPR val:&quot;11.08.2015, 15:15&quot;</ATTRIBUTE>
+<ATTRIBUTE name="ModificationDate" type="EXPRESSION">EXPR val:&quot;20.08.2015, 15:00:51&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Language (BPMN)" type="STRING">English</ATTRIBUTE>
+<ATTRIBUTE name="BPMN20 Model Attributes" type="LONGSTRING">NOTEBOOK
+# TODO AVAL sMfbRegistration:&quot;_MFB-Registration_&quot;
+CHAPTER &quot;Description&quot;
+ATTR &quot;Contact person&quot;
+ATTR &quot;Keywords&quot; lines:2
+ATTR &quot;Description&quot; lines:3
+ATTR &quot;Comment&quot; lines:3
+
+GROUP &quot;Copyright&quot;
+ATTR &quot;Copyright info&quot; 
+ATTR &quot;Copyright info position&quot; 
+ENDGROUP
+ATTR &quot;Name&quot; write-protected
+ATTR &quot;Id&quot; write-protected
+
+
+
+#---------------------------------------------
+CHAPTER &quot;Process properties&quot;
+#---------------------------------------------
+GROUP &quot;Process attributes&quot;
+ATTR &quot;Process type&quot; #None, Private, Public 
+ATTR &quot;Executable&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ATTR &quot;Closed&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ENDGROUP
+
+GROUP &quot;Process relevance&quot;
+ATTR &quot;Auditing&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ATTR &quot;Monitoring&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ENDGROUP
+
+CHAPTER &quot;User attributes&quot;
+ATTR &quot;Model type&quot;
+ATTR &quot;State&quot;
+ATTR &quot;Reviewed on&quot;
+ATTR &quot;Reviewed by&quot;
+
+CHAPTER &quot;System attributes&quot;
+ATTR &quot;Author&quot; write-protected
+ATTR &quot;Creation date&quot; write-protected
+ATTR &quot;Last user&quot; write-protected
+# ATTR &quot;Date last changed from&quot; write-protected
+ATTR &quot;Date last changed&quot; write-protected
+ATTR &quot;Number of objects and relations&quot; write-protected
+ATTR &quot;Context of version&quot; write-protected
+
+CHAPTER &quot;People-like view&quot;
+ATTR &quot;Action&quot;
+ATTR &quot;People-like view&quot;
+
+CHAPTER &quot;BAR Display&quot;
+ATTR &quot;BAR Display active&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot;
+AVAL s_Aktiv: &quot;BAR Display active&quot;
+ATTR &quot;Modelling direction&quot; ctrltype: radio enabled: (s_Aktiv = &quot;Yes&quot;)
+ATTR &quot;Modelling_size&quot;
+
+GROUP &quot;Responsible for execution&quot;
+ATTR &quot;Responsible for execution_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_Responsible_for_execution_display: &quot;Responsible for execution_display&quot;
+ATTR &quot;Responsible for execution_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_Responsible_for_execution_display = &quot;Yes&quot;))
+ATTR &quot;Responsible for execution_size&quot;
+ENDGROUP
+
+GROUP &quot;Accountable for approving results&quot;
+ATTR &quot;Accountable for approving results_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_Accountableforapprovingresults_display: &quot;Actor_display&quot;
+ATTR &quot;Accountable for approving results_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_Accountableforapprovingresults_display = &quot;Yes&quot;))
+ATTR &quot;Accountable for approving results_size&quot;
+ENDGROUP
+
+GROUP &quot;Cooperation/participation&quot;
+ATTR &quot;Cooperation/participation_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_Cooperationparticipation_display: &quot;Cooperation/participation_display&quot;
+ATTR &quot;Cooperation/participation_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_Cooperationparticipation_display = &quot;Yes&quot;))
+ATTR &quot;Cooperation/participation_size&quot;
+ENDGROUP
+
+GROUP &quot;To inform&quot;
+ATTR &quot;To inform_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_Toinform_display: &quot;To inform_display&quot;
+ATTR &quot;To inform_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_Toinform_display = &quot;Yes&quot;))
+ATTR &quot;To inform_size&quot;
+ENDGROUP
+
+GROUP &quot;Knowledge Product&quot;
+ATTR &quot;Knowledge Product_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_KnowledgeProduct_display: &quot;Knowledge Product_display&quot;
+ATTR &quot;Knowledge Product_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_KnowledgeProduct_display = &quot;Yes&quot;))
+ATTR &quot;Knowledge Product_size&quot;
+ENDGROUP
+
+GROUP &quot;Documents and Resources&quot;
+ATTR &quot;Documents and Resources_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_DocumentsandResources_display: &quot;Documents and Resources_display&quot;
+ATTR &quot;Documents and Resources_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_DocumentsandResources_display = &quot;Yes&quot;))
+ATTR &quot;Documents and Resources_size&quot;
+ENDGROUP
+
+GROUP &quot;Incoming Data Object&quot;
+ATTR &quot;Incoming Data Object_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_IncomingDataObject_display: &quot;Incoming Data Object_display&quot;
+ATTR &quot;Incoming Data Object_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_IncomingDataObject_display = &quot;Yes&quot;))
+ATTR &quot;Incoming Data Object_size&quot;
+ENDGROUP
+
+GROUP &quot;Outgoing Data Object&quot;
+ATTR &quot;Outgoing Data Object_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_OutgoingDataObject_display: &quot;Outgoing Data Object_display&quot;
+ATTR &quot;Outgoing Data Object_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_OutgoingDataObject_display = &quot;Yes&quot;))
+ATTR &quot;Outgoing Data Object_size&quot;
+ENDGROUP
+
+GROUP &quot;Description&quot;
+ATTR &quot;Description_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_Description_display: &quot;Description_display&quot;
+ATTR &quot;Description_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_Description_display = &quot;Yes&quot;))
+ATTR &quot;Description_size&quot;
+ENDGROUP
+
+CHAPTER &quot;Comment View&quot;
+ATTR &quot;Comment Mode&quot; ctrltype: check checked-value: &quot;No&quot; unchecked-value: &quot;Yes&quot;
+AVAL s_Aktiv: &quot;Comment Mode&quot;
+ATTR &quot;CommentAreaSize&quot;
+ATTR &quot;CommentModellingAreaSize&quot;
+ATTR &quot;CommentModellingDirection&quot;
+
+
+
+
+CHAPTER &quot;Change history&quot;
+ATTR &quot;Change history&quot; lines:30
+
+</ATTRIBUTE>
+<ATTRIBUTE name="_GoToAceHp_" type="PROGRAMCALL">ITEM &quot;_GoToAceHp_&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="__GfxThumb__" type="LONGSTRING">iVBORw0KGgoAAAANSUhEUgAAAQAAAAC4CAIAAACD/qWdAAAACXBIWXMAAAsTAAALEwEAmpwYAAAR7UlEQVR4nO2df3AT55nHvwsu/YfOpTnSpJAATVYKGLd3+dG0rKBk0nDJSg5xUyymucspUzKrOXqZNWEUYM53HVp3EtcpSMmUudWE3DmTDrXsSx2IVnRoksmlko+kOa4MKFOvakJyMEwHKH9cAs5Yeu+PldeyLRtLWv1Yv8/nD5As6dUj7ff7vs++++p9hPPnzx87dgxEBVy9etXv99c7CqIcmo4dO/a1r/3V5xd9rn9g4PLly4IgNDU1LV68WH5QblrUNPLHkfvWr5+9iTPnzgJYsXRZVQN98513br31VgArl5X/RrY0YvLh2bPmjRMnTlTYFFFHmgB8+uknyeTx+++/v/CBof8auv322+9b/+VMJhPfutf99lPDG7amd2/Gph3RtWulIeCJNS1YHdr/pJiXfiayoTm9+xA2PdOc3p1ufubk2qHU0Npwend66zMnh4ZSAADpZz9r2fFB22dPDW/YigO7083PNKcPYO/eNIBTp7B7dxtE+UExsW2R90UzkLXh9AFs3et+e/+fjh+/544vRDYs6hhaK60dSg2tVQ5txqYdUTyhf7ZfRiayYWtszebe/XJ8Q3PHkPl2h/wfGL79cnxbwrf/yfvWr3/XbGTbtvSpU80HDmDr1hjgP3AAe/emTwGbgYFTzQfeVkUkXtg2OIC2t/fjhW2DH6wO7Xf1LDrU9tl+vPCC68knxWXL0sZw7Q4UUR2E1157bdmypWfPnrt8+fKiRYvMv2az2euvv37lypUAVovi7E18kMnM5WkVYr5LhW9kSyNWU598+gmAc2fPUQrkXJoAnD17bvny5YyxhQsXCoIgCMLChQtvu+22dDp9xx13fHz+/OxNGIYBYPHixVUNdPHixcePH6/wjWxpxMT81ITTERhjsVis3mE4HhoBHIrAGKt3DARRN5rqHQBB1BMyAME1ZIB5giAI1m1Ka+dOUzQarXcMREUEg0FN0wCY/wKgY1oCmqYxwoEAmHI3LAGQFD2sQNGZEZYAKDpjjOmKJEmQpPxfjLAkSUrYYLqSfwKnaJomaJqmKEpdPUjMkQwSgCwCEISp03fT/0Jck2g0SucAjkEQXBjP74tqPRL0xKKAlIJf98e6YoC/1x8LoDfpi3sCMQBIpVJS2OhFIIBef8wVg9TSmQy5MqIoJoLCYBvT5Np+qLpDI0CjM8eunUaAMqARoNEhWVcbMkDDYU5ozpLqzETQEwSi0RQgKUpLc0jzGYn4oDcGvVeTxUQk4lLdPcHh5pNpdzLkyiAecHWkJJ0leUt7CqEUaJ5AY0UZUApUIzKJSHw4nUZbyAcjDvhkWcwkEsZwVxd6k6qYSSQMDMOluowEZBkRTwC9SbW6C8wJAHQdYL4AICxJkiQpum4YYQnjM/2KzpiuQAob5r+MmdcBJElSJAkAFJ3pCiRJ4u6aAF0HmD9QClQGlAIRvEMGmD9EPEKHOQUEtCU1GZmIx9WRksJGZzowHEqqIhJBoeukAkThN3rRE4hFUykoOjMnhXrcSboQRjgTSoHKgFKgeUUiKHjzy0DN9Q497mQIifigtyMqSVIKUPy9mi8ejPs0mmHKQyPAPIFGgDKgEYDgHTLA/MH6URgNBXOHDDBPINGXRxPoF3QEx9DGWLVjy5YtfX199j6TqBCaOqgRhYuc7X0yUQl0DtCIkPRrBo0ABNfQCNDQ0OWtakPfb9UhETcydGwIrqEUyAHQGFI96JutLnZplzxQJehrrSKk2saHjpBjIDtVA/pOnQR5wHboC60KpFSnQMeJ4BqaBnUeNLzYCH2V9kMCdRA0AtgMqd9Z0NFyKuQ0W6AvkeAaSoFsg7pkJ0LHzNmQ6ypEsKorEw7FKpRNlEETgPK2RoxGo7SnokUde2I6CmVDWyPaQ93zkLoH4FzIADZQd/ExxsgD5UEGmCeY6icblAoZoFIaR3PW5rjE3CEDVETjqB/jiVC9o3AYZIAiCBv7K3kyO9puazilBHB/rKTgaxxqA+J4AwwMrMnlfuj3++1qUNjY//t9ay5cuJhj+OL1f7lCbM7mkGXI5pDNYazgdjaHMcas21mGsRyyOQgb+2smrEee/o9zr9zLGC5c+vMtX3HnI5wcz5SwxwoerWWojUndDNDdnR+sd+4sP4UYGFjz0ENPHz68JxaDjR547G8fvfHGLzHGLly4dOQ/359Z/Ziu/mzOrijmxJZ7Fv7Pf/9uwYIF//fJJ0tXuEtSf41DtRdb9IO6GMAMfceOdxm7Alwx75bxMUz1A6OtrcHXX7fTA72/+OXFi5dyDH9x3Rct6byxXXjiZemv725RDrW9sXTwWx9r3yimtmxtzwj63h2LbPcwhouX/jweQ+bFB1w/fg+4O6wfdr/0Ze/AXeFXf+V+efmgZ0T7ev28ahemYJ566m3gCmPl68ekPiOApX7GrmzffnDfvu+V2oKl/sOHI62tj9sb3srbVt38FUzJfNY9x079NH/36x/LRft+8/m15FfH2YHrbsjmsOgLN4zHID6ms0fHw979v+zpHLI57BiRp48MDsVSP3C1o+OlcPj7ZTdVawN0dwuF6geuMnZFVX/e3S3MbmJBEPr6+sw+3lI/Y1cBMDbq830nHq9oEChsf2xCzZmRP+LoPwT01S3BbaGRfwwcYakTkL76fsvjp0NLTxu/uK/rlqOdS0/Ld67Lq78GqjKneqxoxxObxNMbBxmiB98D7lbaVzX/fbf735Z1sd7epzfg4COBkR90+lfgzGn5rnUTeZEjKDw03d1CofoZu8LYFVV97pr6mYk6jABT1G/eNR+afRZvy5YtZumUhx/O9/3m3+Pxg16v1+v9tq7vEYQtZQdmtV/Q94vLVuCxeNLsUL8xmGwvzPuXi+qwnM0hu2xC/eYIUIPpSDNaAG/G+zwP+LM5ueuIPJbT/qUg79/1kWzefiSWNPv+JcsmnRXUJtTKsQ4NgOniYexK2S3XJQWa8QPMsV7T4cM/bW0NtrY+ztioqX5gVNffyOV+aEthoVLPegvVb3arNS48Nfez3imP1j7Uyikmnqtlt1ZrA+zcybq7he3bDxZ+gOef/2dr/JpbDuMfGFgDwOf7TqH65/zy2RA29n/0N+Wr3zoHsHFWavZoz8Tay1P/WG1DtQl/d7fQ0fFSofqff/4nDjsJ3rfve6r6c0v9ZbSwefOpWCwWj+/xer9to/pNZlZ/5qPTxpnT8l3rZ1R/7adWZtB35sxp48yIfPe3ZvOGQwmHv6+qz1nqr6SpOhjANGvl87h+v98cCuxVPzBL3y/etFxccvNs6q/91MoM+hZvukW84eZrjAxOxNLPrl3o6+tz3nUAkwrjtmhvT/f12al+drS9pNUERVuwK5i5vFcl0bKj7UUrUvb3T1vfwVhDZUo7d7Jdu2w4fXf8UohqULmCa7lIrsJozSV00wNub2/v7+9vb28H0N/fLwhCLBZrHA/YNXlVoQESkchgrCOKsJFURSCTSBgAAJcsI5EwgGFAleVEUBhsY5psQ8COoaEWis5OYZxW2OYgUDgUNJoHbKFCA8iqKquq9YtsUZbFicdkETA1L2uMK/EXWZnc+EmFyXTTmoMAin2EOmLX2m9KgaqFpSSrT23wpGIKhdHOY8gAVcdygpVUmKoyFdbgHqh3CFWHDFAHCtPrBh8H5j1kgNpRNKloqMSaQ8gANYWHpMJZkAGI4nAyNJEBqo6DLghYtLe3O2uJaNmQAaqO49Rvwsl5ORmgKsxxgU1Dkol4AulOP7zpNhYa9rg6UpKid4ZcrnhP3Kep4rVbcBJkgKpQ9HqqQ5IKUU0mAYABgJxk6vgDqqbO9BrnQgawjaK9fiHOSSoyEY8r5tf9MW9HCoCis9Cwp8ednIerucgANmCe5haTfiaTQTwQiLW0dIZCw4FADKkUJCnV0sk0BAVvFIrONDkT8QTQm2yY9EJUzY5fnej+5eT8rMFhGiCTCAa6mv2dwGA6jea2NrdLlkUzHYS/RXUjgzbD5XJBFMVMIoHCRW+cM+skjyiKUJNJU0by+I08GmN5UY1nHUTNMQ0gyloyv25z0qMTB0YExiUvyvNvICwdS/cOneQhTCgFKofSp/YziYQx3NUVQyqVkiQJ/t7OtGuwTYcsz8/UwimQAUqggl5flGVRluVJKRBnv5FoTPLnAJlMPN6DNNAW8g0HXGl/uNmtqrI5JdwZggsyEDF63ND4S4Bsz3aceG14vpI/BxDFid91yUnr2Ew+OVNFDkdrEuv8hlKg4lT1HJcc1ThUZIBoNGpXHBVibyRm6enG+XTELFR4mCoyQCOUaA4Gg3ZFYl3KrfbnorTKFio/9FQoexIkSg7h3QDXXMBTDchpjYOzDVD5zjCkRc5xtgHKpr5ZeF2GHaIozjZAqduDNc4CnroHQJg4wABz2f14pueYG8daJqml7GYL+1rlrDmv3VtLGt0Awsb+s6/cCyzIMYxlc4uvu2HKZvxZxn7/VuzEy+1Fi7gIG/vxG3/tu1thY//VRPssNQRmrz1D9atrRqMbAMBvfn1k/fp1CxYseOvNt7ybH58uo9Xr/TOVMEIpvb69RefLVr9zC7c4EQcYYOHChR9++CEAQRCqV7R9YGDNQw/tsrHofNnqJwPUEgcYwHPvRggLcjksvbWlJBnNvQSQqX5gtLV12+uv7xkY2FP5UFC2+h1aucihOMAAVt7/uQkZZf7d63r2dwCAu8IDr/re2RX/Zpd605yLtk8ru70LGGVsFBj1+f4OGC2j7PaU+tVlq59GgFriAAMUk5H46CG2pUBG3+1Si5YuxcwXywrKbk+o3/wXGPV6Hyiv7HZh/ep1D/qzOWRzmRcfdP3kPeVfz4dGWgMs3JtVXXvfB+4MH+z3/faf4vf8SL1xzmET9uIEA0yoPzMygrd+EDiyCrlXUifukr76PtidKfjCK38cG7kD659NbrplatH2ooWgC8qO4/DhZ1tbtxWqn7FRXf91qWW3Td33FbzGKtj4WJxZtebHGLKvsu+OK77tR+oU084SNlGI+YVXiBMMMNH3izevwKOHkltyGHtmcgrxWBEZWcn09EzG7/cX7MrvHxhYY2Y+heov+kIgEwkGYtGWThYaDk7aKc1s07whbOz/qL+91MznmmEThdTdAH+KeIRYS9jf5nMjDvhcMOKAG3CZP6HMGD2uwTYWQr5ynknJZfPKltHsyfQ0ec1F/QBEVUuav56Tp+2UVviSKoVN2EslBviSOrFvnvm/OEkRopivjTdpE6GSy+aVLaO5K2nz5lMDA2u83geupf4SqEHYROU4IQUqV0YlFW03PWBj0fnahE1USKMboPJK6LM+ngh6hkNJd49nEIhGU4BbN/7QGQlGKtwGucphE7bR6AZAddWQ3xFPS8qAZu15Ycs2yCRiR+AAAxBE9eDZAJmIx9WRAiRJSgFKSwuAkyfR2dk8OOzTVCMScakNs2EzUR14NoBYMIs1GVkGIKrzsB4EMQWeDUAQZIACClfIEZxABpjA/IWxLRfYiRrQV9JSrRkgA0yClqA5i8qHazLAVCgFmoY5Xaboc1u75SzIAMQ1mXm6zPmQAQiuIQMQXCNoGodlXwgij0DzHgTPUKUGgmvoHIDgGjIAwTVkAIJryAAE15ABCK4hAxBcQwYguIYMQHANGYDgGjIAwTVkAIJryAAE15ABCK4hAxBcQwYguIYMQHANGYDgGjIAwTVkAIJryAAE15ABCK4hAxBcQwYguIYMQHANGYDgGjIAwTVkAIJryAAE15ABCK4hAxBcQwYguIYMQHANGYDgGjIAwTVkAIJryAAE15ABCK4hAxBcQwYguIYMQHANGYDgGjIAwTVkAIJryAAE15ABCK4hAxBcQwYguIYMQPANI4hqYYQlAJDCBmOGruthSZIkRWdGWIIUNu9KkiSFDSMsSYqu67oeDisKzOfpYUmSlLCRf62iW21KiiIBsFqzGtIZM8KKokz8xWrNYExXMP6cfGtMYIzV2YIEUT8oBSK4hgxAOJ1LEc9LHaklknQhlVqi6Kvg/W0Uq3TWKuNSxHMo1rKqV3PHPS91pABACj/sT1/0ae54cFjVvkkpEME1NAIQXEMGILiGDEDMJ8zzAcDM9WOvdaRW6ez2QSF5UlnSArSFbh90JaFv0uSLQeEPGmulcwCCa/4fLqZUDDFfaz0AAAAASUVORK5CYII=</ATTRIBUTE>
+<ATTRIBUTE name="NT Model Attributes" type="LONGSTRING">NOTEBOOK
+CHAPTER &quot;Description&quot;
+#ATTR &quot;Shared&quot;
+ATTR &quot;Model state&quot; enabled:(cond(search (sMfbRegistration, &quot;MFB_VERS&quot;, 0) = -1, 1, 0))
+ATTR &quot;Description&quot;
+ATTR &quot;Show State&quot; ctrltype:check unchecked-value:&quot;No&quot; checked-value:&quot;Yes&quot; 
+ATTR &quot;Last user&quot; write-protected
+ATTR &quot;Date last changed&quot; write-protected
+#CHAPTER &quot;Suggestion for improvement&quot;
+#ATTR &quot;Suggestion for improvement&quot;
+</ATTRIBUTE>
+<ATTRIBUTE name="Model state" type="ENUMERATION">Draft</ATTRIBUTE>
+<ATTRIBUTE name="Keywords" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Description" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Model type" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Show State" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Actor_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="Actor_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Actor_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="ModelingAreaSize" type="ENUMERATION">20</ATTRIBUTE>
+<ATTRIBUTE name="DrawingAreaWidth" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="DrawingAreaHeight" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Reference overview settings" type="LONGSTRING">Responsible for execution|Responsible for execution
+Accountable for approving results|Accountable for approving results
+Cooperation/participation|Cooperation/participation
+To inform|To inform
+Modelling|Modelling
+Knowledge Product|Knowledge Product
+Documents and Resources|Documents and Resources
+#Data Object|Data Object
+Incoming Data Object|Incoming Data Object
+Outgoing Data Object|Outgoing Data Object
+Description|Description</ATTRIBUTE>
+<ATTRIBUTE name="Data Object_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="Data Object_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Data Object_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="id_bpmndi_diagram" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="id_bpmndi_plane" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="id_bpmndi_collaboration" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="CommentTypeSize" type="ENUMERATION">8</ATTRIBUTE>
+<ATTRIBUTE name="CommentxCoorTextBox" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="CommentyCoorTextBox" type="STRING"></ATTRIBUTE>
+</MODELATTRIBUTES>
+<INSTANCE id="obj.16351" class="Pool (collapsed)" name="Third Party PA">
+<ATTRIBUTE name="Position" type="STRING">NODE x:20cm y:3cm w:40cm h:3cm index:1</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(&quot;&quot;) val:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<RECORD name="Technical Attributes"></RECORD>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="ParticipantType" type="ENUMERATION">Role</ATTRIBUTE>
+<ATTRIBUTE name="Role" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Entity" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="BoundaryVisible" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Process Term" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="ProcessType" type="ENUMERATION">None</ATTRIBUTE>
+<ATTRIBUTE name="Status" type="ENUMERATION">None</ATTRIBUTE>
+<RECORD name="Assignments"></RECORD>
+<RECORD name="Properties"></RECORD>
+<ATTRIBUTE name="AdHoc" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="AdHocOrdering" type="ENUMERATION">None</ATTRIBUTE>
+<ATTRIBUTE name="AdHocCompletionCondition" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="EnableInstanceCompensation" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Categories (Process)" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation (Process)" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="SuppressJoinFailure" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Open questions" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16351&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Color" type="STRING">white</ATTRIBUTE>
+<ATTRIBUTE name="Orientation" type="ENUMERATION">horizontal</ATTRIBUTE>
+<ATTRIBUTE name="Boundary visible" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Auditing" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Monitoring" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Process type" type="ENUMERATION">None</ATTRIBUTE>
+<ATTRIBUTE name="Executable" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Closed" type="ENUMERATION">No</ATTRIBUTE>
+<INTERREF name="Referenced Organizational Unit"></INTERREF>
+<INTERREF name="Referenced process"></INTERREF>
+<ATTRIBUTE name="Cardinality" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16354" class="Pool" name="Monti Azzurri Consorsium">
+<ATTRIBUTE name="Position" type="STRING">NODE x:0cm y:8cm w:40cm h:11.5cm index:2</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(&quot;&quot;) val:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<RECORD name="Technical Attributes"></RECORD>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="ParticipantType" type="ENUMERATION">Role</ATTRIBUTE>
+<ATTRIBUTE name="Role" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Entity" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="BoundaryVisible" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Process Term" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="ProcessType" type="ENUMERATION">None</ATTRIBUTE>
+<ATTRIBUTE name="Status" type="ENUMERATION">None</ATTRIBUTE>
+<RECORD name="Assignments"></RECORD>
+<RECORD name="Properties"></RECORD>
+<ATTRIBUTE name="AdHoc" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="AdHocOrdering" type="ENUMERATION">None</ATTRIBUTE>
+<ATTRIBUTE name="AdHocCompletionCondition" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="EnableInstanceCompensation" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Categories (Process)" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation (Process)" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="SuppressJoinFailure" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Open questions" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16354&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Color" type="STRING">white</ATTRIBUTE>
+<ATTRIBUTE name="Orientation" type="ENUMERATION">horizontal</ATTRIBUTE>
+<ATTRIBUTE name="Boundary visible" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Auditing" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Monitoring" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Process type" type="ENUMERATION">None</ATTRIBUTE>
+<ATTRIBUTE name="Executable" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Closed" type="ENUMERATION">No</ATTRIBUTE>
+<INTERREF name="Referenced Organizational Unit">
+<IREF type="objectreference" tmodeltype="Organizational structure" tmodelname="Org Model Monti Azzurri" tmodelver="" tclassname="Organizational unit" tobjname="Monti Azzurri"></IREF>
+</INTERREF>
+</INSTANCE>
+<INSTANCE id="obj.16357" class="Lane" name="SUAP Office">
+<ATTRIBUTE name="Position" type="STRING">NODE x:3cm y:8cm w:37cm h:6.5cm index:3</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(&quot;&quot;) val:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<RECORD name="Technical Attributes"></RECORD>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Open questions" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16357&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Color" type="STRING">white</ATTRIBUTE>
+<ATTRIBUTE name="Orientation" type="ENUMERATION">horizontal</ATTRIBUTE>
+<ATTRIBUTE name="Line break" type="ENUMERATION">No</ATTRIBUTE>
+<RECORD name="Properties"></RECORD>
+<ATTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Cardinality" type="STRING"></ATTRIBUTE>
+<INTERREF name="Referenced Organizational Unit">
+<IREF type="objectreference" tmodeltype="Organizational structure" tmodelname="Org Model Monti Azzurri" tmodelver="" tclassname="Organizational unit" tobjname="SUAP Office"></IREF>
+</INTERREF>
+<INTERREF name="Referenced Role"></INTERREF>
+<INTERREF name="Referenced Performer"></INTERREF>
+</INSTANCE>
+<INSTANCE id="obj.16360" class="Lane" name="Agriculture Office">
+<ATTRIBUTE name="Position" type="STRING">NODE x:3cm y:14.5cm w:37cm h:5cm index:4</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(&quot;&quot;) val:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<RECORD name="Technical Attributes"></RECORD>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Open questions" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16360&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Color" type="STRING">white</ATTRIBUTE>
+<ATTRIBUTE name="Orientation" type="ENUMERATION">horizontal</ATTRIBUTE>
+<ATTRIBUTE name="Line break" type="ENUMERATION">No</ATTRIBUTE>
+<RECORD name="Properties"></RECORD>
+<ATTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Cardinality" type="STRING"></ATTRIBUTE>
+<INTERREF name="Referenced Organizational Unit">
+<IREF type="objectreference" tmodeltype="Organizational structure" tmodelname="Org Model Monti Azzurri" tmodelver="" tclassname="Organizational unit" tobjname="Agriculture Office"></IREF>
+</INTERREF>
+<INTERREF name="Referenced Role"></INTERREF>
+<INTERREF name="Referenced Performer"></INTERREF>
+</INSTANCE>
+<INSTANCE id="obj.16363" class="Text Annotation" name="Text Annotation-83144">
+<ATTRIBUTE name="Position" type="STRING">NODE x:24cm y:1.5cm index:5</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-02] Attribute \&quot;Fontcolor\&quot; (Pool (collapsed)) does not exist!  \&quot;fontcolor\&quot; (Text Annotation)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<RECORD name="Technical Attributes"></RECORD>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Collection" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16363&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Text" type="STRING">here we could use semantic annotation to check for 1 -n third parties - e.g. based on which PA is involved in SUAP process</ATTRIBUTE>
+<ATTRIBUTE name="Cardinality" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Open questions" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16366" class="Start Event" name="Start Event-83148">
+<ATTRIBUTE name="Position" type="STRING">NODE x:6.5cm y:10cm index:7</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Process calendar" type="LONGSTRING">D@Working day@b@32400-43200@U900;1800@45000-59400@U900;1800@Free day@c@@@$cbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbcbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbcbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbcccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbccbbccb</ATTRIBUTE>
+<ATTRIBUTE name="Quantity" type="EXPRESSION">EXPR expr:(0) val:0</ATTRIBUTE>
+<ATTRIBUTE name="Time period" type="ENUMERATION">Per year</ATTRIBUTE>
+<ATTRIBUTE name="Abandon after tolerance waiting time" type="ENUMERATION">no</ATTRIBUTE>
+<ATTRIBUTE name="Tolerance waiting time" type="TIME">00:000:00:00:00</ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-02] Attribute \&quot;Fontcolor\&quot; (Lane) does not exist!  \&quot;fontcolor\&quot; (Start Event)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<RECORD name="Technical Attributes"></RECORD>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<INTERREF name="Actor"></INTERREF>
+<RECORD name="Assignments"></RECORD>
+<ATTRIBUTE name="Term" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Trigger" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Result" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Aggregated execution time" type="TIME">00:000:00:00:00</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated waiting time" type="TIME">00:000:00:00:00</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated resting time" type="TIME">00:000:00:00:00</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated transport time" type="TIME">00:000:00:00:00</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated cycle time" type="TIME">00:000:00:00:00</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Info on results" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Cost driver" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Cost driver quantity" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated personnel costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="External documentation" type="PROGRAMCALL">ITEM &quot;&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Prozeßstart</ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Open questions" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Modelling direction" type="EXPRESSION">EXPR val:&quot;vertical&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Implementing control" type="ENUMERATION">no</ATTRIBUTE>
+<ATTRIBUTE name="Show name" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16366&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Type" type="ENUMERATION">Top-level</ATTRIBUTE>
+<ATTRIBUTE name="Message" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Timer" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Conditional" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Signal" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Escalation" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Error" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Compensation" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Parallel" type="ENUMERATION">No</ATTRIBUTE>
+<RECORD name="Properties"></RECORD>
+<ATTRIBUTE name="Auditing" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Monitoring" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Collection" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Object type" type="ENUMERATION">Information</ATTRIBUTE>
+<ATTRIBUTE name="Cardinality" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Details" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Timer type" type="ENUMERATION">Date</ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16369" class="Task" name="Send Instance to Third Party">
+<ATTRIBUTE name="Position" type="STRING">NODE x:16cm y:10cm w:3.36cm h:1.8cm index:8</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Performer" type="EXPRESSION">EXPR expr:(&quot;&quot;) val:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Execution time" type="TIME">00:000:00:00:00</ATTRIBUTE>
+<ATTRIBUTE name="Waiting time" type="TIME">00:000:00:00:00</ATTRIBUTE>
+<ATTRIBUTE name="Resting time" type="TIME">00:000:00:00:00</ATTRIBUTE>
+<ATTRIBUTE name="Transport time" type="TIME">00:000:00:00:00</ATTRIBUTE>
+<ATTRIBUTE name="Priority" type="INTEGER">10</ATTRIBUTE>
+<ATTRIBUTE name="Done by" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Continuous execution" type="ENUMERATION">no</ATTRIBUTE>
+<ATTRIBUTE name="Max. resource waiting time" type="TIME">00:000:00:05:00</ATTRIBUTE>
+<ATTRIBUTE name="Cooperative" type="ENUMERATION">no</ATTRIBUTE>
+<ATTRIBUTE name="Cooperation mode" type="ENUMERATION">synchron</ATTRIBUTE>
+<ATTRIBUTE name="Average number of participants" type="INTEGER">1</ATTRIBUTE>
+<ATTRIBUTE name="Min. quota of presence" type="INTEGER">100</ATTRIBUTE>
+<ATTRIBUTE name="Max. start period" type="TIME">00:001:00:00:00</ATTRIBUTE>
+<ATTRIBUTE name="Execution interruptable" type="ENUMERATION">yes</ATTRIBUTE>
+<ATTRIBUTE name="Task stack" type="ENUMERATION">personal</ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-02] Attribute \&quot;Fontcolor\&quot; (Lane) does not exist!  \&quot;fontcolor\&quot; (Task)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<RECORD name="Technical Attributes"></RECORD>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<INTERREF name="Actor"></INTERREF>
+<RECORD name="Assignments"></RECORD>
+<ATTRIBUTE name="Term" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Status" type="ENUMERATION">None</ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="External documentation" type="PROGRAMCALL">ITEM &quot;&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Info on results" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Number" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated execution time" type="TIME">00:000:00:00:00</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated waiting time" type="TIME">00:000:00:00:00</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated resting time" type="TIME">00:000:00:00:00</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated transport time" type="TIME">00:000:00:00:00</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated personnel costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Classification" type="ENUMERATIONLIST"></ATTRIBUTE>
+<ATTRIBUTE name="EDP transaction costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="EDP batch costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Printing costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Postal costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Aktivität</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Open questions" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Type" type="ENUMERATION">Standard</ATTRIBUTE>
+<INTERREF name="referenced subprocess"></INTERREF>
+<ATTRIBUTE name="Display responsible role" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Subprocessname" type="EXPRESSION">EXPR val:&quot;Bezeichnung&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Modelling direction" type="EXPRESSION">EXPR val:&quot;vertical&quot;</ATTRIBUTE>
+<RECORD name="Properties"></RECORD>
+<ATTRIBUTE name="Show name" type="ENUMERATION">center</ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16369&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Task type" type="ENUMERATION">Send</ATTRIBUTE>
+<ATTRIBUTE name="Global task" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Auditing" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Monitoring" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="For compensation" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Loop type" type="ENUMERATION">Multi-instance</ATTRIBUTE>
+<INTERREF name="Call activity"></INTERREF>
+<ATTRIBUTE name="Sequential execution" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Cardinality" type="STRING"></ATTRIBUTE>
+<INTERREF name="Referenced data input"></INTERREF>
+<INTERREF name="Referenced data output"></INTERREF>
+<ATTRIBUTE name="Instantiate" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Collection" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Object type" type="ENUMERATION">Information</ATTRIBUTE>
+<ATTRIBUTE name="Completion condition" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Loop condition (standard)" type="STRING"></ATTRIBUTE>
+<INTERREF name="Referenced message"></INTERREF>
+<ATTRIBUTE name="People-like_view_Expression" type="EXPRESSION">EXPR expr:(maval(&quot;People-like view&quot;)) val:&quot;No&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Action" type="ENUMERATION">Fill in</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Actor_" type="EXPRESSION">EXPR expr:(maval(&quot;Actor_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Description_" type="EXPRESSION">EXPR expr:(maval(&quot;Description_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_Modelling_direction_" type="EXPRESSION">EXPR expr:(maval(&quot;Modelling direction&quot;)) val:&quot;vertical&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Modelling_" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="_REFERENCE_OVERVIEW_SETTINGS_" type="EXPRESSION">EXPR expr:(maval(&quot;Reference overview settings&quot;)) val:&quot;Responsible for execution|Responsible for execution\nAccountable for approving results|Accountable for approving results\nCooperation/participation|Cooperation/participation\nTo inform|To inform\nModelling|Modelling\nKnowledge Product|Knowledge Product\nDocuments and Resources|Documents and Resources\n#Data Object|Data Object\nIncoming Data Object|Incoming Data Object\nOutgoing Data Object|Outgoing Data Object\nDescription|Description&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Actor_" type="EXPRESSION">EXPR expr:(maval(&quot;Actor_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Description_" type="EXPRESSION">EXPR expr:(maval(&quot;Description_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Modelling_" type="EXPRESSION">EXPR expr:(maval(&quot;Modelling_size&quot;)) val:&quot;3&quot;</ATTRIBUTE>
+<ATTRIBUTE name="BoolBarDisplayActive" type="EXPRESSION">EXPR expr:(maval(&quot;BAR Display active&quot;)) val:&quot;No&quot;</ATTRIBUTE>
+<INTERREF name="Data Object"></INTERREF>
+<INTERREF name="Knowledge Product"></INTERREF>
+<INTERREF name="Documents and Resources"></INTERREF>
+<ATTRIBUTE name="_disp_Knowledge Product_" type="EXPRESSION">EXPR expr:(maval(&quot;Knowledge Product_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Data Object_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Documents and Resources_" type="EXPRESSION">EXPR expr:(maval(&quot;Documents and Resources_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Data Object_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Documents and Resources_" type="EXPRESSION">EXPR expr:(maval(&quot;Documents and Resources_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Knowledge Product_" type="EXPRESSION">EXPR expr:(maval(&quot;Knowledge Product_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Responsible for execution_" type="EXPRESSION">EXPR expr:(maval(&quot;Responsible for execution_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Responsible for execution_" type="EXPRESSION">EXPR expr:(maval(&quot;Responsible for execution_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Accountable for approving results_" type="EXPRESSION">EXPR expr:(maval(&quot;Accountable for approving results_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Accountable for approving results_" type="EXPRESSION">EXPR expr:(maval(&quot;Accountable for approving results_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Cooperation/participation_" type="EXPRESSION">EXPR expr:(maval(&quot;Cooperation/participation_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Cooperation/participation_" type="EXPRESSION">EXPR expr:(maval(&quot;Cooperation/participation_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_To inform_" type="EXPRESSION">EXPR expr:(maval(&quot;To inform_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_To inform_" type="EXPRESSION">EXPR expr:(maval(&quot;To inform_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<INTERREF name="Responsible for execution"></INTERREF>
+<INTERREF name="To inform"></INTERREF>
+<INTERREF name="Cooperation/participation"></INTERREF>
+<INTERREF name="Accountable for approving results"></INTERREF>
+<INTERREF name="Incoming Data Object"></INTERREF>
+<INTERREF name="Outgoing Data Object"></INTERREF>
+<ATTRIBUTE name="_size_Outgoing Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Outgoing Data Object_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Outgoing Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Outgoing Data Object_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Incoming Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Incoming Data Object_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Incoming Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Incoming Data Object_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Commentboxcomment" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="CommentAreaSizeExp" type="EXPRESSION">EXPR expr:(maval(&quot;CommentAreaSize&quot;)) val:&quot;2&quot;</ATTRIBUTE>
+<ATTRIBUTE name="CommentBool" type="ENUMERATION">0</ATTRIBUTE>
+<ATTRIBUTE name="CommentBox" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="CommentInfo" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="CommentMode" type="EXPRESSION">EXPR expr:(maval(&quot;Comment Mode&quot;)) val:&quot;No&quot;</ATTRIBUTE>
+<RECORD name="CommentTable"></RECORD>
+<ATTRIBUTE name="WriteComment" type="PROGRAMCALL">ITEM &quot;Add Comment&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="ClearComment" type="PROGRAMCALL">ITEM &quot;Clear Comment&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="CommentModellingAreaSizeExp" type="EXPRESSION">EXPR expr:(maval(&quot;CommentModellingAreaSize&quot;)) val:&quot;3&quot;</ATTRIBUTE>
+<ATTRIBUTE name="BoolCommentModeActive" type="EXPRESSION">EXPR expr:(maval(&quot;Comment Mode&quot;)) val:&quot;No&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Comment Model Direction" type="EXPRESSION">EXPR expr:(maval(&quot;CommentModellingDirection&quot;)) val:&quot;vertical&quot;</ATTRIBUTE>
+<INTERREF name="Decision"></INTERREF>
+<INTERREF name="Referenced documents"></INTERREF>
+<ATTRIBUTE name="Left border" type="EXPRESSION">EXPR
+ val:14.32</ATTRIBUTE>
+<INTERREF name="Referenced Planning Table"></INTERREF>
+<ATTRIBUTE name="Right border" type="EXPRESSION">EXPR
+ val:17.68</ATTRIBUTE>
+<ATTRIBUTE name="Show or Hide" type="ENUMERATION">Shown</ATTRIBUTE>
+<ATTRIBUTE name="Top border" type="EXPRESSION">EXPR
+ val:9.1</ATTRIBUTE>
+<ATTRIBUTE name="Bottom border" type="EXPRESSION">EXPR
+ val:10.9</ATTRIBUTE>
+<ATTRIBUTE name="X" type="EXPRESSION">EXPR
+ val:16</ATTRIBUTE>
+<ATTRIBUTE name="Y" type="EXPRESSION">EXPR
+ val:10</ATTRIBUTE>
+<ATTRIBUTE name="Change Visibility" type="PROGRAMCALL">ITEM &quot;Change Visibility&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Planning Table" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Bounding box" type="EXPRESSION">EXPR
+ val:&quot;[9.1,10.9,14.32,17.68,16,10]&quot;</ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16372" class="Task" name="Receive check of 3rd Party">
+<ATTRIBUTE name="Position" type="STRING">NODE x:25cm y:10cm w:3.36cm h:1.8cm index:9</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Performer" type="EXPRESSION">EXPR expr:(&quot;&quot;) val:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Execution time" type="TIME">00:000:00:00:00</ATTRIBUTE>
+<ATTRIBUTE name="Waiting time" type="TIME">00:000:00:00:00</ATTRIBUTE>
+<ATTRIBUTE name="Resting time" type="TIME">00:000:00:00:00</ATTRIBUTE>
+<ATTRIBUTE name="Transport time" type="TIME">00:000:00:00:00</ATTRIBUTE>
+<ATTRIBUTE name="Priority" type="INTEGER">10</ATTRIBUTE>
+<ATTRIBUTE name="Done by" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Continuous execution" type="ENUMERATION">no</ATTRIBUTE>
+<ATTRIBUTE name="Max. resource waiting time" type="TIME">00:000:00:05:00</ATTRIBUTE>
+<ATTRIBUTE name="Cooperative" type="ENUMERATION">no</ATTRIBUTE>
+<ATTRIBUTE name="Cooperation mode" type="ENUMERATION">synchron</ATTRIBUTE>
+<ATTRIBUTE name="Average number of participants" type="INTEGER">1</ATTRIBUTE>
+<ATTRIBUTE name="Min. quota of presence" type="INTEGER">100</ATTRIBUTE>
+<ATTRIBUTE name="Max. start period" type="TIME">00:001:00:00:00</ATTRIBUTE>
+<ATTRIBUTE name="Execution interruptable" type="ENUMERATION">yes</ATTRIBUTE>
+<ATTRIBUTE name="Task stack" type="ENUMERATION">personal</ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-02] Attribute \&quot;Fontcolor\&quot; (Lane) does not exist!  \&quot;fontcolor\&quot; (Task)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<RECORD name="Technical Attributes"></RECORD>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<INTERREF name="Actor"></INTERREF>
+<RECORD name="Assignments"></RECORD>
+<ATTRIBUTE name="Term" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Status" type="ENUMERATION">None</ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="External documentation" type="PROGRAMCALL">ITEM &quot;&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Info on results" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Number" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated execution time" type="TIME">00:000:00:00:00</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated waiting time" type="TIME">00:000:00:00:00</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated resting time" type="TIME">00:000:00:00:00</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated transport time" type="TIME">00:000:00:00:00</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated personnel costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Classification" type="ENUMERATIONLIST"></ATTRIBUTE>
+<ATTRIBUTE name="EDP transaction costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="EDP batch costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Printing costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Postal costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Aktivität</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Open questions" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Type" type="ENUMERATION">Standard</ATTRIBUTE>
+<INTERREF name="referenced subprocess"></INTERREF>
+<ATTRIBUTE name="Display responsible role" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Subprocessname" type="EXPRESSION">EXPR val:&quot;Bezeichnung&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Modelling direction" type="EXPRESSION">EXPR val:&quot;vertical&quot;</ATTRIBUTE>
+<RECORD name="Properties"></RECORD>
+<ATTRIBUTE name="Show name" type="ENUMERATION">center</ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16372&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Task type" type="ENUMERATION">Receive</ATTRIBUTE>
+<ATTRIBUTE name="Global task" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Auditing" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Monitoring" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="For compensation" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Loop type" type="ENUMERATION">Multi-instance</ATTRIBUTE>
+<INTERREF name="Call activity"></INTERREF>
+<ATTRIBUTE name="Sequential execution" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Cardinality" type="STRING"></ATTRIBUTE>
+<INTERREF name="Referenced data input"></INTERREF>
+<INTERREF name="Referenced data output"></INTERREF>
+<ATTRIBUTE name="Instantiate" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Collection" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Object type" type="ENUMERATION">Information</ATTRIBUTE>
+<ATTRIBUTE name="Completion condition" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Loop condition (standard)" type="STRING"></ATTRIBUTE>
+<INTERREF name="Referenced message"></INTERREF>
+<ATTRIBUTE name="People-like_view_Expression" type="EXPRESSION">EXPR expr:(maval(&quot;People-like view&quot;)) val:&quot;No&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Action" type="ENUMERATION">Fill in</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Actor_" type="EXPRESSION">EXPR expr:(maval(&quot;Actor_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Description_" type="EXPRESSION">EXPR expr:(maval(&quot;Description_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_Modelling_direction_" type="EXPRESSION">EXPR expr:(maval(&quot;Modelling direction&quot;)) val:&quot;vertical&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Modelling_" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="_REFERENCE_OVERVIEW_SETTINGS_" type="EXPRESSION">EXPR expr:(maval(&quot;Reference overview settings&quot;)) val:&quot;Responsible for execution|Responsible for execution\nAccountable for approving results|Accountable for approving results\nCooperation/participation|Cooperation/participation\nTo inform|To inform\nModelling|Modelling\nKnowledge Product|Knowledge Product\nDocuments and Resources|Documents and Resources\n#Data Object|Data Object\nIncoming Data Object|Incoming Data Object\nOutgoing Data Object|Outgoing Data Object\nDescription|Description&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Actor_" type="EXPRESSION">EXPR expr:(maval(&quot;Actor_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Description_" type="EXPRESSION">EXPR expr:(maval(&quot;Description_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Modelling_" type="EXPRESSION">EXPR expr:(maval(&quot;Modelling_size&quot;)) val:&quot;3&quot;</ATTRIBUTE>
+<ATTRIBUTE name="BoolBarDisplayActive" type="EXPRESSION">EXPR expr:(maval(&quot;BAR Display active&quot;)) val:&quot;No&quot;</ATTRIBUTE>
+<INTERREF name="Data Object"></INTERREF>
+<INTERREF name="Knowledge Product"></INTERREF>
+<INTERREF name="Documents and Resources"></INTERREF>
+<ATTRIBUTE name="_disp_Knowledge Product_" type="EXPRESSION">EXPR expr:(maval(&quot;Knowledge Product_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Data Object_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Documents and Resources_" type="EXPRESSION">EXPR expr:(maval(&quot;Documents and Resources_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Data Object_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Documents and Resources_" type="EXPRESSION">EXPR expr:(maval(&quot;Documents and Resources_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Knowledge Product_" type="EXPRESSION">EXPR expr:(maval(&quot;Knowledge Product_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Responsible for execution_" type="EXPRESSION">EXPR expr:(maval(&quot;Responsible for execution_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Responsible for execution_" type="EXPRESSION">EXPR expr:(maval(&quot;Responsible for execution_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Accountable for approving results_" type="EXPRESSION">EXPR expr:(maval(&quot;Accountable for approving results_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Accountable for approving results_" type="EXPRESSION">EXPR expr:(maval(&quot;Accountable for approving results_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Cooperation/participation_" type="EXPRESSION">EXPR expr:(maval(&quot;Cooperation/participation_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Cooperation/participation_" type="EXPRESSION">EXPR expr:(maval(&quot;Cooperation/participation_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_To inform_" type="EXPRESSION">EXPR expr:(maval(&quot;To inform_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_To inform_" type="EXPRESSION">EXPR expr:(maval(&quot;To inform_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<INTERREF name="Responsible for execution"></INTERREF>
+<INTERREF name="To inform"></INTERREF>
+<INTERREF name="Cooperation/participation"></INTERREF>
+<INTERREF name="Accountable for approving results"></INTERREF>
+<INTERREF name="Incoming Data Object"></INTERREF>
+<INTERREF name="Outgoing Data Object"></INTERREF>
+<ATTRIBUTE name="_size_Outgoing Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Outgoing Data Object_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Outgoing Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Outgoing Data Object_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Incoming Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Incoming Data Object_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Incoming Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Incoming Data Object_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Commentboxcomment" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="CommentAreaSizeExp" type="EXPRESSION">EXPR expr:(maval(&quot;CommentAreaSize&quot;)) val:&quot;2&quot;</ATTRIBUTE>
+<ATTRIBUTE name="CommentBool" type="ENUMERATION">0</ATTRIBUTE>
+<ATTRIBUTE name="CommentBox" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="CommentInfo" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="CommentMode" type="EXPRESSION">EXPR expr:(maval(&quot;Comment Mode&quot;)) val:&quot;No&quot;</ATTRIBUTE>
+<RECORD name="CommentTable"></RECORD>
+<ATTRIBUTE name="WriteComment" type="PROGRAMCALL">ITEM &quot;Add Comment&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="ClearComment" type="PROGRAMCALL">ITEM &quot;Clear Comment&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="CommentModellingAreaSizeExp" type="EXPRESSION">EXPR expr:(maval(&quot;CommentModellingAreaSize&quot;)) val:&quot;3&quot;</ATTRIBUTE>
+<ATTRIBUTE name="BoolCommentModeActive" type="EXPRESSION">EXPR expr:(maval(&quot;Comment Mode&quot;)) val:&quot;No&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Comment Model Direction" type="EXPRESSION">EXPR expr:(maval(&quot;CommentModellingDirection&quot;)) val:&quot;vertical&quot;</ATTRIBUTE>
+<INTERREF name="Decision"></INTERREF>
+<INTERREF name="Referenced documents"></INTERREF>
+<ATTRIBUTE name="Left border" type="EXPRESSION">EXPR
+ val:23.32</ATTRIBUTE>
+<INTERREF name="Referenced Planning Table"></INTERREF>
+<ATTRIBUTE name="Right border" type="EXPRESSION">EXPR
+ val:26.68</ATTRIBUTE>
+<ATTRIBUTE name="Show or Hide" type="ENUMERATION">Shown</ATTRIBUTE>
+<ATTRIBUTE name="Top border" type="EXPRESSION">EXPR
+ val:9.1</ATTRIBUTE>
+<ATTRIBUTE name="Bottom border" type="EXPRESSION">EXPR
+ val:10.9</ATTRIBUTE>
+<ATTRIBUTE name="X" type="EXPRESSION">EXPR
+ val:25</ATTRIBUTE>
+<ATTRIBUTE name="Y" type="EXPRESSION">EXPR
+ val:10</ATTRIBUTE>
+<ATTRIBUTE name="Change Visibility" type="PROGRAMCALL">ITEM &quot;Change Visibility&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Planning Table" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Bounding box" type="EXPRESSION">EXPR
+ val:&quot;[9.1,10.9,23.32,26.68,25,10]&quot;</ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16375" class="Task" name="Do Check">
+<ATTRIBUTE name="Position" type="STRING">NODE x:19.5cm y:16.5cm w:3.36cm h:1.8cm index:10</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Performer" type="EXPRESSION">EXPR expr:(&quot;&quot;) val:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Execution time" type="TIME">00:000:00:00:00</ATTRIBUTE>
+<ATTRIBUTE name="Waiting time" type="TIME">00:000:00:00:00</ATTRIBUTE>
+<ATTRIBUTE name="Resting time" type="TIME">00:000:00:00:00</ATTRIBUTE>
+<ATTRIBUTE name="Transport time" type="TIME">00:000:00:00:00</ATTRIBUTE>
+<ATTRIBUTE name="Priority" type="INTEGER">10</ATTRIBUTE>
+<ATTRIBUTE name="Done by" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Continuous execution" type="ENUMERATION">no</ATTRIBUTE>
+<ATTRIBUTE name="Max. resource waiting time" type="TIME">00:000:00:05:00</ATTRIBUTE>
+<ATTRIBUTE name="Cooperative" type="ENUMERATION">no</ATTRIBUTE>
+<ATTRIBUTE name="Cooperation mode" type="ENUMERATION">synchron</ATTRIBUTE>
+<ATTRIBUTE name="Average number of participants" type="INTEGER">1</ATTRIBUTE>
+<ATTRIBUTE name="Min. quota of presence" type="INTEGER">100</ATTRIBUTE>
+<ATTRIBUTE name="Max. start period" type="TIME">00:001:00:00:00</ATTRIBUTE>
+<ATTRIBUTE name="Execution interruptable" type="ENUMERATION">yes</ATTRIBUTE>
+<ATTRIBUTE name="Task stack" type="ENUMERATION">personal</ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-02] Attribute \&quot;Fontcolor\&quot; (Lane) does not exist!  \&quot;fontcolor\&quot; (Task)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<RECORD name="Technical Attributes"></RECORD>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<INTERREF name="Actor"></INTERREF>
+<RECORD name="Assignments"></RECORD>
+<ATTRIBUTE name="Term" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Status" type="ENUMERATION">None</ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING">what ever ...</ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="External documentation" type="PROGRAMCALL">ITEM &quot;&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Info on results" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Number" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated execution time" type="TIME">00:000:00:00:00</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated waiting time" type="TIME">00:000:00:00:00</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated resting time" type="TIME">00:000:00:00:00</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated transport time" type="TIME">00:000:00:00:00</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated personnel costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Classification" type="ENUMERATIONLIST"></ATTRIBUTE>
+<ATTRIBUTE name="EDP transaction costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="EDP batch costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Printing costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Postal costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Aktivität</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Open questions" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Type" type="ENUMERATION">Standard</ATTRIBUTE>
+<INTERREF name="referenced subprocess"></INTERREF>
+<ATTRIBUTE name="Display responsible role" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Subprocessname" type="EXPRESSION">EXPR val:&quot;Bezeichnung&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Modelling direction" type="EXPRESSION">EXPR val:&quot;vertical&quot;</ATTRIBUTE>
+<RECORD name="Properties"></RECORD>
+<ATTRIBUTE name="Show name" type="ENUMERATION">center</ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16375&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Task type" type="ENUMERATION">Not specified</ATTRIBUTE>
+<ATTRIBUTE name="Global task" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Auditing" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Monitoring" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="For compensation" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Loop type" type="ENUMERATION">Not specified</ATTRIBUTE>
+<INTERREF name="Call activity"></INTERREF>
+<ATTRIBUTE name="Sequential execution" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Cardinality" type="STRING"></ATTRIBUTE>
+<INTERREF name="Referenced data input"></INTERREF>
+<INTERREF name="Referenced data output"></INTERREF>
+<ATTRIBUTE name="Instantiate" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Collection" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Object type" type="ENUMERATION">Information</ATTRIBUTE>
+<ATTRIBUTE name="Completion condition" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Loop condition (standard)" type="STRING"></ATTRIBUTE>
+<INTERREF name="Referenced message"></INTERREF>
+<ATTRIBUTE name="People-like_view_Expression" type="EXPRESSION">EXPR expr:(maval(&quot;People-like view&quot;)) val:&quot;No&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Action" type="ENUMERATION">Fill in</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Actor_" type="EXPRESSION">EXPR expr:(maval(&quot;Actor_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Description_" type="EXPRESSION">EXPR expr:(maval(&quot;Description_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_Modelling_direction_" type="EXPRESSION">EXPR expr:(maval(&quot;Modelling direction&quot;)) val:&quot;vertical&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Modelling_" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="_REFERENCE_OVERVIEW_SETTINGS_" type="EXPRESSION">EXPR expr:(maval(&quot;Reference overview settings&quot;)) val:&quot;Responsible for execution|Responsible for execution\nAccountable for approving results|Accountable for approving results\nCooperation/participation|Cooperation/participation\nTo inform|To inform\nModelling|Modelling\nKnowledge Product|Knowledge Product\nDocuments and Resources|Documents and Resources\n#Data Object|Data Object\nIncoming Data Object|Incoming Data Object\nOutgoing Data Object|Outgoing Data Object\nDescription|Description&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Actor_" type="EXPRESSION">EXPR expr:(maval(&quot;Actor_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Description_" type="EXPRESSION">EXPR expr:(maval(&quot;Description_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Modelling_" type="EXPRESSION">EXPR expr:(maval(&quot;Modelling_size&quot;)) val:&quot;3&quot;</ATTRIBUTE>
+<ATTRIBUTE name="BoolBarDisplayActive" type="EXPRESSION">EXPR expr:(maval(&quot;BAR Display active&quot;)) val:&quot;No&quot;</ATTRIBUTE>
+<INTERREF name="Data Object"></INTERREF>
+<INTERREF name="Knowledge Product"></INTERREF>
+<INTERREF name="Documents and Resources"></INTERREF>
+<ATTRIBUTE name="_disp_Knowledge Product_" type="EXPRESSION">EXPR expr:(maval(&quot;Knowledge Product_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Data Object_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Documents and Resources_" type="EXPRESSION">EXPR expr:(maval(&quot;Documents and Resources_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Data Object_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Documents and Resources_" type="EXPRESSION">EXPR expr:(maval(&quot;Documents and Resources_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Knowledge Product_" type="EXPRESSION">EXPR expr:(maval(&quot;Knowledge Product_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Responsible for execution_" type="EXPRESSION">EXPR expr:(maval(&quot;Responsible for execution_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Responsible for execution_" type="EXPRESSION">EXPR expr:(maval(&quot;Responsible for execution_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Accountable for approving results_" type="EXPRESSION">EXPR expr:(maval(&quot;Accountable for approving results_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Accountable for approving results_" type="EXPRESSION">EXPR expr:(maval(&quot;Accountable for approving results_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Cooperation/participation_" type="EXPRESSION">EXPR expr:(maval(&quot;Cooperation/participation_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Cooperation/participation_" type="EXPRESSION">EXPR expr:(maval(&quot;Cooperation/participation_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_To inform_" type="EXPRESSION">EXPR expr:(maval(&quot;To inform_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_To inform_" type="EXPRESSION">EXPR expr:(maval(&quot;To inform_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<INTERREF name="Responsible for execution"></INTERREF>
+<INTERREF name="To inform"></INTERREF>
+<INTERREF name="Cooperation/participation"></INTERREF>
+<INTERREF name="Accountable for approving results"></INTERREF>
+<INTERREF name="Incoming Data Object"></INTERREF>
+<INTERREF name="Outgoing Data Object"></INTERREF>
+<ATTRIBUTE name="_size_Outgoing Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Outgoing Data Object_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Outgoing Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Outgoing Data Object_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Incoming Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Incoming Data Object_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Incoming Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Incoming Data Object_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Commentboxcomment" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="CommentAreaSizeExp" type="EXPRESSION">EXPR expr:(maval(&quot;CommentAreaSize&quot;)) val:&quot;2&quot;</ATTRIBUTE>
+<ATTRIBUTE name="CommentBool" type="ENUMERATION">0</ATTRIBUTE>
+<ATTRIBUTE name="CommentBox" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="CommentInfo" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="CommentMode" type="EXPRESSION">EXPR expr:(maval(&quot;Comment Mode&quot;)) val:&quot;No&quot;</ATTRIBUTE>
+<RECORD name="CommentTable"></RECORD>
+<ATTRIBUTE name="WriteComment" type="PROGRAMCALL">ITEM &quot;Add Comment&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="ClearComment" type="PROGRAMCALL">ITEM &quot;Clear Comment&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="CommentModellingAreaSizeExp" type="EXPRESSION">EXPR expr:(maval(&quot;CommentModellingAreaSize&quot;)) val:&quot;3&quot;</ATTRIBUTE>
+<ATTRIBUTE name="BoolCommentModeActive" type="EXPRESSION">EXPR expr:(maval(&quot;Comment Mode&quot;)) val:&quot;No&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Comment Model Direction" type="EXPRESSION">EXPR expr:(maval(&quot;CommentModellingDirection&quot;)) val:&quot;vertical&quot;</ATTRIBUTE>
+<INTERREF name="Decision"></INTERREF>
+<INTERREF name="Referenced documents"></INTERREF>
+<ATTRIBUTE name="Left border" type="EXPRESSION">EXPR
+ val:17.82</ATTRIBUTE>
+<INTERREF name="Referenced Planning Table"></INTERREF>
+<ATTRIBUTE name="Right border" type="EXPRESSION">EXPR
+ val:21.18</ATTRIBUTE>
+<ATTRIBUTE name="Show or Hide" type="ENUMERATION">Shown</ATTRIBUTE>
+<ATTRIBUTE name="Top border" type="EXPRESSION">EXPR
+ val:15.6</ATTRIBUTE>
+<ATTRIBUTE name="Bottom border" type="EXPRESSION">EXPR
+ val:17.4</ATTRIBUTE>
+<ATTRIBUTE name="X" type="EXPRESSION">EXPR
+ val:19.5</ATTRIBUTE>
+<ATTRIBUTE name="Y" type="EXPRESSION">EXPR
+ val:16.5</ATTRIBUTE>
+<ATTRIBUTE name="Change Visibility" type="PROGRAMCALL">ITEM &quot;Change Visibility&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Planning Table" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Bounding box" type="EXPRESSION">EXPR
+ val:&quot;[15.6,17.4,17.82,21.18,19.5,16.5]&quot;</ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16378" class="Exclusive Gateway" name="is check necessary?">
+<ATTRIBUTE name="Position" type="STRING">NODE x:14cm y:16.5cm index:11</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Variable type" type="ENUMERATION">enumeration</ATTRIBUTE>
+<ATTRIBUTE name="Variable scope" type="ENUMERATION">global</ATTRIBUTE>
+<ATTRIBUTE name="Variable name" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Variable value" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-02] Attribute \&quot;Fontcolor\&quot; (Lane) does not exist!  \&quot;fontcolor\&quot; (Exclusive Gateway)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<RECORD name="Technical Attributes"></RECORD>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<INTERREF name="Actor"></INTERREF>
+<RECORD name="Assignments"></RECORD>
+<ATTRIBUTE name="Term" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Entscheidung</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Open questions" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Sum" type="EXPRESSION">EXPR
+ val:0</ATTRIBUTE>
+<ATTRIBUTE name="Type" type="ENUMERATION">Data-based (without marker)</ATTRIBUTE>
+<ATTRIBUTE name="Show name" type="ENUMERATION">below</ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16378&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Constraints" type="ENUMERATION">Unspecified</ATTRIBUTE>
+<RECORD name="Properties"></RECORD>
+<ATTRIBUTE name="Cardinality" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16381" class="Data Object" name="Instance SCIA (update)">
+<ATTRIBUTE name="Position" type="STRING">NODE x:19.5cm y:12cm index:13</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(&quot;&quot;) val:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<RECORD name="Technical Attributes"></RECORD>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Collection" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Open questions" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Data type" type="ENUMERATION">Data Input</ATTRIBUTE>
+<INTERREF name="Referenced input data (optional)">
+<IREF type="objectreference" tmodeltype="Document and Knowledge model" tmodelname="Document and Knowledge model TitoloUnico" tmodelver="" tclassname="Document" tobjname="SCIA Instance"></IREF>
+</INTERREF>
+<INTERREF name="Referenced input data (while executing)"></INTERREF>
+<ATTRIBUTE name="Collection (input)" type="ENUMERATION">No</ATTRIBUTE>
+<INTERREF name="Referenced output data (optional)"></INTERREF>
+<INTERREF name="Referenced output data (while executing)"></INTERREF>
+<ATTRIBUTE name="Collection (output)" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Capacity" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Unlimited" type="ENUMERATION">No</ATTRIBUTE>
+<INTERREF name="Referenced data store (global)"></INTERREF>
+<ATTRIBUTE name="Auditing" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Monitoring" type="ENUMERATION">No</ATTRIBUTE>
+<RECORD name="Properties"></RECORD>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16381&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Cardinality" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16384" class="Non-exclusive Gateway" name="Non-exclusive Gateway-83191">
+<ATTRIBUTE name="Position" type="STRING">NODE x:10cm y:10cm index:16</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-02] Attribute \&quot;Fontcolor\&quot; (Lane) does not exist!  \&quot;fontcolor\&quot; (Non-exclusive Gateway)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<RECORD name="Technical Attributes"></RECORD>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<INTERREF name="Actor"></INTERREF>
+<RECORD name="Assignments"></RECORD>
+<ATTRIBUTE name="Term" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Representation" type="ENUMERATION">without name</ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Parallelität</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Modelling direction (Model)" type="EXPRESSION">EXPR val:&quot;vertical&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Modelling direction" type="ENUMERATION">undefined</ATTRIBUTE>
+<ATTRIBUTE name="Change modelling direction (global)" type="PROGRAMCALL">ITEM &quot;Change modelling direction (global)&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Type" type="ENUMERATION">AND</ATTRIBUTE>
+<ATTRIBUTE name="Show name" type="ENUMERATION">do not show</ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16384&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Gateway type" type="ENUMERATION">Parallel</ATTRIBUTE>
+<ATTRIBUTE name="Type (parallel)" type="ENUMERATION">Data-based</ATTRIBUTE>
+<ATTRIBUTE name="Activation condition (complex)" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Open questions" type="STRING"></ATTRIBUTE>
+<RECORD name="Properties"></RECORD>
+<ATTRIBUTE name="Cardinality" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16387" class="End Event" name="End Event-83205">
+<ATTRIBUTE name="Position" type="STRING">NODE x:36.5cm y:10cm index:19</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Type" type="ENUMERATION">local</ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-02] Attribute \&quot;Fontcolor\&quot; (Lane) does not exist!  \&quot;fontcolor\&quot; (End Event)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<RECORD name="Technical Attributes"></RECORD>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<INTERREF name="Actor"></INTERREF>
+<ATTRIBUTE name="Representation" type="ENUMERATION">without name</ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Ende</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Show name" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Open questions" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16387&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Message" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Signal" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Escalation" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Error" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Compensation" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Terminate" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Cancel" type="ENUMERATION">No</ATTRIBUTE>
+<RECORD name="Properties"></RECORD>
+<ATTRIBUTE name="Auditing" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Monitoring" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Collection" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Object type" type="ENUMERATION">Information</ATTRIBUTE>
+<ATTRIBUTE name="Cardinality" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Details" type="LONGSTRING"></ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16390" class="Data Object" name="3rd Party Opinion">
+<ATTRIBUTE name="Position" type="STRING">NODE x:28.5cm y:11.5cm index:21</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(&quot;&quot;) val:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<RECORD name="Technical Attributes"></RECORD>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Collection" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Open questions" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Data type" type="ENUMERATION">Data Input</ATTRIBUTE>
+<INTERREF name="Referenced input data (optional)">
+<IREF type="objectreference" tmodeltype="Document and Knowledge model" tmodelname="Document and Knowledge model TitoloUnico" tmodelver="" tclassname="Document" tobjname="Third Party Opinion"></IREF>
+</INTERREF>
+<INTERREF name="Referenced input data (while executing)"></INTERREF>
+<ATTRIBUTE name="Collection (input)" type="ENUMERATION">No</ATTRIBUTE>
+<INTERREF name="Referenced output data (optional)"></INTERREF>
+<INTERREF name="Referenced output data (while executing)"></INTERREF>
+<ATTRIBUTE name="Collection (output)" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Capacity" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Unlimited" type="ENUMERATION">No</ATTRIBUTE>
+<INTERREF name="Referenced data store (global)"></INTERREF>
+<ATTRIBUTE name="Auditing" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Monitoring" type="ENUMERATION">No</ATTRIBUTE>
+<RECORD name="Properties"></RECORD>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16390&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Cardinality" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16393" class="Task" name="Check Involvement">
+<ATTRIBUTE name="Position" type="STRING">NODE x:10cm y:16.5cm w:3.36cm h:1.8cm index:27</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Performer" type="EXPRESSION">EXPR expr:(&quot;&quot;) val:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Execution time" type="TIME">00:000:00:00:00</ATTRIBUTE>
+<ATTRIBUTE name="Waiting time" type="TIME">00:000:00:00:00</ATTRIBUTE>
+<ATTRIBUTE name="Resting time" type="TIME">00:000:00:00:00</ATTRIBUTE>
+<ATTRIBUTE name="Transport time" type="TIME">00:000:00:00:00</ATTRIBUTE>
+<ATTRIBUTE name="Priority" type="INTEGER">10</ATTRIBUTE>
+<ATTRIBUTE name="Done by" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Continuous execution" type="ENUMERATION">no</ATTRIBUTE>
+<ATTRIBUTE name="Max. resource waiting time" type="TIME">00:000:00:05:00</ATTRIBUTE>
+<ATTRIBUTE name="Cooperative" type="ENUMERATION">no</ATTRIBUTE>
+<ATTRIBUTE name="Cooperation mode" type="ENUMERATION">synchron</ATTRIBUTE>
+<ATTRIBUTE name="Average number of participants" type="INTEGER">1</ATTRIBUTE>
+<ATTRIBUTE name="Min. quota of presence" type="INTEGER">100</ATTRIBUTE>
+<ATTRIBUTE name="Max. start period" type="TIME">00:001:00:00:00</ATTRIBUTE>
+<ATTRIBUTE name="Execution interruptable" type="ENUMERATION">yes</ATTRIBUTE>
+<ATTRIBUTE name="Task stack" type="ENUMERATION">personal</ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-02] Attribute \&quot;Fontcolor\&quot; (Lane) does not exist!  \&quot;fontcolor\&quot; (Task)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<RECORD name="Technical Attributes"></RECORD>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<INTERREF name="Actor"></INTERREF>
+<RECORD name="Assignments"></RECORD>
+<ATTRIBUTE name="Term" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Status" type="ENUMERATION">None</ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING">in original BPMN model not considered</ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="External documentation" type="PROGRAMCALL">ITEM &quot;&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Info on results" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Number" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated execution time" type="TIME">00:000:00:00:00</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated waiting time" type="TIME">00:000:00:00:00</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated resting time" type="TIME">00:000:00:00:00</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated transport time" type="TIME">00:000:00:00:00</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated personnel costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Classification" type="ENUMERATIONLIST"></ATTRIBUTE>
+<ATTRIBUTE name="EDP transaction costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="EDP batch costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Printing costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Postal costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Aktivität</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Open questions" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Type" type="ENUMERATION">Standard</ATTRIBUTE>
+<INTERREF name="referenced subprocess"></INTERREF>
+<ATTRIBUTE name="Display responsible role" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Subprocessname" type="EXPRESSION">EXPR val:&quot;Bezeichnung&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Modelling direction" type="EXPRESSION">EXPR val:&quot;vertical&quot;</ATTRIBUTE>
+<RECORD name="Properties"></RECORD>
+<ATTRIBUTE name="Show name" type="ENUMERATION">center</ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16393&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Task type" type="ENUMERATION">Receive</ATTRIBUTE>
+<ATTRIBUTE name="Global task" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Auditing" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Monitoring" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="For compensation" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Loop type" type="ENUMERATION">Not specified</ATTRIBUTE>
+<INTERREF name="Call activity"></INTERREF>
+<ATTRIBUTE name="Sequential execution" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Cardinality" type="STRING"></ATTRIBUTE>
+<INTERREF name="Referenced data input"></INTERREF>
+<INTERREF name="Referenced data output"></INTERREF>
+<ATTRIBUTE name="Instantiate" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Collection" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Object type" type="ENUMERATION">Information</ATTRIBUTE>
+<ATTRIBUTE name="Completion condition" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Loop condition (standard)" type="STRING"></ATTRIBUTE>
+<INTERREF name="Referenced message"></INTERREF>
+<ATTRIBUTE name="People-like_view_Expression" type="EXPRESSION">EXPR expr:(maval(&quot;People-like view&quot;)) val:&quot;No&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Action" type="ENUMERATION">Fill in</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Actor_" type="EXPRESSION">EXPR expr:(maval(&quot;Actor_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Description_" type="EXPRESSION">EXPR expr:(maval(&quot;Description_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_Modelling_direction_" type="EXPRESSION">EXPR expr:(maval(&quot;Modelling direction&quot;)) val:&quot;vertical&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Modelling_" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="_REFERENCE_OVERVIEW_SETTINGS_" type="EXPRESSION">EXPR expr:(maval(&quot;Reference overview settings&quot;)) val:&quot;Responsible for execution|Responsible for execution\nAccountable for approving results|Accountable for approving results\nCooperation/participation|Cooperation/participation\nTo inform|To inform\nModelling|Modelling\nKnowledge Product|Knowledge Product\nDocuments and Resources|Documents and Resources\n#Data Object|Data Object\nIncoming Data Object|Incoming Data Object\nOutgoing Data Object|Outgoing Data Object\nDescription|Description&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Actor_" type="EXPRESSION">EXPR expr:(maval(&quot;Actor_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Description_" type="EXPRESSION">EXPR expr:(maval(&quot;Description_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Modelling_" type="EXPRESSION">EXPR expr:(maval(&quot;Modelling_size&quot;)) val:&quot;3&quot;</ATTRIBUTE>
+<ATTRIBUTE name="BoolBarDisplayActive" type="EXPRESSION">EXPR expr:(maval(&quot;BAR Display active&quot;)) val:&quot;No&quot;</ATTRIBUTE>
+<INTERREF name="Data Object"></INTERREF>
+<INTERREF name="Knowledge Product"></INTERREF>
+<INTERREF name="Documents and Resources"></INTERREF>
+<ATTRIBUTE name="_disp_Knowledge Product_" type="EXPRESSION">EXPR expr:(maval(&quot;Knowledge Product_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Data Object_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Documents and Resources_" type="EXPRESSION">EXPR expr:(maval(&quot;Documents and Resources_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Data Object_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Documents and Resources_" type="EXPRESSION">EXPR expr:(maval(&quot;Documents and Resources_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Knowledge Product_" type="EXPRESSION">EXPR expr:(maval(&quot;Knowledge Product_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Responsible for execution_" type="EXPRESSION">EXPR expr:(maval(&quot;Responsible for execution_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Responsible for execution_" type="EXPRESSION">EXPR expr:(maval(&quot;Responsible for execution_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Accountable for approving results_" type="EXPRESSION">EXPR expr:(maval(&quot;Accountable for approving results_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Accountable for approving results_" type="EXPRESSION">EXPR expr:(maval(&quot;Accountable for approving results_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Cooperation/participation_" type="EXPRESSION">EXPR expr:(maval(&quot;Cooperation/participation_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Cooperation/participation_" type="EXPRESSION">EXPR expr:(maval(&quot;Cooperation/participation_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_To inform_" type="EXPRESSION">EXPR expr:(maval(&quot;To inform_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_To inform_" type="EXPRESSION">EXPR expr:(maval(&quot;To inform_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<INTERREF name="Responsible for execution"></INTERREF>
+<INTERREF name="To inform"></INTERREF>
+<INTERREF name="Cooperation/participation"></INTERREF>
+<INTERREF name="Accountable for approving results"></INTERREF>
+<INTERREF name="Incoming Data Object"></INTERREF>
+<INTERREF name="Outgoing Data Object"></INTERREF>
+<ATTRIBUTE name="_size_Outgoing Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Outgoing Data Object_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Outgoing Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Outgoing Data Object_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Incoming Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Incoming Data Object_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Incoming Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Incoming Data Object_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Commentboxcomment" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="CommentAreaSizeExp" type="EXPRESSION">EXPR expr:(maval(&quot;CommentAreaSize&quot;)) val:&quot;2&quot;</ATTRIBUTE>
+<ATTRIBUTE name="CommentBool" type="ENUMERATION">0</ATTRIBUTE>
+<ATTRIBUTE name="CommentBox" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="CommentInfo" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="CommentMode" type="EXPRESSION">EXPR expr:(maval(&quot;Comment Mode&quot;)) val:&quot;No&quot;</ATTRIBUTE>
+<RECORD name="CommentTable"></RECORD>
+<ATTRIBUTE name="WriteComment" type="PROGRAMCALL">ITEM &quot;Add Comment&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="ClearComment" type="PROGRAMCALL">ITEM &quot;Clear Comment&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="CommentModellingAreaSizeExp" type="EXPRESSION">EXPR expr:(maval(&quot;CommentModellingAreaSize&quot;)) val:&quot;3&quot;</ATTRIBUTE>
+<ATTRIBUTE name="BoolCommentModeActive" type="EXPRESSION">EXPR expr:(maval(&quot;Comment Mode&quot;)) val:&quot;No&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Comment Model Direction" type="EXPRESSION">EXPR expr:(maval(&quot;CommentModellingDirection&quot;)) val:&quot;vertical&quot;</ATTRIBUTE>
+<INTERREF name="Decision"></INTERREF>
+<INTERREF name="Referenced documents"></INTERREF>
+<ATTRIBUTE name="Left border" type="EXPRESSION">EXPR
+ val:8.32</ATTRIBUTE>
+<INTERREF name="Referenced Planning Table"></INTERREF>
+<ATTRIBUTE name="Right border" type="EXPRESSION">EXPR
+ val:11.68</ATTRIBUTE>
+<ATTRIBUTE name="Show or Hide" type="ENUMERATION">Shown</ATTRIBUTE>
+<ATTRIBUTE name="Top border" type="EXPRESSION">EXPR
+ val:15.6</ATTRIBUTE>
+<ATTRIBUTE name="Bottom border" type="EXPRESSION">EXPR
+ val:17.4</ATTRIBUTE>
+<ATTRIBUTE name="X" type="EXPRESSION">EXPR
+ val:10</ATTRIBUTE>
+<ATTRIBUTE name="Y" type="EXPRESSION">EXPR
+ val:16.5</ATTRIBUTE>
+<ATTRIBUTE name="Change Visibility" type="PROGRAMCALL">ITEM &quot;Change Visibility&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Planning Table" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Bounding box" type="EXPRESSION">EXPR
+ val:&quot;[15.6,17.4,8.32,11.68,10,16.5]&quot;</ATTRIBUTE>
+</INSTANCE>
+<CONNECTOR id="con.16396" class="Message Flow">
+<FROM instance="Third Party PA" class="Pool (collapsed)"></FROM>
+<TO instance="Receive check of 3rd Party" class="Task"></TO>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 0 index:22</ATTRIBUTE>
+<ATTRIBUTE name="Message Name" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="ParticipantType (from)" type="ENUMERATION">Role</ATTRIBUTE>
+<ATTRIBUTE name="Role (from)" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Entity (from)" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="ParticipantType (to)" type="ENUMERATION">Role</ATTRIBUTE>
+<ATTRIBUTE name="Role (to)" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Entity (to)" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Name" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Message Properties" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;Task&quot;</ATTRIBUTE>
+<ATTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Pool (collapsed)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Number" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Show Name" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Show Number" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Representation" type="ENUMERATION">above/below</ATTRIBUTE>
+<ATTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Description" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Show name" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Doku" type="STRING">NOTEBOOK
+
+#-----------------------
+CHAPTER &quot;Description&quot;
+#-----------------------
+ATTR &quot;Name&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+ATTR &quot;Id&quot; </ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16396&quot;</ATTRIBUTE>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16397" class="Is inside">
+<FROM instance="SUAP Office" class="Lane"></FROM>
+<TO instance="Monti Azzurri Consorsium" class="Pool"></TO>
+<ATTRIBUTE name="AutoConnect" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16398" class="Is inside">
+<FROM instance="Agriculture Office" class="Lane"></FROM>
+<TO instance="Monti Azzurri Consorsium" class="Pool"></TO>
+<ATTRIBUTE name="AutoConnect" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16399" class="Is inside">
+<FROM instance="Agriculture Office" class="Lane"></FROM>
+<TO instance="SUAP Office" class="Lane"></TO>
+<ATTRIBUTE name="AutoConnect" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16400" class="Association">
+<FROM instance="Text Annotation-83144" class="Text Annotation"></FROM>
+<TO instance="Third Party PA" class="Pool (collapsed)"></TO>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 0 index:6</ATTRIBUTE>
+<ATTRIBUTE name="Direction" type="ENUMERATION">None</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Name" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;Pool (collapsed)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Text Annotation&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Show Name" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Representation" type="ENUMERATION">above/below</ATTRIBUTE>
+<ATTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Description" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Show name" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Doku" type="STRING">NOTEBOOK
+
+#-----------------------
+CHAPTER &quot;Description&quot;
+#-----------------------
+ATTR &quot;Name&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+
+ATTR &quot;Id&quot; </ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16400&quot;</ATTRIBUTE>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16401" class="Is inside">
+<FROM instance="Text Annotation-83144" class="Text Annotation"></FROM>
+<TO instance="Third Party PA" class="Pool (collapsed)"></TO>
+<ATTRIBUTE name="AutoConnect" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16402" class="Is inside">
+<FROM instance="Start Event-83148" class="Start Event"></FROM>
+<TO instance="Monti Azzurri Consorsium" class="Pool"></TO>
+<ATTRIBUTE name="AutoConnect" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16403" class="Is inside">
+<FROM instance="Start Event-83148" class="Start Event"></FROM>
+<TO instance="SUAP Office" class="Lane"></TO>
+<ATTRIBUTE name="AutoConnect" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16404" class="Subsequent">
+<FROM instance="Start Event-83148" class="Start Event"></FROM>
+<TO instance="Non-exclusive Gateway-83191" class="Non-exclusive Gateway"></TO>
+<ATTRIBUTE name="Transition condition" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Transition probability" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualized values" type="ENUMERATION">Denomination</ATTRIBUTE>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 0 index:17</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">2</ATTRIBUTE>
+<ATTRIBUTE name="Representation" type="ENUMERATION">above/below</ATTRIBUTE>
+<ATTRIBUTE name="Font colour" type="ENUMERATION">black</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Info zur Übergangsbedingung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Nachfolger</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Denomination" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Description" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Auditing" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Monitoring" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Default" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Immediate" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Category" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16404&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Color" type="STRING">black</ATTRIBUTE>
+<ATTRIBUTE name="Doku" type="STRING">NOTEBOOK
+
+#-----------------------
+LANG &quot;en&quot;
+#-----------------------
+CHAPTER &quot;Description&quot;
+ATTR &quot;Denomination&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+
+
+CHAPTER &quot;Details (BPMN)&quot;
+
+ATTR &quot;Auditing&quot; 
+ATTR &quot;Monitoring&quot; 
+
+ATTR &quot;Default&quot; 
+ATTR &quot;Immediate&quot; 
+ATTR &quot;Category&quot;
+ATTR &quot;Id&quot; 
+
+
+CHAPTER &quot;Details (Simulation)&quot;
+
+ATTR &quot;Transition condition&quot; dialog:transcond
+
+ATTR &quot;Transition probability&quot;
+
+</ATTRIBUTE>
+<ATTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;Non-exclusive Gateway&quot;</ATTRIBUTE>
+<ATTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Start Event&quot;</ATTRIBUTE>
+<ATTRIBUTE name="ModelTypeExp" type="EXPRESSION">EXPR val:&quot;Business process diagram (BPMN 2.0)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16405" class="Is inside">
+<FROM instance="Send Instance to Third Party" class="Task"></FROM>
+<TO instance="Monti Azzurri Consorsium" class="Pool"></TO>
+<ATTRIBUTE name="AutoConnect" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16406" class="Is inside">
+<FROM instance="Send Instance to Third Party" class="Task"></FROM>
+<TO instance="SUAP Office" class="Lane"></TO>
+<ATTRIBUTE name="AutoConnect" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16407" class="Message Flow">
+<FROM instance="Send Instance to Third Party" class="Task"></FROM>
+<TO instance="Third Party PA" class="Pool (collapsed)"></TO>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 0 index:20</ATTRIBUTE>
+<ATTRIBUTE name="Message Name" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="ParticipantType (from)" type="ENUMERATION">Role</ATTRIBUTE>
+<ATTRIBUTE name="Role (from)" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Entity (from)" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="ParticipantType (to)" type="ENUMERATION">Role</ATTRIBUTE>
+<ATTRIBUTE name="Role (to)" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Entity (to)" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Name" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Message Properties" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;Pool (collapsed)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Task&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Number" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Show Name" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Show Number" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Representation" type="ENUMERATION">above/below</ATTRIBUTE>
+<ATTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Description" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Show name" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Doku" type="STRING">NOTEBOOK
+
+#-----------------------
+CHAPTER &quot;Description&quot;
+#-----------------------
+ATTR &quot;Name&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+ATTR &quot;Id&quot; </ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16407&quot;</ATTRIBUTE>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16408" class="Subsequent">
+<FROM instance="Send Instance to Third Party" class="Task"></FROM>
+<TO instance="Receive check of 3rd Party" class="Task"></TO>
+<ATTRIBUTE name="Transition condition" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Transition probability" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualized values" type="ENUMERATION">Denomination</ATTRIBUTE>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 0 index:26</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">8</ATTRIBUTE>
+<ATTRIBUTE name="Representation" type="ENUMERATION">above/below</ATTRIBUTE>
+<ATTRIBUTE name="Font colour" type="ENUMERATION">black</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Info zur Übergangsbedingung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Nachfolger</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Denomination" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Description" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Auditing" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Monitoring" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Default" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Immediate" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Category" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16408&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Color" type="STRING">black</ATTRIBUTE>
+<ATTRIBUTE name="Doku" type="STRING">NOTEBOOK
+
+#-----------------------
+LANG &quot;en&quot;
+#-----------------------
+CHAPTER &quot;Description&quot;
+ATTR &quot;Denomination&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+
+
+CHAPTER &quot;Details (BPMN)&quot;
+
+ATTR &quot;Auditing&quot; 
+ATTR &quot;Monitoring&quot; 
+
+ATTR &quot;Default&quot; 
+ATTR &quot;Immediate&quot; 
+ATTR &quot;Category&quot;
+ATTR &quot;Id&quot; 
+
+
+CHAPTER &quot;Details (Simulation)&quot;
+
+ATTR &quot;Transition condition&quot; dialog:transcond
+
+ATTR &quot;Transition probability&quot;
+
+</ATTRIBUTE>
+<ATTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;Task&quot;</ATTRIBUTE>
+<ATTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Task&quot;</ATTRIBUTE>
+<ATTRIBUTE name="ModelTypeExp" type="EXPRESSION">EXPR val:&quot;Business process diagram (BPMN 2.0)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16409" class="Is inside">
+<FROM instance="Receive check of 3rd Party" class="Task"></FROM>
+<TO instance="Monti Azzurri Consorsium" class="Pool"></TO>
+<ATTRIBUTE name="AutoConnect" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16410" class="Is inside">
+<FROM instance="Receive check of 3rd Party" class="Task"></FROM>
+<TO instance="SUAP Office" class="Lane"></TO>
+<ATTRIBUTE name="AutoConnect" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16411" class="Subsequent">
+<FROM instance="Receive check of 3rd Party" class="Task"></FROM>
+<TO instance="End Event-83205" class="End Event"></TO>
+<ATTRIBUTE name="Transition condition" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Transition probability" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualized values" type="ENUMERATION">Denomination</ATTRIBUTE>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 0 index:30</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">9</ATTRIBUTE>
+<ATTRIBUTE name="Representation" type="ENUMERATION">above/below</ATTRIBUTE>
+<ATTRIBUTE name="Font colour" type="ENUMERATION">black</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Info zur Übergangsbedingung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Nachfolger</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Denomination" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Description" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Auditing" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Monitoring" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Default" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Immediate" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Category" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16411&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Color" type="STRING">black</ATTRIBUTE>
+<ATTRIBUTE name="Doku" type="STRING">NOTEBOOK
+
+#-----------------------
+LANG &quot;en&quot;
+#-----------------------
+CHAPTER &quot;Description&quot;
+ATTR &quot;Denomination&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+
+
+CHAPTER &quot;Details (BPMN)&quot;
+
+ATTR &quot;Auditing&quot; 
+ATTR &quot;Monitoring&quot; 
+
+ATTR &quot;Default&quot; 
+ATTR &quot;Immediate&quot; 
+ATTR &quot;Category&quot;
+ATTR &quot;Id&quot; 
+
+
+CHAPTER &quot;Details (Simulation)&quot;
+
+ATTR &quot;Transition condition&quot; dialog:transcond
+
+ATTR &quot;Transition probability&quot;
+
+</ATTRIBUTE>
+<ATTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;End Event&quot;</ATTRIBUTE>
+<ATTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Task&quot;</ATTRIBUTE>
+<ATTRIBUTE name="ModelTypeExp" type="EXPRESSION">EXPR val:&quot;Business process diagram (BPMN 2.0)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16412" class="Is inside">
+<FROM instance="Do Check" class="Task"></FROM>
+<TO instance="Monti Azzurri Consorsium" class="Pool"></TO>
+<ATTRIBUTE name="AutoConnect" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16413" class="Is inside">
+<FROM instance="Do Check" class="Task"></FROM>
+<TO instance="Agriculture Office" class="Lane"></TO>
+<ATTRIBUTE name="AutoConnect" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16414" class="Subsequent">
+<FROM instance="Do Check" class="Task"></FROM>
+<TO instance="End Event-83205" class="End Event"></TO>
+<ATTRIBUTE name="Transition condition" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Transition probability" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualized values" type="ENUMERATION">Denomination</ATTRIBUTE>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 1 x1:36.5cm y1:16.5cm index:24</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">6</ATTRIBUTE>
+<ATTRIBUTE name="Representation" type="ENUMERATION">above/below</ATTRIBUTE>
+<ATTRIBUTE name="Font colour" type="ENUMERATION">black</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Info zur Übergangsbedingung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Nachfolger</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Denomination" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Description" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Auditing" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Monitoring" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Default" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Immediate" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Category" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16414&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Color" type="STRING">black</ATTRIBUTE>
+<ATTRIBUTE name="Doku" type="STRING">NOTEBOOK
+
+#-----------------------
+LANG &quot;en&quot;
+#-----------------------
+CHAPTER &quot;Description&quot;
+ATTR &quot;Denomination&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+
+
+CHAPTER &quot;Details (BPMN)&quot;
+
+ATTR &quot;Auditing&quot; 
+ATTR &quot;Monitoring&quot; 
+
+ATTR &quot;Default&quot; 
+ATTR &quot;Immediate&quot; 
+ATTR &quot;Category&quot;
+ATTR &quot;Id&quot; 
+
+
+CHAPTER &quot;Details (Simulation)&quot;
+
+ATTR &quot;Transition condition&quot; dialog:transcond
+
+ATTR &quot;Transition probability&quot;
+
+</ATTRIBUTE>
+<ATTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;End Event&quot;</ATTRIBUTE>
+<ATTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Task&quot;</ATTRIBUTE>
+<ATTRIBUTE name="ModelTypeExp" type="EXPRESSION">EXPR val:&quot;Business process diagram (BPMN 2.0)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16415" class="Is inside">
+<FROM instance="is check necessary?" class="Exclusive Gateway"></FROM>
+<TO instance="Monti Azzurri Consorsium" class="Pool"></TO>
+<ATTRIBUTE name="AutoConnect" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16416" class="Subsequent">
+<FROM instance="is check necessary?" class="Exclusive Gateway"></FROM>
+<TO instance="Do Check" class="Task"></TO>
+<ATTRIBUTE name="Transition condition" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Transition probability" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualized values" type="ENUMERATION">Denomination</ATTRIBUTE>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 0 index:12</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">1</ATTRIBUTE>
+<ATTRIBUTE name="Representation" type="ENUMERATION">above/below</ATTRIBUTE>
+<ATTRIBUTE name="Font colour" type="ENUMERATION">black</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Info zur Übergangsbedingung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Nachfolger</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Denomination" type="STRING">yes</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Auditing" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Monitoring" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Default" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Immediate" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Category" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16416&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Color" type="STRING">black</ATTRIBUTE>
+<ATTRIBUTE name="Doku" type="STRING">NOTEBOOK
+
+#-----------------------
+LANG &quot;en&quot;
+#-----------------------
+CHAPTER &quot;Description&quot;
+ATTR &quot;Denomination&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+
+
+CHAPTER &quot;Details (BPMN)&quot;
+
+ATTR &quot;Auditing&quot; 
+ATTR &quot;Monitoring&quot; 
+
+ATTR &quot;Default&quot; 
+ATTR &quot;Immediate&quot; 
+ATTR &quot;Category&quot;
+ATTR &quot;Id&quot; 
+
+
+CHAPTER &quot;Details (Simulation)&quot;
+
+ATTR &quot;Transition condition&quot; dialog:transcond
+
+ATTR &quot;Transition probability&quot;
+
+</ATTRIBUTE>
+<ATTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;Task&quot;</ATTRIBUTE>
+<ATTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Exclusive Gateway&quot;</ATTRIBUTE>
+<ATTRIBUTE name="ModelTypeExp" type="EXPRESSION">EXPR val:&quot;Business process diagram (BPMN 2.0)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16417" class="Is inside">
+<FROM instance="is check necessary?" class="Exclusive Gateway"></FROM>
+<TO instance="Agriculture Office" class="Lane"></TO>
+<ATTRIBUTE name="AutoConnect" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16418" class="Subsequent">
+<FROM instance="is check necessary?" class="Exclusive Gateway"></FROM>
+<TO instance="End Event-83205" class="End Event"></TO>
+<ATTRIBUTE name="Transition condition" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Transition probability" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualized values" type="ENUMERATION">Denomination</ATTRIBUTE>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 2 x1:14cm y1:18.5cm x2:36.5cm y2:18.5cm index:25</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">7</ATTRIBUTE>
+<ATTRIBUTE name="Representation" type="ENUMERATION">above/below</ATTRIBUTE>
+<ATTRIBUTE name="Font colour" type="ENUMERATION">black</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Info zur Übergangsbedingung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Nachfolger</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Denomination" type="STRING">no</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Auditing" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Monitoring" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Default" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Immediate" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Category" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16418&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Color" type="STRING">black</ATTRIBUTE>
+<ATTRIBUTE name="Doku" type="STRING">NOTEBOOK
+
+#-----------------------
+LANG &quot;en&quot;
+#-----------------------
+CHAPTER &quot;Description&quot;
+ATTR &quot;Denomination&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+
+
+CHAPTER &quot;Details (BPMN)&quot;
+
+ATTR &quot;Auditing&quot; 
+ATTR &quot;Monitoring&quot; 
+
+ATTR &quot;Default&quot; 
+ATTR &quot;Immediate&quot; 
+ATTR &quot;Category&quot;
+ATTR &quot;Id&quot; 
+
+
+CHAPTER &quot;Details (Simulation)&quot;
+
+ATTR &quot;Transition condition&quot; dialog:transcond
+
+ATTR &quot;Transition probability&quot;
+
+</ATTRIBUTE>
+<ATTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;End Event&quot;</ATTRIBUTE>
+<ATTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Exclusive Gateway&quot;</ATTRIBUTE>
+<ATTRIBUTE name="ModelTypeExp" type="EXPRESSION">EXPR val:&quot;Business process diagram (BPMN 2.0)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16419" class="Is inside">
+<FROM instance="Instance SCIA (update)" class="Data Object"></FROM>
+<TO instance="Monti Azzurri Consorsium" class="Pool"></TO>
+<ATTRIBUTE name="AutoConnect" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16420" class="Is inside">
+<FROM instance="Instance SCIA (update)" class="Data Object"></FROM>
+<TO instance="SUAP Office" class="Lane"></TO>
+<ATTRIBUTE name="AutoConnect" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16421" class="Data Association">
+<FROM instance="Instance SCIA (update)" class="Data Object"></FROM>
+<TO instance="Send Instance to Third Party" class="Task"></TO>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 0 index:14</ATTRIBUTE>
+<ATTRIBUTE name="Name" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Representation" type="ENUMERATION">above/below</ATTRIBUTE>
+<ATTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Show name" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Doku" type="STRING">#-----------------------
+CHAPTER &quot;Description&quot;
+#-----------------------
+ATTR &quot;Name&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+ATTR &quot;Id&quot; </ATTRIBUTE>
+<ATTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Data Object&quot;</ATTRIBUTE>
+<ATTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;Task&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16421&quot;</ATTRIBUTE>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16422" class="Data Association">
+<FROM instance="Instance SCIA (update)" class="Data Object"></FROM>
+<TO instance="Do Check" class="Task"></TO>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 0 index:15</ATTRIBUTE>
+<ATTRIBUTE name="Name" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Representation" type="ENUMERATION">above/below</ATTRIBUTE>
+<ATTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Show name" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Doku" type="STRING">#-----------------------
+CHAPTER &quot;Description&quot;
+#-----------------------
+ATTR &quot;Name&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+ATTR &quot;Id&quot; </ATTRIBUTE>
+<ATTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Data Object&quot;</ATTRIBUTE>
+<ATTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;Task&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16422&quot;</ATTRIBUTE>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16423" class="Data Association">
+<FROM instance="Instance SCIA (update)" class="Data Object"></FROM>
+<TO instance="Check Involvement" class="Task"></TO>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 0 index:31</ATTRIBUTE>
+<ATTRIBUTE name="Name" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Representation" type="ENUMERATION">above/below</ATTRIBUTE>
+<ATTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Show name" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Doku" type="STRING">#-----------------------
+CHAPTER &quot;Description&quot;
+#-----------------------
+ATTR &quot;Name&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+ATTR &quot;Id&quot; </ATTRIBUTE>
+<ATTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Data Object&quot;</ATTRIBUTE>
+<ATTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;Task&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16423&quot;</ATTRIBUTE>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16424" class="Is inside">
+<FROM instance="Non-exclusive Gateway-83191" class="Non-exclusive Gateway"></FROM>
+<TO instance="Monti Azzurri Consorsium" class="Pool"></TO>
+<ATTRIBUTE name="AutoConnect" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16425" class="Is inside">
+<FROM instance="Non-exclusive Gateway-83191" class="Non-exclusive Gateway"></FROM>
+<TO instance="SUAP Office" class="Lane"></TO>
+<ATTRIBUTE name="AutoConnect" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16426" class="Subsequent">
+<FROM instance="Non-exclusive Gateway-83191" class="Non-exclusive Gateway"></FROM>
+<TO instance="Send Instance to Third Party" class="Task"></TO>
+<ATTRIBUTE name="Transition condition" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Transition probability" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualized values" type="ENUMERATION">Denomination</ATTRIBUTE>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 0 index:18</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">3</ATTRIBUTE>
+<ATTRIBUTE name="Representation" type="ENUMERATION">above/below</ATTRIBUTE>
+<ATTRIBUTE name="Font colour" type="ENUMERATION">black</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Info zur Übergangsbedingung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Nachfolger</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Denomination" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Description" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Auditing" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Monitoring" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Default" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Immediate" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Category" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16426&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Color" type="STRING">black</ATTRIBUTE>
+<ATTRIBUTE name="Doku" type="STRING">NOTEBOOK
+
+#-----------------------
+LANG &quot;en&quot;
+#-----------------------
+CHAPTER &quot;Description&quot;
+ATTR &quot;Denomination&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+
+
+CHAPTER &quot;Details (BPMN)&quot;
+
+ATTR &quot;Auditing&quot; 
+ATTR &quot;Monitoring&quot; 
+
+ATTR &quot;Default&quot; 
+ATTR &quot;Immediate&quot; 
+ATTR &quot;Category&quot;
+ATTR &quot;Id&quot; 
+
+
+CHAPTER &quot;Details (Simulation)&quot;
+
+ATTR &quot;Transition condition&quot; dialog:transcond
+
+ATTR &quot;Transition probability&quot;
+
+</ATTRIBUTE>
+<ATTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;Task&quot;</ATTRIBUTE>
+<ATTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Non-exclusive Gateway&quot;</ATTRIBUTE>
+<ATTRIBUTE name="ModelTypeExp" type="EXPRESSION">EXPR val:&quot;Business process diagram (BPMN 2.0)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16427" class="Subsequent">
+<FROM instance="Non-exclusive Gateway-83191" class="Non-exclusive Gateway"></FROM>
+<TO instance="Check Involvement" class="Task"></TO>
+<ATTRIBUTE name="Transition condition" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Transition probability" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualized values" type="ENUMERATION">Denomination</ATTRIBUTE>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 0 index:28</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">10</ATTRIBUTE>
+<ATTRIBUTE name="Representation" type="ENUMERATION">above/below</ATTRIBUTE>
+<ATTRIBUTE name="Font colour" type="ENUMERATION">black</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Info zur Übergangsbedingung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Nachfolger</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Denomination" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Description" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Auditing" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Monitoring" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Default" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Immediate" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Category" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16427&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Color" type="STRING">black</ATTRIBUTE>
+<ATTRIBUTE name="Doku" type="STRING">NOTEBOOK
+
+#-----------------------
+LANG &quot;en&quot;
+#-----------------------
+CHAPTER &quot;Description&quot;
+ATTR &quot;Denomination&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+
+
+CHAPTER &quot;Details (BPMN)&quot;
+
+ATTR &quot;Auditing&quot; 
+ATTR &quot;Monitoring&quot; 
+
+ATTR &quot;Default&quot; 
+ATTR &quot;Immediate&quot; 
+ATTR &quot;Category&quot;
+ATTR &quot;Id&quot; 
+
+
+CHAPTER &quot;Details (Simulation)&quot;
+
+ATTR &quot;Transition condition&quot; dialog:transcond
+
+ATTR &quot;Transition probability&quot;
+
+</ATTRIBUTE>
+<ATTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;Task&quot;</ATTRIBUTE>
+<ATTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Non-exclusive Gateway&quot;</ATTRIBUTE>
+<ATTRIBUTE name="ModelTypeExp" type="EXPRESSION">EXPR val:&quot;Business process diagram (BPMN 2.0)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16428" class="Is inside">
+<FROM instance="End Event-83205" class="End Event"></FROM>
+<TO instance="Monti Azzurri Consorsium" class="Pool"></TO>
+<ATTRIBUTE name="AutoConnect" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16429" class="Is inside">
+<FROM instance="End Event-83205" class="End Event"></FROM>
+<TO instance="SUAP Office" class="Lane"></TO>
+<ATTRIBUTE name="AutoConnect" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16430" class="Is inside">
+<FROM instance="3rd Party Opinion" class="Data Object"></FROM>
+<TO instance="Monti Azzurri Consorsium" class="Pool"></TO>
+<ATTRIBUTE name="AutoConnect" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16431" class="Is inside">
+<FROM instance="3rd Party Opinion" class="Data Object"></FROM>
+<TO instance="SUAP Office" class="Lane"></TO>
+<ATTRIBUTE name="AutoConnect" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16432" class="Data Association">
+<FROM instance="3rd Party Opinion" class="Data Object"></FROM>
+<TO instance="Receive check of 3rd Party" class="Task"></TO>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 0 index:23</ATTRIBUTE>
+<ATTRIBUTE name="Name" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Representation" type="ENUMERATION">above/below</ATTRIBUTE>
+<ATTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Show name" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Doku" type="STRING">#-----------------------
+CHAPTER &quot;Description&quot;
+#-----------------------
+ATTR &quot;Name&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+ATTR &quot;Id&quot; </ATTRIBUTE>
+<ATTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Data Object&quot;</ATTRIBUTE>
+<ATTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;Task&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16432&quot;</ATTRIBUTE>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16433" class="Is inside">
+<FROM instance="Check Involvement" class="Task"></FROM>
+<TO instance="Monti Azzurri Consorsium" class="Pool"></TO>
+<ATTRIBUTE name="AutoConnect" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16434" class="Is inside">
+<FROM instance="Check Involvement" class="Task"></FROM>
+<TO instance="Agriculture Office" class="Lane"></TO>
+<ATTRIBUTE name="AutoConnect" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16435" class="Subsequent">
+<FROM instance="Check Involvement" class="Task"></FROM>
+<TO instance="is check necessary?" class="Exclusive Gateway"></TO>
+<ATTRIBUTE name="Transition condition" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Transition probability" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualized values" type="ENUMERATION">Denomination</ATTRIBUTE>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 0 index:29</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">11</ATTRIBUTE>
+<ATTRIBUTE name="Representation" type="ENUMERATION">above/below</ATTRIBUTE>
+<ATTRIBUTE name="Font colour" type="ENUMERATION">black</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Info zur Übergangsbedingung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Nachfolger</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Denomination" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Description" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Auditing" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Monitoring" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Default" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Immediate" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Category" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16435&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Color" type="STRING">black</ATTRIBUTE>
+<ATTRIBUTE name="Doku" type="STRING">NOTEBOOK
+
+#-----------------------
+LANG &quot;en&quot;
+#-----------------------
+CHAPTER &quot;Description&quot;
+ATTR &quot;Denomination&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+
+
+CHAPTER &quot;Details (BPMN)&quot;
+
+ATTR &quot;Auditing&quot; 
+ATTR &quot;Monitoring&quot; 
+
+ATTR &quot;Default&quot; 
+ATTR &quot;Immediate&quot; 
+ATTR &quot;Category&quot;
+ATTR &quot;Id&quot; 
+
+
+CHAPTER &quot;Details (Simulation)&quot;
+
+ATTR &quot;Transition condition&quot; dialog:transcond
+
+ATTR &quot;Transition probability&quot;
+
+</ATTRIBUTE>
+<ATTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;Exclusive Gateway&quot;</ATTRIBUTE>
+<ATTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Task&quot;</ATTRIBUTE>
+<ATTRIBUTE name="ModelTypeExp" type="EXPRESSION">EXPR val:&quot;Business process diagram (BPMN 2.0)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+</MODEL>
+<MODEL id="mod.16231" name="TitoloUnico_MontiAzzurrSUB" version="" modeltype="Business process diagram (BPMN 2.0)" libtype="bp" applib="LearnPAd Prototype Dynamic Library 0.21">
+<MODELATTRIBUTES>
+<ATTRIBUTE name="Contact person" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Keywords" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Copyright info" type="STRING">Edit the model attributes to display your copyright info</ATTRIBUTE>
+<ATTRIBUTE name="Copyright info position" type="ENUMERATION">Bottom right</ATTRIBUTE>
+<ATTRIBUTE name="Name" type="STRING">TitoloUnico_MontiAzzurrSUB</ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;86405&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Process type" type="ENUMERATION">None</ATTRIBUTE>
+<ATTRIBUTE name="Executable" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Closed" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Auditing" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Monitoring" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Model type" type="ENUMERATION">Current model</ATTRIBUTE>
+<ATTRIBUTE name="State" type="ENUMERATION">In process</ATTRIBUTE>
+<ATTRIBUTE name="Reviewed on" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Reviewed by" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Author" type="STRING">barbara</ATTRIBUTE>
+<ATTRIBUTE name="Creation date" type="STRING">11.08.2015, 14:04</ATTRIBUTE>
+<ATTRIBUTE name="Last user" type="STRING">barbara</ATTRIBUTE>
+<ATTRIBUTE name="Date last changed" type="STRING">20.08.2015, 15:51:40</ATTRIBUTE>
+<ATTRIBUTE name="Number of objects and relations" type="INTEGER">77</ATTRIBUTE>
+<ATTRIBUTE name="Context of version" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Action" type="ENUMERATION">Fill in</ATTRIBUTE>
+<ATTRIBUTE name="People-like view" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="BAR Display active" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Modelling direction" type="ENUMERATION">vertical</ATTRIBUTE>
+<ATTRIBUTE name="Modelling_size" type="ENUMERATION">3</ATTRIBUTE>
+<ATTRIBUTE name="Responsible for execution_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Responsible for execution_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="Responsible for execution_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="Accountable for approving results_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Accountable for approving results_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="Accountable for approving results_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="Cooperation/participation_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Cooperation/participation_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="Cooperation/participation_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="To inform_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="To inform_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="To inform_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="Knowledge Product_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Knowledge Product_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="Knowledge Product_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="Documents and Resources_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Documents and Resources_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="Documents and Resources_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="Incoming Data Object_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Incoming Data Object_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="Incoming Data Object_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="Outgoing Data Object_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Outgoing Data Object_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="Outgoing Data Object_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="Description_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Description_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="Description_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="Comment Mode" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="CommentAreaSize" type="ENUMERATION">2</ATTRIBUTE>
+<ATTRIBUTE name="CommentModellingAreaSize" type="ENUMERATION">3</ATTRIBUTE>
+<ATTRIBUTE name="CommentModellingDirection" type="ENUMERATION">vertical</ATTRIBUTE>
+<RECORD name="Change history"></RECORD>
+<ATTRIBUTE name="Position" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-01] Internal error!  \&quot;fontcolor\&quot; (BPModel)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<RECORD name="Technical Attributes"></RECORD>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Keine Modellbezeichnung vergeben</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Pool Term" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="ParticipantType" type="ENUMERATION">Role</ATTRIBUTE>
+<ATTRIBUTE name="Role" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Entity" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="BoundaryVisible" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="BPD Model Attributes" type="STRING">NOTEBOOK
+
+CHAPTER &quot;Business Process Diagram Attributes&quot;
+ATTR &quot;Name&quot; write-protected
+ATTR &quot;Contact person&quot;
+ATTR &quot;Author&quot; write-protected
+ATTR &quot;Language (BPMN)&quot;
+ATTR &quot;ExpressionLanguage&quot;
+ATTR &quot;QueryLanguage&quot;
+ATTR &quot;Creation date&quot; write-protected
+ATTR &quot;Date last changed&quot; write-protected
+ATTR &quot;Documentation (Model)&quot;
+ATTR &quot;State&quot;
+
+GROUP &quot;Copyright&quot;
+ATTR &quot;Copyright info&quot; 
+ATTR &quot;Copyright info position&quot; 
+ENDGROUP
+
+CHAPTER &quot;Process Attributes&quot;
+ATTR &quot;Name&quot; write-protected
+ATTR &quot;Process Term&quot;
+ATTR &quot;ProcessType&quot;
+ATTR &quot;Status&quot;
+ATTR &quot;Assignments&quot; lines:5
+ATTR &quot;Properties (BPMN)&quot; lines:5
+ATTR &quot;AdHoc&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+GROUP &quot;AdHoc = True&quot;
+ATTR &quot;AdHocOrdering&quot;
+ATTR &quot;AdHocCompletionCondition&quot;
+ENDGROUP
+ATTR &quot;SuppressJoinFailure&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ATTR &quot;EnableInstanceCompensation&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ATTR &quot;Categories (Process)&quot;
+ATTR &quot;Documentation (Process)&quot;
+
+CHAPTER &quot;Pool Attributes&quot;
+GROUP &quot;Common Graphical Object Attributes&quot;
+ATTR &quot;Name&quot; write-protected
+ATTR &quot;Categories (Pool)&quot;
+ATTR &quot;Documentation (Pool)&quot;
+ENDGROUP
+GROUP &quot;Common Swimlane Attributes&quot;
+ATTR &quot;Pool Term&quot;
+ENDGROUP
+GROUP &quot;Pool Attributes&quot;
+ATTR &quot;ParticipantType&quot;
+ATTR &quot;Role&quot;
+ATTR &quot;Entity&quot;
+ATTR &quot;BoundaryVisible&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot; write-protected
+ENDGROUP</ATTRIBUTE>
+<ATTRIBUTE name="Language" type="ENUMERATION">System</ATTRIBUTE>
+<ATTRIBUTE name="ExpressionLanguage" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="QueryLanguage" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Process Term" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="BPD Term" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="ProcessType" type="ENUMERATION">None</ATTRIBUTE>
+<ATTRIBUTE name="Status" type="ENUMERATION">None</ATTRIBUTE>
+<RECORD name="Assignments"></RECORD>
+<ATTRIBUTE name="AdHoc" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="AdHocOrdering" type="ENUMERATION">None</ATTRIBUTE>
+<ATTRIBUTE name="AdHocCompletionCondition" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="EnableInstanceCompensation" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Categories (Process)" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation (Process)" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation (Pool)" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Categories (Pool)" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="SuppressJoinFailure" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="RACI/DEMI visualisation" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="IT systems" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Responsible role" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Input/Output" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Products" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Use cases" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Products color" type="STRING">whitesmoke</ATTRIBUTE>
+<ATTRIBUTE name="RACI/DEMI color" type="STRING">whitesmoke</ATTRIBUTE>
+<ATTRIBUTE name="Responsible role color" type="STRING">whitesmoke</ATTRIBUTE>
+<ATTRIBUTE name="Input/Output color" type="STRING">whitesmoke</ATTRIBUTE>
+<ATTRIBUTE name="Use cases color" type="STRING">whitesmoke</ATTRIBUTE>
+<ATTRIBUTE name="IT systems color" type="STRING">whitesmoke</ATTRIBUTE>
+<ATTRIBUTE name="_ToggleModelInfo_" type="PROGRAMCALL">ITEM &quot;_ToggleModelInfo_&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Display modelling information" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Documentation (Model)" type="STRING"></ATTRIBUTE>
+<RECORD name="Properties (BPMN)"></RECORD>
+<ATTRIBUTE name="CreationDate" type="EXPRESSION">EXPR val:&quot;11.08.2015, 14:04&quot;</ATTRIBUTE>
+<ATTRIBUTE name="ModificationDate" type="EXPRESSION">EXPR val:&quot;20.08.2015, 15:51:40&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Language (BPMN)" type="STRING">English</ATTRIBUTE>
+<ATTRIBUTE name="BPMN20 Model Attributes" type="LONGSTRING">NOTEBOOK
+# TODO AVAL sMfbRegistration:&quot;_MFB-Registration_&quot;
+CHAPTER &quot;Description&quot;
+ATTR &quot;Contact person&quot;
+ATTR &quot;Keywords&quot; lines:2
+ATTR &quot;Description&quot; lines:3
+ATTR &quot;Comment&quot; lines:3
+
+GROUP &quot;Copyright&quot;
+ATTR &quot;Copyright info&quot; 
+ATTR &quot;Copyright info position&quot; 
+ENDGROUP
+ATTR &quot;Name&quot; write-protected
+ATTR &quot;Id&quot; write-protected
+
+
+
+#---------------------------------------------
+CHAPTER &quot;Process properties&quot;
+#---------------------------------------------
+GROUP &quot;Process attributes&quot;
+ATTR &quot;Process type&quot; #None, Private, Public 
+ATTR &quot;Executable&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ATTR &quot;Closed&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ENDGROUP
+
+GROUP &quot;Process relevance&quot;
+ATTR &quot;Auditing&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ATTR &quot;Monitoring&quot; ctrltype:check checked-value:&quot;Yes&quot; unchecked-value:&quot;No&quot;
+ENDGROUP
+
+CHAPTER &quot;User attributes&quot;
+ATTR &quot;Model type&quot;
+ATTR &quot;State&quot;
+ATTR &quot;Reviewed on&quot;
+ATTR &quot;Reviewed by&quot;
+
+CHAPTER &quot;System attributes&quot;
+ATTR &quot;Author&quot; write-protected
+ATTR &quot;Creation date&quot; write-protected
+ATTR &quot;Last user&quot; write-protected
+# ATTR &quot;Date last changed from&quot; write-protected
+ATTR &quot;Date last changed&quot; write-protected
+ATTR &quot;Number of objects and relations&quot; write-protected
+ATTR &quot;Context of version&quot; write-protected
+
+CHAPTER &quot;People-like view&quot;
+ATTR &quot;Action&quot;
+ATTR &quot;People-like view&quot;
+
+CHAPTER &quot;BAR Display&quot;
+ATTR &quot;BAR Display active&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot;
+AVAL s_Aktiv: &quot;BAR Display active&quot;
+ATTR &quot;Modelling direction&quot; ctrltype: radio enabled: (s_Aktiv = &quot;Yes&quot;)
+ATTR &quot;Modelling_size&quot;
+
+GROUP &quot;Responsible for execution&quot;
+ATTR &quot;Responsible for execution_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_Responsible_for_execution_display: &quot;Responsible for execution_display&quot;
+ATTR &quot;Responsible for execution_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_Responsible_for_execution_display = &quot;Yes&quot;))
+ATTR &quot;Responsible for execution_size&quot;
+ENDGROUP
+
+GROUP &quot;Accountable for approving results&quot;
+ATTR &quot;Accountable for approving results_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_Accountableforapprovingresults_display: &quot;Actor_display&quot;
+ATTR &quot;Accountable for approving results_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_Accountableforapprovingresults_display = &quot;Yes&quot;))
+ATTR &quot;Accountable for approving results_size&quot;
+ENDGROUP
+
+GROUP &quot;Cooperation/participation&quot;
+ATTR &quot;Cooperation/participation_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_Cooperationparticipation_display: &quot;Cooperation/participation_display&quot;
+ATTR &quot;Cooperation/participation_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_Cooperationparticipation_display = &quot;Yes&quot;))
+ATTR &quot;Cooperation/participation_size&quot;
+ENDGROUP
+
+GROUP &quot;To inform&quot;
+ATTR &quot;To inform_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_Toinform_display: &quot;To inform_display&quot;
+ATTR &quot;To inform_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_Toinform_display = &quot;Yes&quot;))
+ATTR &quot;To inform_size&quot;
+ENDGROUP
+
+GROUP &quot;Knowledge Product&quot;
+ATTR &quot;Knowledge Product_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_KnowledgeProduct_display: &quot;Knowledge Product_display&quot;
+ATTR &quot;Knowledge Product_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_KnowledgeProduct_display = &quot;Yes&quot;))
+ATTR &quot;Knowledge Product_size&quot;
+ENDGROUP
+
+GROUP &quot;Documents and Resources&quot;
+ATTR &quot;Documents and Resources_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_DocumentsandResources_display: &quot;Documents and Resources_display&quot;
+ATTR &quot;Documents and Resources_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_DocumentsandResources_display = &quot;Yes&quot;))
+ATTR &quot;Documents and Resources_size&quot;
+ENDGROUP
+
+GROUP &quot;Incoming Data Object&quot;
+ATTR &quot;Incoming Data Object_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_IncomingDataObject_display: &quot;Incoming Data Object_display&quot;
+ATTR &quot;Incoming Data Object_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_IncomingDataObject_display = &quot;Yes&quot;))
+ATTR &quot;Incoming Data Object_size&quot;
+ENDGROUP
+
+GROUP &quot;Outgoing Data Object&quot;
+ATTR &quot;Outgoing Data Object_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_OutgoingDataObject_display: &quot;Outgoing Data Object_display&quot;
+ATTR &quot;Outgoing Data Object_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_OutgoingDataObject_display = &quot;Yes&quot;))
+ATTR &quot;Outgoing Data Object_size&quot;
+ENDGROUP
+
+GROUP &quot;Description&quot;
+ATTR &quot;Description_display&quot; ctrltype: check checked-value: &quot;Yes&quot; unchecked-value: &quot;No&quot; enabled: (s_Aktiv = &quot;Yes&quot;)
+AVAL s_Description_display: &quot;Description_display&quot;
+ATTR &quot;Description_color&quot; dialog: color enabled: ((s_Aktiv = &quot;Yes&quot;) AND (s_Description_display = &quot;Yes&quot;))
+ATTR &quot;Description_size&quot;
+ENDGROUP
+
+CHAPTER &quot;Comment View&quot;
+ATTR &quot;Comment Mode&quot; ctrltype: check checked-value: &quot;No&quot; unchecked-value: &quot;Yes&quot;
+AVAL s_Aktiv: &quot;Comment Mode&quot;
+ATTR &quot;CommentAreaSize&quot;
+ATTR &quot;CommentModellingAreaSize&quot;
+ATTR &quot;CommentModellingDirection&quot;
+
+
+
+
+CHAPTER &quot;Change history&quot;
+ATTR &quot;Change history&quot; lines:30
+
+</ATTRIBUTE>
+<ATTRIBUTE name="_GoToAceHp_" type="PROGRAMCALL">ITEM &quot;_GoToAceHp_&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="__GfxThumb__" type="LONGSTRING">iVBORw0KGgoAAAANSUhEUgAAAQAAAADdCAIAAADbxzt0AAAACXBIWXMAAAsTAAALEwEAmpwYAAARJElEQVR4nO3df3AT14EH8O9mnH/auQ69y5T+0aS9QfK1hnYCgXS8DpPkDmgkG+Lc4RXtpHADZhlIiNTkKJermcDgaWJ+zMlJSkeCZkpmCpHsuWCD10ngepebWukQEujUqBnskqSZXkgn03/qGM7I++6PlYSsX5YleVf2+37+SISs1Xu23vftPr3dfcrHH3989f2r586eA1BXV3f77bc/0vrIHz76A+adsbGxGzduaJrmdEWohtSdP38+Ho+vX78+/dRbv37r+xs2FNnm/MWL9y5dOvt1q6bzFy+OjY05XQuqPX19fS+99NKJEydOnjx58uTJEydOGIYhJuIj8Xiwsd2YiAcbAQCNjSoAwJiYiMfjYiIebITe368DQKM69TUWtbExGO/XATS26+3temOj3t9v9MeNdgBQD8fFxIRIvn/qHQDAKrRRbW/XU0+qhw9bRSc3aW/XGxuD8X4Aen882N6eKm7CONyuN7YbE3EVMCb6AQTjE2JiIh6P9/X1RSIRQZRB6evrW7p06aVLlxRFue222wDU19e7vvrVIpn56Nq1O7/85UqTZ6+Prl27ePEiD4EoiyKEiEajTlfDPgwAZVKEEE7XgcgxdU5XgMhJdeFw2Ok6EFXfggULSjncrQOg6/rs14fIPqV36zwEIqkxACQ1BoCkxgCQ1BgAkhoDMEtGBwdHcOXUKbTuasZBd2eDoQH1cW8ngggHEDQ66t0ej8vpakqPAZglLo/HBY/HAwAICU/yaeEBEPI7Vi3KwgCQ1BgAkhoDQFJjAEhqDABJjQGgmqAozlyaUoeZnDpXtm3btoVCodkuheY0R87Mr9N13Z5LIhcsWGBDKTQX+Xw+ONRCeEkkOU9RFACONEUGgKRm0yDYqSEOzRVODoKJpMWOmaTGPQBJjWMAqgkcAxA5gB0zSY17AJIaxwBUEzgGIHIAO2aSGvcAJDWOAagmcAxA5AB2zCQ17gFIahwDUE1wbAxg25XIXIyMiqtWCylxdTDLDNYIC4fDZa8mxmXIqLhqtZCZpohjAJIaxwBUEzgPQOQAmwIwh7p/6x41ZL+y//KRSKT0UW8W7gHyiEQiTleBSmXdVa5sHAPkV3aPUhtGu7dtioYBXTse8s/vhcjmRgDIXi5/aMg/p25GPM8HwXOr+yd5cA8wH9TCwL2SkSic6yI5BpgnnB24V3gg7iDuAeaPcjvg0e4mdyCmGyLkmf7F+VUeAI4ByCku/5CQdulu7gGoOqydgCNfH1dSNMcAdlNW95T+4shWUcrnKoSYdp2r2Sh3yiYlD0Ly12RVNO/z4mxbFYvOxT2ArZTVPeNGW8JEYhIJEwkTNzMep5+/mXq8akcPEJ22Lfb2Lgaesb/ctJ6eBtMsqQ/+hx2/+M8f3WUKfPGv/+auRQ3T1kRZ3VMkA11dynPPARXseTgGsNMoLmiPDRrmw97jUJffG7twHlihLn07dhEA8K29wUV7oyPL8MAh7cW/D2x7vaQ/Wm/v4nXrOvr790WjxdpB6a0/Yc7st+rtXbxu3d7+/r3FK2AZPrP/udG7hBCffvpn4813KqlJV5fy1FOXgM+EGOvqUnbvLqeNcQ9gJxeWRw+v8iT+Ip4t1Ao3+a3HLe/5Eyamncy1Wr8Q4y0t28+c2dfbu880n8nbChOToz950L3nPABghe77Bh7csevq45sm/73j6krvq8DiZer9XdqR1YGtr82gJVmtX4jxtWt3nj5drAKWb3j37P7u306a+MKCL1p/gV8+qWx9Wb17eezSBT34YWi5OSWrhWS2fiHGAoGXy8sAxwBVUPo8VCQSSfXBo8f8B6/Eh80nOx4w3ZOD7id+kXxN8zGx877Ux39O850r+CVjJBJpbe0QYlyI68B4c3ObEOOf/7wv7+vPnolsOSs2Tk3dileHEiZuvi/8qee9cX/CxFHA58v/PjkV2CvEOHBdiPHm5u8B45/7XLENI5HIt+5RM/dC6gHxm+fy9P3pAOT980YikXTrF+IzYKx4VQvhHqA6io/DfD5f+gWpz9716KHQrb5/pfhVZ/Znn5gEVkUjW/N0HOk37O/vbGnZDowLMS7EuGEMZNUks+hpjzdulVvyb9Tfv3ft2p3pEA4MnCq0YXqTZP7XuPe/rf7rr4+bj7sPXFAf+bk2+XzcxPBdqb1Q81eSNckc4mf+OpmtX4jPitS2CI4BqkbTlhWaUdI0LRqNapqmrO75cE1JrbD/twsBbN4C4IXcI4r0G/b27sts/ab5TLImqbNBR4R4Nxr1HVU+7GkrsfUb8YWbt+B1Ez/b8EnhX/ZWBTJbf6oCVoWnnJQqNC1q1WQNEpOuRwfEBqvEV8U/WTVZOWUvlJjETfNWcVnlAujqUgKBl63W3929i2MAxxWbUUp/hNmt8I/xb3dctn702ott6db/45Zz/3ZmFYDXzZ0a8hxSW2+4fv3l3t7FXm9zRuvXAGSeDerSNN/RntzW/+0tPVnlWq0/XfSWVxYWz0C6As3NrTmtH7knpWpTajJ6vMV94AJwj4p3Yov3BL+2PzAAfW88dHeq9ecdA6Tff/du0dWlpB8XqmdxdgTAwXXAa1B2H7ywAbgszrYpq3uyWv+eh6L7X9MwXUO0mmBO45uuXBMAMsu1Wj+A0oueUQVyauLypft+Ew8sUg6/J7ananIzYwxQxO7dQlEUzgPMGVaDy33eerLliR4Am7ckm2DCvLFrVejguW353mlwm9LZMNIRd3vDUHXj0P8FAksHdiiKEhwRuZfAlFIukkdcmL7opiu7huoPKt4woKqIxQDoT0eubV7m7W5qii4BwoghZgiRe3JRoZoAeOjxMifCKmFHAIQQpXxPUuFUZbVmOkuZVa1kE3G2rfiLXzcBIGHeSJjXD57b9vj9z7745tM5r/KErNYlRPIQw+MB4C98Us+05c6g6CEPgFC66Az+oSE/UPzr29w2nTxGKLet1/qpENaBWvGvaZNTlZO3hmVFHiRMrHlsylRlhZtnmnZWtfJNin9UGrQtryx89o2N1j9ffPPpfAch1imcgKqqsZj1/yUdHcNeb0e+freUcksuOg/rOMSp60hr+hCoq0t56qmhJ58cm3a6btpWm3X8Wt3NLb29i9eu/eHp09PMqla4ybR+tuGTLa8sTD/O95ICA+6KB1olFF19JR4jFFGjp0JYff/hw02Zz2RmILPnuGmOHnnQvec8lq3Au28D0I98vOsrV0fWNXkDb45M/mDTL0Xs8kXs+524exJZ7wB88sKDyo9M/dGG4fjPgY1L3KJh44Hm/25xH3xH/eay2G+ht4jhO7u0n64JtBtTWkm6DlZTBq63tGwpMquaWeesTaqbgdKHd9XtgGdUdLXM8yvCAAQCR4LBHciZ2LNmHCORSMJ0bX5DfD+r877T9dYH4qaJRGRobcb0ITKmKq3/uiKRP35Hu2kicejW5tqr4h8ztrpp4qFhf8LEsakzndaDhx/+oTWjKcT15uZWIa4XmlVN1zlrk4GBamaAbGBfAKzWj8ITe4UOXW7me4DUkV/2TOcMN898h9OnD7S0bEnP6aDAwWVmiVmbWF8FOsLB0/GrYn5eEWZNVQQCR4T4TIix55/fZx3/5E7sKat7Plid3XxXbE5+sfPGT9qy2nF6cy01v/hBtK2MzTFlclHLmtNB5qRmapZXZExG5m4yFweCMpv1PcC003W3pkhzOm8A6qLFsd9fzu3Fs97Bd7Sn7M0z61B4TmfKoDPzRzOdBpo9c7f7x/weA5QyTV1ofiT2+8sAmndm/yjrFLEKN8+0fv3ljA6+JGVsQpaenikfjRAzvhKtQjU0E1zKTE2mrL9UWZuPDg4OnPIGwgBU3Tge8riS36/7fN26iobjWtQdzZnUHO1uckc1Q4t2RhGLxQAAqtrt88WgGmKo7HsryKytra2np0dRFJu7kjrgT4PbmjobtA7gVDyOhtbWelzp7IS2xF+PUbSOuHFlwO235Q6TFf7mM9/c5fH4PSLzfK3s79fzza2mXuP3SHszhapL7wpszkAd8KXk1DaQ7ro8nuRDF+ACUp/znwYHBzO2vQLUn/KeahUhDwa7uzsDgVjeE1HmqcFtinc4GFwSCIRV3Tje6nV78579QsVZfX9bW/I8iKyDotlmHQKNjo4ODBxEHPHhcHhJMNhQ34zOTfGOjl3AyBWcqkfI4wG+lA4GACsvnuQn7vH7PX65+kNPyBq3+ZM7EJ7uWrZ067efFQCXy5X6GEOpwwHPkPV/lwfs1Ypz9kwYqkQNDYKJ7McAkMNsPujPwgCQk9raZvblddUxAFSh0e4mN4BLyHfl8nQbxjsM+Hxh6IbYdeXWFQ5L/krT7Bl5MgAVGlUUNwCfz3cNeELGcbDLPyQCinJ3WRsCty5q8zhxk2oGoEIu62IOnos2RzEAVVD6rWGp1jAAlZqNSyLJNgxARWbvkkiyBwNQvnTrT18SWfy+sGUo5Q61ACKRSImvpCwMQPmsS2EyL4lMX6UJey/Rsr/EeYMBqFTufWGtayxh4yVa6cuUeQA2UwxARVL3pv2O9c/Ma53trwxbfxkYgEqtX3+Z8wBzFwNQNZJ3wHP0viwMAFXHHN0HMgBUNXOu+wcDYL/ZXrB6thVa5hoQuT+qwfpnYQBsVcXbuDui+ILbv1mZcQMys5wFt+3HANhpFBe0xwzDbPUeh3rPvbF3pi6U/c29wUV7o6PLYl/bYZxp9+qlLZRts0KtP+/Ce7WPAbCTC8ujh1Z7En8RPy50J+CNfuvB9t+JxCTCTtc4l7Xgdt8jRvN/dJ4GhIhdvABAf/6j1v+6s3NkWWz4XTQf0wfawzNacNspDEB1lH7STqrRjx4LHByJD5s/6LjfdE++5vanFsr2HhWP3ZfqQYsulO2IhOlKLri91fO9qX3/svc96cfb46FEyQtuO4gBqIJp1wjLdxd416MHQ7f6/pXif/bnu417gYWyHVTKkU/6edT816MMQHVMs+xX0bvAF1rEIOs27jWi9Nafu8x1DWIAbFLwLvD/G29MLZQ98EJb8du414ISF9wutMx1rWEAbFVklVzM8DbuTsnt+5FahyGr9TMAlEeFd4F3VvF1GNILbqfVYICzMAAOqKk2PVNzOsC5GACasRpv0zPCAJDUGACSGgNAUmMASGp1AMLhUs+5Kv2VRHOCMu15LERzTunfUylc2o1kxjEASY0BIKkxACQ1BoCkxgCQ1BgAkhoDQFJjAEhqDABJjQEgqTEAJDUGgKTGAJDUGACSGgNAUmMASGoMAEmNASCpMQAkNQaApMYAkNQYAJIaA0BSYwBIagwASY0BIKkxACQ1BoCkxgCQ1BgAkhoDQFJjAEhqDABJjQEgqTEAJDUGgKTGAJDUGACSGgNAUmMASGoMAEmNASCpMQAkNQaApMYAkNQYAJIaA0BSYwBIagwASY0BIKkxACQ1BoCkxgCQ1BgAkhoDQFJjAEhqDABJjQEgqTEAJDUGgKTGAJDUGACSGgNAUmMASGoMAEmNASCpMQAkNQaApMYAkNQYAJIaA0BSYwBIagwASY0BIKkxACQ1BoCkxgCQ1BgAkhoDQFJjAEhqDABJjQEgqTEAJDUGgKTGAJDUGACSGgNAUmMASGoMAEmNASCpMQAkNQaApMYAkNQYAJIaA0BSYwBIagwAyU0QOW8kqAKAGjQMwwiqqqrqRvpJVVVVAKpuGIYRBJKPg6qq6nrQMIKqbggDgKoCQHBkJJjcBIYYCeq6rgIAdF0HANUQhp5q/IoQwtbAEdUSHgLRPPPn7qaXArE7VPXTWMx65uuGUK809UeX3LFk+L1wDADU4H2xwK+E+BfuAUhq3APQfGXtCgBADT6sRfsCMUD9ur4Erbv+7pS7L4w7hPhn7gFIav8PGG/U1/8MqI8AAAAASUVORK5CYII=</ATTRIBUTE>
+<ATTRIBUTE name="NT Model Attributes" type="LONGSTRING">NOTEBOOK
+CHAPTER &quot;Description&quot;
+#ATTR &quot;Shared&quot;
+ATTR &quot;Model state&quot; enabled:(cond(search (sMfbRegistration, &quot;MFB_VERS&quot;, 0) = -1, 1, 0))
+ATTR &quot;Description&quot;
+ATTR &quot;Show State&quot; ctrltype:check unchecked-value:&quot;No&quot; checked-value:&quot;Yes&quot; 
+ATTR &quot;Last user&quot; write-protected
+ATTR &quot;Date last changed&quot; write-protected
+#CHAPTER &quot;Suggestion for improvement&quot;
+#ATTR &quot;Suggestion for improvement&quot;
+</ATTRIBUTE>
+<ATTRIBUTE name="Model state" type="ENUMERATION">Draft</ATTRIBUTE>
+<ATTRIBUTE name="Keywords" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Description" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Model type" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Show State" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Actor_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="Actor_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Actor_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="ModelingAreaSize" type="ENUMERATION">20</ATTRIBUTE>
+<ATTRIBUTE name="DrawingAreaWidth" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="DrawingAreaHeight" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Reference overview settings" type="LONGSTRING">Responsible for execution|Responsible for execution
+Accountable for approving results|Accountable for approving results
+Cooperation/participation|Cooperation/participation
+To inform|To inform
+Modelling|Modelling
+Knowledge Product|Knowledge Product
+Documents and Resources|Documents and Resources
+#Data Object|Data Object
+Incoming Data Object|Incoming Data Object
+Outgoing Data Object|Outgoing Data Object
+Description|Description</ATTRIBUTE>
+<ATTRIBUTE name="Data Object_color" type="STRING">lightblue</ATTRIBUTE>
+<ATTRIBUTE name="Data Object_display" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Data Object_size" type="ENUMERATION">1</ATTRIBUTE>
+<ATTRIBUTE name="id_bpmndi_diagram" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="id_bpmndi_plane" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="id_bpmndi_collaboration" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="CommentTypeSize" type="ENUMERATION">8</ATTRIBUTE>
+<ATTRIBUTE name="CommentxCoorTextBox" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="CommentyCoorTextBox" type="STRING"></ATTRIBUTE>
+</MODELATTRIBUTES>
+<INSTANCE id="obj.16232" class="Pool (collapsed)" name="Entrepreneur">
+<ATTRIBUTE name="Position" type="STRING">NODE x:25.25cm y:3cm w:50.5cm h:3cm index:1</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(&quot;&quot;) val:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<RECORD name="Technical Attributes"></RECORD>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="ParticipantType" type="ENUMERATION">Role</ATTRIBUTE>
+<ATTRIBUTE name="Role" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Entity" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="BoundaryVisible" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Process Term" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="ProcessType" type="ENUMERATION">None</ATTRIBUTE>
+<ATTRIBUTE name="Status" type="ENUMERATION">None</ATTRIBUTE>
+<RECORD name="Assignments"></RECORD>
+<RECORD name="Properties"></RECORD>
+<ATTRIBUTE name="AdHoc" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="AdHocOrdering" type="ENUMERATION">None</ATTRIBUTE>
+<ATTRIBUTE name="AdHocCompletionCondition" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="EnableInstanceCompensation" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Categories (Process)" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation (Process)" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="SuppressJoinFailure" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Open questions" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16232&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Color" type="STRING">white</ATTRIBUTE>
+<ATTRIBUTE name="Orientation" type="ENUMERATION">horizontal</ATTRIBUTE>
+<ATTRIBUTE name="Boundary visible" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Auditing" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Monitoring" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Process type" type="ENUMERATION">None</ATTRIBUTE>
+<ATTRIBUTE name="Executable" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Closed" type="ENUMERATION">No</ATTRIBUTE>
+<INTERREF name="Referenced Organizational Unit"></INTERREF>
+<INTERREF name="Referenced process"></INTERREF>
+<ATTRIBUTE name="Cardinality" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16235" class="Pool" name="Monti Azzurri Consorsium">
+<ATTRIBUTE name="Position" type="STRING">NODE x:0cm y:9cm w:50cm h:15cm index:2</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(&quot;&quot;) val:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<RECORD name="Technical Attributes"></RECORD>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="ParticipantType" type="ENUMERATION">Role</ATTRIBUTE>
+<ATTRIBUTE name="Role" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Entity" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="BoundaryVisible" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Process Term" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="ProcessType" type="ENUMERATION">None</ATTRIBUTE>
+<ATTRIBUTE name="Status" type="ENUMERATION">None</ATTRIBUTE>
+<RECORD name="Assignments"></RECORD>
+<RECORD name="Properties"></RECORD>
+<ATTRIBUTE name="AdHoc" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="AdHocOrdering" type="ENUMERATION">None</ATTRIBUTE>
+<ATTRIBUTE name="AdHocCompletionCondition" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="EnableInstanceCompensation" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Categories (Process)" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation (Process)" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="SuppressJoinFailure" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Open questions" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16235&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Color" type="STRING">white</ATTRIBUTE>
+<ATTRIBUTE name="Orientation" type="ENUMERATION">horizontal</ATTRIBUTE>
+<ATTRIBUTE name="Boundary visible" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Auditing" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Monitoring" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Process type" type="ENUMERATION">None</ATTRIBUTE>
+<ATTRIBUTE name="Executable" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Closed" type="ENUMERATION">No</ATTRIBUTE>
+<INTERREF name="Referenced Organizational Unit">
+<IREF type="objectreference" tmodeltype="Organizational structure" tmodelname="Org Model Monti Azzurri" tmodelver="" tclassname="Organizational unit" tobjname="Monti Azzurri"></IREF>
+</INTERREF>
+</INSTANCE>
+<INSTANCE id="obj.16238" class="Lane" name="Office SUAP">
+<ATTRIBUTE name="Position" type="STRING">NODE x:3cm y:9cm w:47cm h:15cm index:3</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(&quot;&quot;) val:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<RECORD name="Technical Attributes"></RECORD>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Open questions" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16238&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Color" type="STRING">white</ATTRIBUTE>
+<ATTRIBUTE name="Orientation" type="ENUMERATION">horizontal</ATTRIBUTE>
+<ATTRIBUTE name="Line break" type="ENUMERATION">No</ATTRIBUTE>
+<RECORD name="Properties"></RECORD>
+<ATTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Cardinality" type="STRING"></ATTRIBUTE>
+<INTERREF name="Referenced Organizational Unit">
+<IREF type="objectreference" tmodeltype="Organizational structure" tmodelname="Org Model Monti Azzurri" tmodelver="" tclassname="Organizational unit" tobjname="SUAP Office"></IREF>
+</INTERREF>
+<INTERREF name="Referenced Role"></INTERREF>
+<INTERREF name="Referenced Performer"></INTERREF>
+</INSTANCE>
+<INSTANCE id="obj.16241" class="Start Event" name="Start Event-83017">
+<ATTRIBUTE name="Position" type="STRING">NODE x:7cm y:15cm index:4</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Process calendar" type="LONGSTRING">D@Working day@b@32400-43200@U900;1800@45000-59400@U900;1800@Free day@c@@@$cbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbcbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbcbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbcccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbbbbbccbccbbccb</ATTRIBUTE>
+<ATTRIBUTE name="Quantity" type="EXPRESSION">EXPR expr:(0) val:0</ATTRIBUTE>
+<ATTRIBUTE name="Time period" type="ENUMERATION">Per year</ATTRIBUTE>
+<ATTRIBUTE name="Abandon after tolerance waiting time" type="ENUMERATION">no</ATTRIBUTE>
+<ATTRIBUTE name="Tolerance waiting time" type="TIME">00:000:00:00:00</ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-02] Attribute \&quot;Fontcolor\&quot; (Lane) does not exist!  \&quot;fontcolor\&quot; (Start Event)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<RECORD name="Technical Attributes"></RECORD>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<INTERREF name="Actor"></INTERREF>
+<RECORD name="Assignments"></RECORD>
+<ATTRIBUTE name="Term" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Trigger" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Result" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Aggregated execution time" type="TIME">00:000:00:00:00</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated waiting time" type="TIME">00:000:00:00:00</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated resting time" type="TIME">00:000:00:00:00</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated transport time" type="TIME">00:000:00:00:00</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated cycle time" type="TIME">00:000:00:00:00</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Info on results" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Cost driver" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Cost driver quantity" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated personnel costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="External documentation" type="PROGRAMCALL">ITEM &quot;&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Prozeßstart</ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Open questions" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Modelling direction" type="EXPRESSION">EXPR val:&quot;vertical&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Implementing control" type="ENUMERATION">no</ATTRIBUTE>
+<ATTRIBUTE name="Show name" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16241&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Type" type="ENUMERATION">Top-level</ATTRIBUTE>
+<ATTRIBUTE name="Message" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Timer" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Conditional" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Signal" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Escalation" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Error" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Compensation" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Parallel" type="ENUMERATION">No</ATTRIBUTE>
+<RECORD name="Properties"></RECORD>
+<ATTRIBUTE name="Auditing" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Monitoring" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Collection" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Object type" type="ENUMERATION">Information</ATTRIBUTE>
+<ATTRIBUTE name="Cardinality" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Details" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Timer type" type="ENUMERATION">Date</ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16244" class="Sub-Process" name="Receive Instance">
+<ATTRIBUTE name="Position" type="STRING">NODE x:11cm y:15cm w:3.36cm h:1.8cm index:5</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<INTERREF name="Referenced subprocess"></INTERREF>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-02] Attribute \&quot;Fontcolor\&quot; (Lane) does not exist!  \&quot;fontcolor\&quot; (Sub-Process)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<RECORD name="Technical Attributes"></RECORD>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<INTERREF name="Actor"></INTERREF>
+<RECORD name="Assignments"></RECORD>
+<ATTRIBUTE name="Term" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Prozeßaufruf</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Aggregated execution time" type="EXPRESSION">EXPR val:0s</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated costs" type="EXPRESSION">EXPR val:0</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated resting time" type="EXPRESSION">EXPR val:0s</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated personnel costs" type="EXPRESSION">EXPR val:0</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated waiting time" type="EXPRESSION">EXPR val:0s</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated transport time" type="EXPRESSION">EXPR val:0s</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated cycle time" type="EXPRESSION">EXPR val:0s</ATTRIBUTE>
+<ATTRIBUTE name="Open questions" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Performer" type="EXPRESSION">EXPR expr:(cond (avalf (&quot;%o&quot;, &quot;Responsible role&quot;) &lt;&gt; &quot;&quot;, &quot;({\&quot;&quot; + avalf (&quot;%o&quot;, &quot;Responsible role&quot;) + &quot;\&quot; : \&quot;Role\&quot;} &lt;- \&quot;Has role\&quot;)&quot;,&quot;&quot;)) val:error:&quot;[acoexpar-02] Attribute \&quot;Responsible role\&quot; (Sub-Process) does not exist!  \&quot;Performer\&quot; (Sub-Process)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Subprocessname" type="EXPRESSION">EXPR val:&quot;Bezeichnung&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Classification" type="ENUMERATIONLIST"></ATTRIBUTE>
+<ATTRIBUTE name="External documentation" type="PROGRAMCALL">ITEM &quot;&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="__NameGeneration__" type="STRING">NAMEGEN srcattr:&quot;Referenced subprocess&quot; format:&quot;%m&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Type" type="ENUMERATION">Embedded</ATTRIBUTE>
+<ATTRIBUTE name="Global" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16244&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Auditing" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Monitoring" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="For compensation" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Loop type" type="ENUMERATION">Not specified</ATTRIBUTE>
+<ATTRIBUTE name="Sequential execution" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Cardinality" type="STRING"></ATTRIBUTE>
+<INTERREF name="Referenced data input"></INTERREF>
+<INTERREF name="Referenced data output"></INTERREF>
+<RECORD name="Properties"></RECORD>
+<ATTRIBUTE name="Collection" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Object type" type="ENUMERATION">Information</ATTRIBUTE>
+<ATTRIBUTE name="Loop condition (standard)" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Completion condition" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Completion condition (ad-hoc)" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Suppress Sub-Process" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Actor_" type="EXPRESSION">EXPR expr:(maval(&quot;Actor_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Description_" type="EXPRESSION">EXPR expr:(maval(&quot;Description_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_Modelling_direction_" type="EXPRESSION">EXPR expr:(maval(&quot;Modelling direction&quot;)) val:&quot;vertical&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Modelling_" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="_REFERENCE_OVERVIEW_SETTINGS_" type="EXPRESSION">EXPR expr:(maval(&quot;Reference overview settings&quot;)) val:&quot;Responsible for execution|Responsible for execution\nAccountable for approving results|Accountable for approving results\nCooperation/participation|Cooperation/participation\nTo inform|To inform\nModelling|Modelling\nKnowledge Product|Knowledge Product\nDocuments and Resources|Documents and Resources\n#Data Object|Data Object\nIncoming Data Object|Incoming Data Object\nOutgoing Data Object|Outgoing Data Object\nDescription|Description&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Actor_" type="EXPRESSION">EXPR expr:(maval(&quot;Actor_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Description_" type="EXPRESSION">EXPR expr:(maval(&quot;Description_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Modelling_" type="EXPRESSION">EXPR expr:(maval(&quot;Modelling_size&quot;)) val:&quot;3&quot;</ATTRIBUTE>
+<ATTRIBUTE name="BoolBarDisplayActive" type="EXPRESSION">EXPR expr:(maval(&quot;BAR Display active&quot;)) val:&quot;No&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Knowledge Product_" type="EXPRESSION">EXPR expr:(maval(&quot;Knowledge Product_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Data Object_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Documents and Resources_" type="EXPRESSION">EXPR expr:(maval(&quot;Documents and Resources_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Data Object_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Documents and Resources_" type="EXPRESSION">EXPR expr:(maval(&quot;Documents and Resources_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Knowledge Product_" type="EXPRESSION">EXPR expr:(maval(&quot;Knowledge Product_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<INTERREF name="Data Object"></INTERREF>
+<INTERREF name="Knowledge Product"></INTERREF>
+<INTERREF name="Documents and Resources"></INTERREF>
+<INTERREF name="Knowledge Intensive"></INTERREF>
+<ATTRIBUTE name="_disp_Responsible for execution_" type="EXPRESSION">EXPR expr:(maval(&quot;Responsible for execution_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Responsible for execution_" type="EXPRESSION">EXPR expr:(maval(&quot;Responsible for execution_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Accountable for approving results_" type="EXPRESSION">EXPR expr:(maval(&quot;Accountable for approving results_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Accountable for approving results_" type="EXPRESSION">EXPR expr:(maval(&quot;Accountable for approving results_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Cooperation/participation_" type="EXPRESSION">EXPR expr:(maval(&quot;Cooperation/participation_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Cooperation/participation_" type="EXPRESSION">EXPR expr:(maval(&quot;Cooperation/participation_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_To inform_" type="EXPRESSION">EXPR expr:(maval(&quot;To inform_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_To inform_" type="EXPRESSION">EXPR expr:(maval(&quot;To inform_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Outgoing Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Outgoing Data Object_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Outgoing Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Outgoing Data Object_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Incoming Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Incoming Data Object_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Incoming Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Incoming Data Object_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<INTERREF name="Incoming Data Object"></INTERREF>
+<INTERREF name="Outgoing Data Object"></INTERREF>
+<INTERREF name="Responsible for execution"></INTERREF>
+<INTERREF name="Cooperation/participation"></INTERREF>
+<INTERREF name="Accountable for approving results"></INTERREF>
+<INTERREF name="To inform"></INTERREF>
+<INTERREF name="Referenced Case Plan Model"></INTERREF>
+</INSTANCE>
+<INSTANCE id="obj.16247" class="Sub-Process" name="Assess Application">
+<ATTRIBUTE name="Position" type="STRING">NODE x:15.5cm y:15cm w:3.36cm h:1.8cm index:6</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<INTERREF name="Referenced subprocess"></INTERREF>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-02] Attribute \&quot;Fontcolor\&quot; (Lane) does not exist!  \&quot;fontcolor\&quot; (Sub-Process)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<RECORD name="Technical Attributes"></RECORD>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<INTERREF name="Actor"></INTERREF>
+<RECORD name="Assignments"></RECORD>
+<ATTRIBUTE name="Term" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING">Orig.Name = Instance Assessment</ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Prozeßaufruf</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Aggregated execution time" type="EXPRESSION">EXPR val:0s</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated costs" type="EXPRESSION">EXPR val:0</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated resting time" type="EXPRESSION">EXPR val:0s</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated personnel costs" type="EXPRESSION">EXPR val:0</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated waiting time" type="EXPRESSION">EXPR val:0s</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated transport time" type="EXPRESSION">EXPR val:0s</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated cycle time" type="EXPRESSION">EXPR val:0s</ATTRIBUTE>
+<ATTRIBUTE name="Open questions" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Performer" type="EXPRESSION">EXPR expr:(cond (avalf (&quot;%o&quot;, &quot;Responsible role&quot;) &lt;&gt; &quot;&quot;, &quot;({\&quot;&quot; + avalf (&quot;%o&quot;, &quot;Responsible role&quot;) + &quot;\&quot; : \&quot;Role\&quot;} &lt;- \&quot;Has role\&quot;)&quot;,&quot;&quot;)) val:error:&quot;[acoexpar-02] Attribute \&quot;Responsible role\&quot; (Sub-Process) does not exist!  \&quot;Performer\&quot; (Sub-Process)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Subprocessname" type="EXPRESSION">EXPR val:&quot;Bezeichnung&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Classification" type="ENUMERATIONLIST"></ATTRIBUTE>
+<ATTRIBUTE name="External documentation" type="PROGRAMCALL">ITEM &quot;&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="__NameGeneration__" type="STRING">NAMEGEN srcattr:&quot;Referenced subprocess&quot; format:&quot;%m&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Type" type="ENUMERATION">Embedded</ATTRIBUTE>
+<ATTRIBUTE name="Global" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16247&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Auditing" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Monitoring" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="For compensation" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Loop type" type="ENUMERATION">Not specified</ATTRIBUTE>
+<ATTRIBUTE name="Sequential execution" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Cardinality" type="STRING"></ATTRIBUTE>
+<INTERREF name="Referenced data input"></INTERREF>
+<INTERREF name="Referenced data output"></INTERREF>
+<RECORD name="Properties"></RECORD>
+<ATTRIBUTE name="Collection" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Object type" type="ENUMERATION">Information</ATTRIBUTE>
+<ATTRIBUTE name="Loop condition (standard)" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Completion condition" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Completion condition (ad-hoc)" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Suppress Sub-Process" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Actor_" type="EXPRESSION">EXPR expr:(maval(&quot;Actor_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Description_" type="EXPRESSION">EXPR expr:(maval(&quot;Description_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_Modelling_direction_" type="EXPRESSION">EXPR expr:(maval(&quot;Modelling direction&quot;)) val:&quot;vertical&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Modelling_" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="_REFERENCE_OVERVIEW_SETTINGS_" type="EXPRESSION">EXPR expr:(maval(&quot;Reference overview settings&quot;)) val:&quot;Responsible for execution|Responsible for execution\nAccountable for approving results|Accountable for approving results\nCooperation/participation|Cooperation/participation\nTo inform|To inform\nModelling|Modelling\nKnowledge Product|Knowledge Product\nDocuments and Resources|Documents and Resources\n#Data Object|Data Object\nIncoming Data Object|Incoming Data Object\nOutgoing Data Object|Outgoing Data Object\nDescription|Description&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Actor_" type="EXPRESSION">EXPR expr:(maval(&quot;Actor_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Description_" type="EXPRESSION">EXPR expr:(maval(&quot;Description_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Modelling_" type="EXPRESSION">EXPR expr:(maval(&quot;Modelling_size&quot;)) val:&quot;3&quot;</ATTRIBUTE>
+<ATTRIBUTE name="BoolBarDisplayActive" type="EXPRESSION">EXPR expr:(maval(&quot;BAR Display active&quot;)) val:&quot;No&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Knowledge Product_" type="EXPRESSION">EXPR expr:(maval(&quot;Knowledge Product_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Data Object_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Documents and Resources_" type="EXPRESSION">EXPR expr:(maval(&quot;Documents and Resources_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Data Object_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Documents and Resources_" type="EXPRESSION">EXPR expr:(maval(&quot;Documents and Resources_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Knowledge Product_" type="EXPRESSION">EXPR expr:(maval(&quot;Knowledge Product_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<INTERREF name="Data Object"></INTERREF>
+<INTERREF name="Knowledge Product"></INTERREF>
+<INTERREF name="Documents and Resources"></INTERREF>
+<INTERREF name="Knowledge Intensive"></INTERREF>
+<ATTRIBUTE name="_disp_Responsible for execution_" type="EXPRESSION">EXPR expr:(maval(&quot;Responsible for execution_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Responsible for execution_" type="EXPRESSION">EXPR expr:(maval(&quot;Responsible for execution_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Accountable for approving results_" type="EXPRESSION">EXPR expr:(maval(&quot;Accountable for approving results_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Accountable for approving results_" type="EXPRESSION">EXPR expr:(maval(&quot;Accountable for approving results_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Cooperation/participation_" type="EXPRESSION">EXPR expr:(maval(&quot;Cooperation/participation_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Cooperation/participation_" type="EXPRESSION">EXPR expr:(maval(&quot;Cooperation/participation_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_To inform_" type="EXPRESSION">EXPR expr:(maval(&quot;To inform_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_To inform_" type="EXPRESSION">EXPR expr:(maval(&quot;To inform_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Outgoing Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Outgoing Data Object_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Outgoing Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Outgoing Data Object_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Incoming Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Incoming Data Object_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Incoming Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Incoming Data Object_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<INTERREF name="Incoming Data Object"></INTERREF>
+<INTERREF name="Outgoing Data Object"></INTERREF>
+<INTERREF name="Responsible for execution"></INTERREF>
+<INTERREF name="Cooperation/participation"></INTERREF>
+<INTERREF name="Accountable for approving results"></INTERREF>
+<INTERREF name="To inform"></INTERREF>
+<INTERREF name="Referenced Case Plan Model"></INTERREF>
+</INSTANCE>
+<INSTANCE id="obj.16250" class="Sub-Process" name="Manage of 3rd Party Admin">
+<ATTRIBUTE name="Position" type="STRING">NODE x:27cm y:13cm w:3.36cm h:1.8cm index:7</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<INTERREF name="Referenced subprocess">
+<IREF type="modelreference" tmodeltype="Business process diagram (BPMN 2.0)" tmodelname="TitoloUnico_MontiAzzurrSUB_3" tmodelver=""></IREF>
+</INTERREF>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-02] Attribute \&quot;Fontcolor\&quot; (Lane) does not exist!  \&quot;fontcolor\&quot; (Sub-Process)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<RECORD name="Technical Attributes"></RECORD>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<INTERREF name="Actor"></INTERREF>
+<RECORD name="Assignments"></RECORD>
+<ATTRIBUTE name="Term" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING">Orig.Name = Manage of third party Administration</ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Prozeßaufruf</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Aggregated execution time" type="EXPRESSION">EXPR val:0s</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated costs" type="EXPRESSION">EXPR val:0</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated resting time" type="EXPRESSION">EXPR val:0s</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated personnel costs" type="EXPRESSION">EXPR val:0</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated waiting time" type="EXPRESSION">EXPR val:0s</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated transport time" type="EXPRESSION">EXPR val:0s</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated cycle time" type="EXPRESSION">EXPR val:0s</ATTRIBUTE>
+<ATTRIBUTE name="Open questions" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Performer" type="EXPRESSION">EXPR expr:(cond (avalf (&quot;%o&quot;, &quot;Responsible role&quot;) &lt;&gt; &quot;&quot;, &quot;({\&quot;&quot; + avalf (&quot;%o&quot;, &quot;Responsible role&quot;) + &quot;\&quot; : \&quot;Role\&quot;} &lt;- \&quot;Has role\&quot;)&quot;,&quot;&quot;)) val:error:&quot;[acoexpar-02] Attribute \&quot;Responsible role\&quot; (Sub-Process) does not exist!  \&quot;Performer\&quot; (Sub-Process)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Subprocessname" type="EXPRESSION">EXPR val:&quot;Keine Modellbezeichnung vergeben&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Classification" type="ENUMERATIONLIST"></ATTRIBUTE>
+<ATTRIBUTE name="External documentation" type="PROGRAMCALL">ITEM &quot;&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="__NameGeneration__" type="STRING">NAMEGEN srcattr:&quot;Referenced subprocess&quot; format:&quot;%m&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Type" type="ENUMERATION">Embedded</ATTRIBUTE>
+<ATTRIBUTE name="Global" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16250&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Auditing" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Monitoring" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="For compensation" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Loop type" type="ENUMERATION">Not specified</ATTRIBUTE>
+<ATTRIBUTE name="Sequential execution" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Cardinality" type="STRING"></ATTRIBUTE>
+<INTERREF name="Referenced data input"></INTERREF>
+<INTERREF name="Referenced data output"></INTERREF>
+<RECORD name="Properties"></RECORD>
+<ATTRIBUTE name="Collection" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Object type" type="ENUMERATION">Information</ATTRIBUTE>
+<ATTRIBUTE name="Loop condition (standard)" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Completion condition" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Completion condition (ad-hoc)" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Suppress Sub-Process" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Actor_" type="EXPRESSION">EXPR expr:(maval(&quot;Actor_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Description_" type="EXPRESSION">EXPR expr:(maval(&quot;Description_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_Modelling_direction_" type="EXPRESSION">EXPR expr:(maval(&quot;Modelling direction&quot;)) val:&quot;vertical&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Modelling_" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="_REFERENCE_OVERVIEW_SETTINGS_" type="EXPRESSION">EXPR expr:(maval(&quot;Reference overview settings&quot;)) val:&quot;Responsible for execution|Responsible for execution\nAccountable for approving results|Accountable for approving results\nCooperation/participation|Cooperation/participation\nTo inform|To inform\nModelling|Modelling\nKnowledge Product|Knowledge Product\nDocuments and Resources|Documents and Resources\n#Data Object|Data Object\nIncoming Data Object|Incoming Data Object\nOutgoing Data Object|Outgoing Data Object\nDescription|Description&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Actor_" type="EXPRESSION">EXPR expr:(maval(&quot;Actor_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Description_" type="EXPRESSION">EXPR expr:(maval(&quot;Description_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Modelling_" type="EXPRESSION">EXPR expr:(maval(&quot;Modelling_size&quot;)) val:&quot;3&quot;</ATTRIBUTE>
+<ATTRIBUTE name="BoolBarDisplayActive" type="EXPRESSION">EXPR expr:(maval(&quot;BAR Display active&quot;)) val:&quot;No&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Knowledge Product_" type="EXPRESSION">EXPR expr:(maval(&quot;Knowledge Product_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Data Object_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Documents and Resources_" type="EXPRESSION">EXPR expr:(maval(&quot;Documents and Resources_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Data Object_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Documents and Resources_" type="EXPRESSION">EXPR expr:(maval(&quot;Documents and Resources_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Knowledge Product_" type="EXPRESSION">EXPR expr:(maval(&quot;Knowledge Product_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<INTERREF name="Data Object"></INTERREF>
+<INTERREF name="Knowledge Product"></INTERREF>
+<INTERREF name="Documents and Resources"></INTERREF>
+<INTERREF name="Knowledge Intensive"></INTERREF>
+<ATTRIBUTE name="_disp_Responsible for execution_" type="EXPRESSION">EXPR expr:(maval(&quot;Responsible for execution_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Responsible for execution_" type="EXPRESSION">EXPR expr:(maval(&quot;Responsible for execution_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Accountable for approving results_" type="EXPRESSION">EXPR expr:(maval(&quot;Accountable for approving results_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Accountable for approving results_" type="EXPRESSION">EXPR expr:(maval(&quot;Accountable for approving results_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Cooperation/participation_" type="EXPRESSION">EXPR expr:(maval(&quot;Cooperation/participation_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Cooperation/participation_" type="EXPRESSION">EXPR expr:(maval(&quot;Cooperation/participation_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_To inform_" type="EXPRESSION">EXPR expr:(maval(&quot;To inform_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_To inform_" type="EXPRESSION">EXPR expr:(maval(&quot;To inform_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Outgoing Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Outgoing Data Object_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Outgoing Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Outgoing Data Object_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Incoming Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Incoming Data Object_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Incoming Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Incoming Data Object_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<INTERREF name="Incoming Data Object"></INTERREF>
+<INTERREF name="Outgoing Data Object"></INTERREF>
+<INTERREF name="Responsible for execution"></INTERREF>
+<INTERREF name="Cooperation/participation"></INTERREF>
+<INTERREF name="Accountable for approving results"></INTERREF>
+<INTERREF name="To inform"></INTERREF>
+<INTERREF name="Referenced Case Plan Model"></INTERREF>
+</INSTANCE>
+<INSTANCE id="obj.16253" class="Sub-Process" name="Manage Service Conference">
+<ATTRIBUTE name="Position" type="STRING">NODE x:27cm y:21.5cm w:3.36cm h:1.8cm index:8</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<INTERREF name="Referenced subprocess">
+<IREF type="modelreference" tmodeltype="Business process diagram (BPMN 2.0)" tmodelname="TitoloUnico_MonitAzzurrSUB_4" tmodelver=""></IREF>
+</INTERREF>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-02] Attribute \&quot;Fontcolor\&quot; (Lane) does not exist!  \&quot;fontcolor\&quot; (Sub-Process)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<RECORD name="Technical Attributes"></RECORD>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<INTERREF name="Actor"></INTERREF>
+<RECORD name="Assignments"></RECORD>
+<ATTRIBUTE name="Term" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING">Orig.Name = Announces Service Conference</ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Prozeßaufruf</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Aggregated execution time" type="EXPRESSION">EXPR val:0s</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated costs" type="EXPRESSION">EXPR val:0</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated resting time" type="EXPRESSION">EXPR val:0s</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated personnel costs" type="EXPRESSION">EXPR val:0</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated waiting time" type="EXPRESSION">EXPR val:0s</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated transport time" type="EXPRESSION">EXPR val:0s</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated cycle time" type="EXPRESSION">EXPR val:0s</ATTRIBUTE>
+<ATTRIBUTE name="Open questions" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Performer" type="EXPRESSION">EXPR expr:(cond (avalf (&quot;%o&quot;, &quot;Responsible role&quot;) &lt;&gt; &quot;&quot;, &quot;({\&quot;&quot; + avalf (&quot;%o&quot;, &quot;Responsible role&quot;) + &quot;\&quot; : \&quot;Role\&quot;} &lt;- \&quot;Has role\&quot;)&quot;,&quot;&quot;)) val:error:&quot;[acoexpar-02] Attribute \&quot;Responsible role\&quot; (Sub-Process) does not exist!  \&quot;Performer\&quot; (Sub-Process)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Subprocessname" type="EXPRESSION">EXPR val:&quot;Keine Modellbezeichnung vergeben&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Classification" type="ENUMERATIONLIST"></ATTRIBUTE>
+<ATTRIBUTE name="External documentation" type="PROGRAMCALL">ITEM &quot;&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="__NameGeneration__" type="STRING">NAMEGEN srcattr:&quot;Referenced subprocess&quot; format:&quot;%m&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Type" type="ENUMERATION">Embedded</ATTRIBUTE>
+<ATTRIBUTE name="Global" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16253&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Auditing" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Monitoring" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="For compensation" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Loop type" type="ENUMERATION">Not specified</ATTRIBUTE>
+<ATTRIBUTE name="Sequential execution" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Cardinality" type="STRING"></ATTRIBUTE>
+<INTERREF name="Referenced data input"></INTERREF>
+<INTERREF name="Referenced data output"></INTERREF>
+<RECORD name="Properties"></RECORD>
+<ATTRIBUTE name="Collection" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Object type" type="ENUMERATION">Information</ATTRIBUTE>
+<ATTRIBUTE name="Loop condition (standard)" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Completion condition" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Completion condition (ad-hoc)" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Suppress Sub-Process" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Actor_" type="EXPRESSION">EXPR expr:(maval(&quot;Actor_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Description_" type="EXPRESSION">EXPR expr:(maval(&quot;Description_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_Modelling_direction_" type="EXPRESSION">EXPR expr:(maval(&quot;Modelling direction&quot;)) val:&quot;vertical&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Modelling_" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="_REFERENCE_OVERVIEW_SETTINGS_" type="EXPRESSION">EXPR expr:(maval(&quot;Reference overview settings&quot;)) val:&quot;Responsible for execution|Responsible for execution\nAccountable for approving results|Accountable for approving results\nCooperation/participation|Cooperation/participation\nTo inform|To inform\nModelling|Modelling\nKnowledge Product|Knowledge Product\nDocuments and Resources|Documents and Resources\n#Data Object|Data Object\nIncoming Data Object|Incoming Data Object\nOutgoing Data Object|Outgoing Data Object\nDescription|Description&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Actor_" type="EXPRESSION">EXPR expr:(maval(&quot;Actor_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Description_" type="EXPRESSION">EXPR expr:(maval(&quot;Description_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Modelling_" type="EXPRESSION">EXPR expr:(maval(&quot;Modelling_size&quot;)) val:&quot;3&quot;</ATTRIBUTE>
+<ATTRIBUTE name="BoolBarDisplayActive" type="EXPRESSION">EXPR expr:(maval(&quot;BAR Display active&quot;)) val:&quot;No&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Knowledge Product_" type="EXPRESSION">EXPR expr:(maval(&quot;Knowledge Product_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Data Object_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Documents and Resources_" type="EXPRESSION">EXPR expr:(maval(&quot;Documents and Resources_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Data Object_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Documents and Resources_" type="EXPRESSION">EXPR expr:(maval(&quot;Documents and Resources_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Knowledge Product_" type="EXPRESSION">EXPR expr:(maval(&quot;Knowledge Product_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<INTERREF name="Data Object"></INTERREF>
+<INTERREF name="Knowledge Product"></INTERREF>
+<INTERREF name="Documents and Resources"></INTERREF>
+<INTERREF name="Knowledge Intensive"></INTERREF>
+<ATTRIBUTE name="_disp_Responsible for execution_" type="EXPRESSION">EXPR expr:(maval(&quot;Responsible for execution_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Responsible for execution_" type="EXPRESSION">EXPR expr:(maval(&quot;Responsible for execution_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Accountable for approving results_" type="EXPRESSION">EXPR expr:(maval(&quot;Accountable for approving results_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Accountable for approving results_" type="EXPRESSION">EXPR expr:(maval(&quot;Accountable for approving results_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Cooperation/participation_" type="EXPRESSION">EXPR expr:(maval(&quot;Cooperation/participation_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Cooperation/participation_" type="EXPRESSION">EXPR expr:(maval(&quot;Cooperation/participation_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_To inform_" type="EXPRESSION">EXPR expr:(maval(&quot;To inform_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_To inform_" type="EXPRESSION">EXPR expr:(maval(&quot;To inform_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Outgoing Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Outgoing Data Object_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Outgoing Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Outgoing Data Object_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Incoming Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Incoming Data Object_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Incoming Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Incoming Data Object_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<INTERREF name="Incoming Data Object"></INTERREF>
+<INTERREF name="Outgoing Data Object"></INTERREF>
+<INTERREF name="Responsible for execution"></INTERREF>
+<INTERREF name="Cooperation/participation"></INTERREF>
+<INTERREF name="Accountable for approving results"></INTERREF>
+<INTERREF name="To inform"></INTERREF>
+<INTERREF name="Referenced Case Plan Model"></INTERREF>
+</INSTANCE>
+<INSTANCE id="obj.16256" class="Sub-Process" name="Check Integration">
+<ATTRIBUTE name="Position" type="STRING">NODE x:35.5cm y:13cm w:3.36cm h:1.8cm index:9</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<INTERREF name="Referenced subprocess"></INTERREF>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-02] Attribute \&quot;Fontcolor\&quot; (Lane) does not exist!  \&quot;fontcolor\&quot; (Sub-Process)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<RECORD name="Technical Attributes"></RECORD>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<INTERREF name="Actor"></INTERREF>
+<RECORD name="Assignments"></RECORD>
+<ATTRIBUTE name="Term" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Prozeßaufruf</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Aggregated execution time" type="EXPRESSION">EXPR val:0s</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated costs" type="EXPRESSION">EXPR val:0</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated resting time" type="EXPRESSION">EXPR val:0s</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated personnel costs" type="EXPRESSION">EXPR val:0</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated waiting time" type="EXPRESSION">EXPR val:0s</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated transport time" type="EXPRESSION">EXPR val:0s</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated cycle time" type="EXPRESSION">EXPR val:0s</ATTRIBUTE>
+<ATTRIBUTE name="Open questions" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Performer" type="EXPRESSION">EXPR expr:(cond (avalf (&quot;%o&quot;, &quot;Responsible role&quot;) &lt;&gt; &quot;&quot;, &quot;({\&quot;&quot; + avalf (&quot;%o&quot;, &quot;Responsible role&quot;) + &quot;\&quot; : \&quot;Role\&quot;} &lt;- \&quot;Has role\&quot;)&quot;,&quot;&quot;)) val:error:&quot;[acoexpar-02] Attribute \&quot;Responsible role\&quot; (Sub-Process) does not exist!  \&quot;Performer\&quot; (Sub-Process)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Subprocessname" type="EXPRESSION">EXPR val:&quot;Bezeichnung&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Classification" type="ENUMERATIONLIST"></ATTRIBUTE>
+<ATTRIBUTE name="External documentation" type="PROGRAMCALL">ITEM &quot;&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="__NameGeneration__" type="STRING">NAMEGEN srcattr:&quot;Referenced subprocess&quot; format:&quot;%m&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Type" type="ENUMERATION">Embedded</ATTRIBUTE>
+<ATTRIBUTE name="Global" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16256&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Auditing" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Monitoring" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="For compensation" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Loop type" type="ENUMERATION">Not specified</ATTRIBUTE>
+<ATTRIBUTE name="Sequential execution" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Cardinality" type="STRING"></ATTRIBUTE>
+<INTERREF name="Referenced data input"></INTERREF>
+<INTERREF name="Referenced data output"></INTERREF>
+<RECORD name="Properties"></RECORD>
+<ATTRIBUTE name="Collection" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Object type" type="ENUMERATION">Information</ATTRIBUTE>
+<ATTRIBUTE name="Loop condition (standard)" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Completion condition" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Completion condition (ad-hoc)" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Suppress Sub-Process" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Actor_" type="EXPRESSION">EXPR expr:(maval(&quot;Actor_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Description_" type="EXPRESSION">EXPR expr:(maval(&quot;Description_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_Modelling_direction_" type="EXPRESSION">EXPR expr:(maval(&quot;Modelling direction&quot;)) val:&quot;vertical&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Modelling_" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="_REFERENCE_OVERVIEW_SETTINGS_" type="EXPRESSION">EXPR expr:(maval(&quot;Reference overview settings&quot;)) val:&quot;Responsible for execution|Responsible for execution\nAccountable for approving results|Accountable for approving results\nCooperation/participation|Cooperation/participation\nTo inform|To inform\nModelling|Modelling\nKnowledge Product|Knowledge Product\nDocuments and Resources|Documents and Resources\n#Data Object|Data Object\nIncoming Data Object|Incoming Data Object\nOutgoing Data Object|Outgoing Data Object\nDescription|Description&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Actor_" type="EXPRESSION">EXPR expr:(maval(&quot;Actor_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Description_" type="EXPRESSION">EXPR expr:(maval(&quot;Description_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Modelling_" type="EXPRESSION">EXPR expr:(maval(&quot;Modelling_size&quot;)) val:&quot;3&quot;</ATTRIBUTE>
+<ATTRIBUTE name="BoolBarDisplayActive" type="EXPRESSION">EXPR expr:(maval(&quot;BAR Display active&quot;)) val:&quot;No&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Knowledge Product_" type="EXPRESSION">EXPR expr:(maval(&quot;Knowledge Product_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Data Object_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Documents and Resources_" type="EXPRESSION">EXPR expr:(maval(&quot;Documents and Resources_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Data Object_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Documents and Resources_" type="EXPRESSION">EXPR expr:(maval(&quot;Documents and Resources_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Knowledge Product_" type="EXPRESSION">EXPR expr:(maval(&quot;Knowledge Product_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<INTERREF name="Data Object"></INTERREF>
+<INTERREF name="Knowledge Product"></INTERREF>
+<INTERREF name="Documents and Resources"></INTERREF>
+<INTERREF name="Knowledge Intensive"></INTERREF>
+<ATTRIBUTE name="_disp_Responsible for execution_" type="EXPRESSION">EXPR expr:(maval(&quot;Responsible for execution_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Responsible for execution_" type="EXPRESSION">EXPR expr:(maval(&quot;Responsible for execution_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Accountable for approving results_" type="EXPRESSION">EXPR expr:(maval(&quot;Accountable for approving results_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Accountable for approving results_" type="EXPRESSION">EXPR expr:(maval(&quot;Accountable for approving results_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Cooperation/participation_" type="EXPRESSION">EXPR expr:(maval(&quot;Cooperation/participation_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Cooperation/participation_" type="EXPRESSION">EXPR expr:(maval(&quot;Cooperation/participation_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_To inform_" type="EXPRESSION">EXPR expr:(maval(&quot;To inform_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_To inform_" type="EXPRESSION">EXPR expr:(maval(&quot;To inform_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Outgoing Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Outgoing Data Object_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Outgoing Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Outgoing Data Object_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Incoming Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Incoming Data Object_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Incoming Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Incoming Data Object_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<INTERREF name="Incoming Data Object"></INTERREF>
+<INTERREF name="Outgoing Data Object"></INTERREF>
+<INTERREF name="Responsible for execution"></INTERREF>
+<INTERREF name="Cooperation/participation"></INTERREF>
+<INTERREF name="Accountable for approving results"></INTERREF>
+<INTERREF name="To inform"></INTERREF>
+<INTERREF name="Referenced Case Plan Model"></INTERREF>
+</INSTANCE>
+<INSTANCE id="obj.16259" class="Sub-Process" name="Manage Inhibition">
+<ATTRIBUTE name="Position" type="STRING">NODE x:40.5cm y:21.5cm w:3.36cm h:1.95cm index:10</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<INTERREF name="Referenced subprocess"></INTERREF>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-02] Attribute \&quot;Fontcolor\&quot; (Lane) does not exist!  \&quot;fontcolor\&quot; (Sub-Process)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<RECORD name="Technical Attributes"></RECORD>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<INTERREF name="Actor"></INTERREF>
+<RECORD name="Assignments"></RECORD>
+<ATTRIBUTE name="Term" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING">Orgi.Name = Manage of the Inhibition
+don&apos;t understand what is done; what is meant with &apos;inhibition&apos;?</ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Prozeßaufruf</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Aggregated execution time" type="EXPRESSION">EXPR val:0s</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated costs" type="EXPRESSION">EXPR val:0</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated resting time" type="EXPRESSION">EXPR val:0s</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated personnel costs" type="EXPRESSION">EXPR val:0</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated waiting time" type="EXPRESSION">EXPR val:0s</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated transport time" type="EXPRESSION">EXPR val:0s</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated cycle time" type="EXPRESSION">EXPR val:0s</ATTRIBUTE>
+<ATTRIBUTE name="Open questions" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Performer" type="EXPRESSION">EXPR expr:(cond (avalf (&quot;%o&quot;, &quot;Responsible role&quot;) &lt;&gt; &quot;&quot;, &quot;({\&quot;&quot; + avalf (&quot;%o&quot;, &quot;Responsible role&quot;) + &quot;\&quot; : \&quot;Role\&quot;} &lt;- \&quot;Has role\&quot;)&quot;,&quot;&quot;)) val:error:&quot;[acoexpar-02] Attribute \&quot;Responsible role\&quot; (Sub-Process) does not exist!  \&quot;Performer\&quot; (Sub-Process)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Subprocessname" type="EXPRESSION">EXPR val:&quot;Bezeichnung&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Classification" type="ENUMERATIONLIST"></ATTRIBUTE>
+<ATTRIBUTE name="External documentation" type="PROGRAMCALL">ITEM &quot;&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="__NameGeneration__" type="STRING">NAMEGEN srcattr:&quot;Referenced subprocess&quot; format:&quot;%m&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Type" type="ENUMERATION">Embedded</ATTRIBUTE>
+<ATTRIBUTE name="Global" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16259&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Auditing" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Monitoring" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="For compensation" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Loop type" type="ENUMERATION">Not specified</ATTRIBUTE>
+<ATTRIBUTE name="Sequential execution" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Cardinality" type="STRING"></ATTRIBUTE>
+<INTERREF name="Referenced data input"></INTERREF>
+<INTERREF name="Referenced data output"></INTERREF>
+<RECORD name="Properties"></RECORD>
+<ATTRIBUTE name="Collection" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Object type" type="ENUMERATION">Information</ATTRIBUTE>
+<ATTRIBUTE name="Loop condition (standard)" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Completion condition" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Completion condition (ad-hoc)" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Suppress Sub-Process" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Actor_" type="EXPRESSION">EXPR expr:(maval(&quot;Actor_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Description_" type="EXPRESSION">EXPR expr:(maval(&quot;Description_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_Modelling_direction_" type="EXPRESSION">EXPR expr:(maval(&quot;Modelling direction&quot;)) val:&quot;vertical&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Modelling_" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="_REFERENCE_OVERVIEW_SETTINGS_" type="EXPRESSION">EXPR expr:(maval(&quot;Reference overview settings&quot;)) val:&quot;Responsible for execution|Responsible for execution\nAccountable for approving results|Accountable for approving results\nCooperation/participation|Cooperation/participation\nTo inform|To inform\nModelling|Modelling\nKnowledge Product|Knowledge Product\nDocuments and Resources|Documents and Resources\n#Data Object|Data Object\nIncoming Data Object|Incoming Data Object\nOutgoing Data Object|Outgoing Data Object\nDescription|Description&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Actor_" type="EXPRESSION">EXPR expr:(maval(&quot;Actor_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Description_" type="EXPRESSION">EXPR expr:(maval(&quot;Description_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Modelling_" type="EXPRESSION">EXPR expr:(maval(&quot;Modelling_size&quot;)) val:&quot;3&quot;</ATTRIBUTE>
+<ATTRIBUTE name="BoolBarDisplayActive" type="EXPRESSION">EXPR expr:(maval(&quot;BAR Display active&quot;)) val:&quot;No&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Knowledge Product_" type="EXPRESSION">EXPR expr:(maval(&quot;Knowledge Product_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Data Object_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Documents and Resources_" type="EXPRESSION">EXPR expr:(maval(&quot;Documents and Resources_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Data Object_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Documents and Resources_" type="EXPRESSION">EXPR expr:(maval(&quot;Documents and Resources_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Knowledge Product_" type="EXPRESSION">EXPR expr:(maval(&quot;Knowledge Product_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<INTERREF name="Data Object"></INTERREF>
+<INTERREF name="Knowledge Product"></INTERREF>
+<INTERREF name="Documents and Resources"></INTERREF>
+<INTERREF name="Knowledge Intensive"></INTERREF>
+<ATTRIBUTE name="_disp_Responsible for execution_" type="EXPRESSION">EXPR expr:(maval(&quot;Responsible for execution_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Responsible for execution_" type="EXPRESSION">EXPR expr:(maval(&quot;Responsible for execution_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Accountable for approving results_" type="EXPRESSION">EXPR expr:(maval(&quot;Accountable for approving results_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Accountable for approving results_" type="EXPRESSION">EXPR expr:(maval(&quot;Accountable for approving results_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Cooperation/participation_" type="EXPRESSION">EXPR expr:(maval(&quot;Cooperation/participation_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Cooperation/participation_" type="EXPRESSION">EXPR expr:(maval(&quot;Cooperation/participation_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_To inform_" type="EXPRESSION">EXPR expr:(maval(&quot;To inform_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_To inform_" type="EXPRESSION">EXPR expr:(maval(&quot;To inform_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Outgoing Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Outgoing Data Object_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Outgoing Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Outgoing Data Object_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Incoming Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Incoming Data Object_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Incoming Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Incoming Data Object_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<INTERREF name="Incoming Data Object"></INTERREF>
+<INTERREF name="Outgoing Data Object"></INTERREF>
+<INTERREF name="Responsible for execution"></INTERREF>
+<INTERREF name="Cooperation/participation"></INTERREF>
+<INTERREF name="Accountable for approving results"></INTERREF>
+<INTERREF name="To inform"></INTERREF>
+<INTERREF name="Referenced Case Plan Model"></INTERREF>
+</INSTANCE>
+<INSTANCE id="obj.16262" class="Task" name="Send Authorization Document">
+<ATTRIBUTE name="Position" type="STRING">NODE x:45cm y:13cm w:3.36cm h:1.8cm index:11</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Performer" type="EXPRESSION">EXPR expr:(&quot;&quot;) val:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Execution time" type="TIME">00:000:00:00:00</ATTRIBUTE>
+<ATTRIBUTE name="Waiting time" type="TIME">00:000:00:00:00</ATTRIBUTE>
+<ATTRIBUTE name="Resting time" type="TIME">00:000:00:00:00</ATTRIBUTE>
+<ATTRIBUTE name="Transport time" type="TIME">00:000:00:00:00</ATTRIBUTE>
+<ATTRIBUTE name="Priority" type="INTEGER">10</ATTRIBUTE>
+<ATTRIBUTE name="Done by" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Continuous execution" type="ENUMERATION">no</ATTRIBUTE>
+<ATTRIBUTE name="Max. resource waiting time" type="TIME">00:000:00:05:00</ATTRIBUTE>
+<ATTRIBUTE name="Cooperative" type="ENUMERATION">no</ATTRIBUTE>
+<ATTRIBUTE name="Cooperation mode" type="ENUMERATION">synchron</ATTRIBUTE>
+<ATTRIBUTE name="Average number of participants" type="INTEGER">1</ATTRIBUTE>
+<ATTRIBUTE name="Min. quota of presence" type="INTEGER">100</ATTRIBUTE>
+<ATTRIBUTE name="Max. start period" type="TIME">00:001:00:00:00</ATTRIBUTE>
+<ATTRIBUTE name="Execution interruptable" type="ENUMERATION">yes</ATTRIBUTE>
+<ATTRIBUTE name="Task stack" type="ENUMERATION">personal</ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-02] Attribute \&quot;Fontcolor\&quot; (Lane) does not exist!  \&quot;fontcolor\&quot; (Task)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<RECORD name="Technical Attributes"></RECORD>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<INTERREF name="Actor"></INTERREF>
+<RECORD name="Assignments"></RECORD>
+<ATTRIBUTE name="Term" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Status" type="ENUMERATION">None</ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="External documentation" type="PROGRAMCALL">ITEM &quot;&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Info on results" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Number" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated execution time" type="TIME">00:000:00:00:00</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated waiting time" type="TIME">00:000:00:00:00</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated resting time" type="TIME">00:000:00:00:00</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated transport time" type="TIME">00:000:00:00:00</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Aggregated personnel costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Classification" type="ENUMERATIONLIST"></ATTRIBUTE>
+<ATTRIBUTE name="EDP transaction costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="EDP batch costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Printing costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Postal costs" type="DOUBLE">0</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Aktivität</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Open questions" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Type" type="ENUMERATION">Standard</ATTRIBUTE>
+<INTERREF name="referenced subprocess"></INTERREF>
+<ATTRIBUTE name="Display responsible role" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Subprocessname" type="EXPRESSION">EXPR val:&quot;Bezeichnung&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Modelling direction" type="EXPRESSION">EXPR val:&quot;vertical&quot;</ATTRIBUTE>
+<RECORD name="Properties"></RECORD>
+<ATTRIBUTE name="Show name" type="ENUMERATION">center</ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16262&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Task type" type="ENUMERATION">Send</ATTRIBUTE>
+<ATTRIBUTE name="Global task" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Auditing" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Monitoring" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="For compensation" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Loop type" type="ENUMERATION">Not specified</ATTRIBUTE>
+<INTERREF name="Call activity"></INTERREF>
+<ATTRIBUTE name="Sequential execution" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Cardinality" type="STRING"></ATTRIBUTE>
+<INTERREF name="Referenced data input"></INTERREF>
+<INTERREF name="Referenced data output"></INTERREF>
+<ATTRIBUTE name="Instantiate" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Collection" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Object type" type="ENUMERATION">Information</ATTRIBUTE>
+<ATTRIBUTE name="Completion condition" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Loop condition (standard)" type="STRING"></ATTRIBUTE>
+<INTERREF name="Referenced message"></INTERREF>
+<ATTRIBUTE name="People-like_view_Expression" type="EXPRESSION">EXPR expr:(maval(&quot;People-like view&quot;)) val:&quot;No&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Action" type="ENUMERATION">Fill in</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Actor_" type="EXPRESSION">EXPR expr:(maval(&quot;Actor_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Description_" type="EXPRESSION">EXPR expr:(maval(&quot;Description_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_Modelling_direction_" type="EXPRESSION">EXPR expr:(maval(&quot;Modelling direction&quot;)) val:&quot;vertical&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Modelling_" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="_REFERENCE_OVERVIEW_SETTINGS_" type="EXPRESSION">EXPR expr:(maval(&quot;Reference overview settings&quot;)) val:&quot;Responsible for execution|Responsible for execution\nAccountable for approving results|Accountable for approving results\nCooperation/participation|Cooperation/participation\nTo inform|To inform\nModelling|Modelling\nKnowledge Product|Knowledge Product\nDocuments and Resources|Documents and Resources\n#Data Object|Data Object\nIncoming Data Object|Incoming Data Object\nOutgoing Data Object|Outgoing Data Object\nDescription|Description&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Actor_" type="EXPRESSION">EXPR expr:(maval(&quot;Actor_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Description_" type="EXPRESSION">EXPR expr:(maval(&quot;Description_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Modelling_" type="EXPRESSION">EXPR expr:(maval(&quot;Modelling_size&quot;)) val:&quot;3&quot;</ATTRIBUTE>
+<ATTRIBUTE name="BoolBarDisplayActive" type="EXPRESSION">EXPR expr:(maval(&quot;BAR Display active&quot;)) val:&quot;No&quot;</ATTRIBUTE>
+<INTERREF name="Data Object"></INTERREF>
+<INTERREF name="Knowledge Product"></INTERREF>
+<INTERREF name="Documents and Resources"></INTERREF>
+<ATTRIBUTE name="_disp_Knowledge Product_" type="EXPRESSION">EXPR expr:(maval(&quot;Knowledge Product_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Data Object_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Documents and Resources_" type="EXPRESSION">EXPR expr:(maval(&quot;Documents and Resources_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Data Object_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Documents and Resources_" type="EXPRESSION">EXPR expr:(maval(&quot;Documents and Resources_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Knowledge Product_" type="EXPRESSION">EXPR expr:(maval(&quot;Knowledge Product_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Responsible for execution_" type="EXPRESSION">EXPR expr:(maval(&quot;Responsible for execution_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Responsible for execution_" type="EXPRESSION">EXPR expr:(maval(&quot;Responsible for execution_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Accountable for approving results_" type="EXPRESSION">EXPR expr:(maval(&quot;Accountable for approving results_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Accountable for approving results_" type="EXPRESSION">EXPR expr:(maval(&quot;Accountable for approving results_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Cooperation/participation_" type="EXPRESSION">EXPR expr:(maval(&quot;Cooperation/participation_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Cooperation/participation_" type="EXPRESSION">EXPR expr:(maval(&quot;Cooperation/participation_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_To inform_" type="EXPRESSION">EXPR expr:(maval(&quot;To inform_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_To inform_" type="EXPRESSION">EXPR expr:(maval(&quot;To inform_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<INTERREF name="Responsible for execution"></INTERREF>
+<INTERREF name="To inform"></INTERREF>
+<INTERREF name="Cooperation/participation"></INTERREF>
+<INTERREF name="Accountable for approving results"></INTERREF>
+<INTERREF name="Incoming Data Object"></INTERREF>
+<INTERREF name="Outgoing Data Object"></INTERREF>
+<ATTRIBUTE name="_size_Outgoing Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Outgoing Data Object_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Outgoing Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Outgoing Data Object_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_size_Incoming Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Incoming Data Object_size&quot;)) val:&quot;1&quot;</ATTRIBUTE>
+<ATTRIBUTE name="_disp_Incoming Data Object_" type="EXPRESSION">EXPR expr:(maval(&quot;Incoming Data Object_display&quot;)) val:&quot;Yes&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Commentboxcomment" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="CommentAreaSizeExp" type="EXPRESSION">EXPR expr:(maval(&quot;CommentAreaSize&quot;)) val:&quot;2&quot;</ATTRIBUTE>
+<ATTRIBUTE name="CommentBool" type="ENUMERATION">0</ATTRIBUTE>
+<ATTRIBUTE name="CommentBox" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="CommentInfo" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="CommentMode" type="EXPRESSION">EXPR expr:(maval(&quot;Comment Mode&quot;)) val:&quot;No&quot;</ATTRIBUTE>
+<RECORD name="CommentTable"></RECORD>
+<ATTRIBUTE name="WriteComment" type="PROGRAMCALL">ITEM &quot;Add Comment&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="ClearComment" type="PROGRAMCALL">ITEM &quot;Clear Comment&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="CommentModellingAreaSizeExp" type="EXPRESSION">EXPR expr:(maval(&quot;CommentModellingAreaSize&quot;)) val:&quot;3&quot;</ATTRIBUTE>
+<ATTRIBUTE name="BoolCommentModeActive" type="EXPRESSION">EXPR expr:(maval(&quot;Comment Mode&quot;)) val:&quot;No&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Comment Model Direction" type="EXPRESSION">EXPR expr:(maval(&quot;CommentModellingDirection&quot;)) val:&quot;vertical&quot;</ATTRIBUTE>
+<INTERREF name="Decision"></INTERREF>
+<INTERREF name="Referenced documents"></INTERREF>
+<ATTRIBUTE name="Left border" type="EXPRESSION">EXPR
+ val:43.32</ATTRIBUTE>
+<INTERREF name="Referenced Planning Table"></INTERREF>
+<ATTRIBUTE name="Right border" type="EXPRESSION">EXPR
+ val:46.68</ATTRIBUTE>
+<ATTRIBUTE name="Show or Hide" type="ENUMERATION">Shown</ATTRIBUTE>
+<ATTRIBUTE name="Top border" type="EXPRESSION">EXPR
+ val:12.1</ATTRIBUTE>
+<ATTRIBUTE name="Bottom border" type="EXPRESSION">EXPR
+ val:13.9</ATTRIBUTE>
+<ATTRIBUTE name="X" type="EXPRESSION">EXPR
+ val:45</ATTRIBUTE>
+<ATTRIBUTE name="Y" type="EXPRESSION">EXPR
+ val:13</ATTRIBUTE>
+<ATTRIBUTE name="Change Visibility" type="PROGRAMCALL">ITEM &quot;Change Visibility&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Planning Table" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Bounding box" type="EXPRESSION">EXPR
+ val:&quot;[12.1,13.9,43.32,46.68,45,13]&quot;</ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16265" class="Exclusive Gateway" name="reject application?">
+<ATTRIBUTE name="Position" type="STRING">NODE x:19cm y:15cm index:12</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Variable type" type="ENUMERATION">enumeration</ATTRIBUTE>
+<ATTRIBUTE name="Variable scope" type="ENUMERATION">global</ATTRIBUTE>
+<ATTRIBUTE name="Variable name" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Variable value" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-02] Attribute \&quot;Fontcolor\&quot; (Lane) does not exist!  \&quot;fontcolor\&quot; (Exclusive Gateway)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<RECORD name="Technical Attributes"></RECORD>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<INTERREF name="Actor"></INTERREF>
+<RECORD name="Assignments"></RECORD>
+<ATTRIBUTE name="Term" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING">Orig.Name = is Rejected?</ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Entscheidung</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Open questions" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Sum" type="EXPRESSION">EXPR
+ val:0</ATTRIBUTE>
+<ATTRIBUTE name="Type" type="ENUMERATION">Data-based (without marker)</ATTRIBUTE>
+<ATTRIBUTE name="Show name" type="ENUMERATION">below</ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16265&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Constraints" type="ENUMERATION">Unspecified</ATTRIBUTE>
+<RECORD name="Properties"></RECORD>
+<ATTRIBUTE name="Cardinality" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16268" class="Intermediate Event (boundary)" name="Intermediate Event (boundary)-83066">
+<ATTRIBUTE name="Position" type="STRING">NODE x:28.5cm y:14cm index:16</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(&quot;&quot;) val:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<RECORD name="Technical Attributes"></RECORD>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<INTERREF name="Actor"></INTERREF>
+<RECORD name="Assignments"></RECORD>
+<ATTRIBUTE name="Term" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR expr:(&quot;&quot;) val:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING">first implementation: display events as buttons to trigger change of flow</ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING">further development:
+1) enhance BPMN meta model properties for events &gt; trigger/description
+2) display time gone for timer trigger
+
+</ATTRIBUTE>
+<ATTRIBUTE name="External documentation" type="PROGRAMCALL">ITEM &quot;&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Open questions" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Auslöser</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<INTERREF name="Referenced trigger"></INTERREF>
+<ATTRIBUTE name="Modelling direction" type="EXPRESSION">EXPR expr:(&quot;&quot;) val:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Type" type="ENUMERATION">interrupting</ATTRIBUTE>
+<ATTRIBUTE name="Show name" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16268&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Message" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Timer" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Conditional" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Signal" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Escalation" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Error" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Compensation" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Parallel" type="ENUMERATION">No</ATTRIBUTE>
+<INTERREF name="Referenced message"></INTERREF>
+<ATTRIBUTE name="Cancel" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="cancelActivity" type="ENUMERATION">No</ATTRIBUTE>
+<RECORD name="Properties"></RECORD>
+<INTERREF name="Attached to">
+<IREF type="objectreference" tmodeltype="Business process diagram (BPMN 2.0)" tmodelname="TitoloUnico_MontiAzzurrSUB" tmodelver="" tclassname="Sub-Process" tobjname="Manage of 3rd Party Admin"></IREF>
+</INTERREF>
+<ATTRIBUTE name="Auditing" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Monitoring" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Cancel activity" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Collection" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Object type" type="ENUMERATION">Information</ATTRIBUTE>
+<ATTRIBUTE name="Cardinality" type="STRING"></ATTRIBUTE>
+<INTERREF name="Referenced activity"></INTERREF>
+<ATTRIBUTE name="Details" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Timer type" type="ENUMERATION">Date</ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16271" class="Intermediate Event (boundary)" name="Intermediate Event (boundary)-83071">
+<ATTRIBUTE name="Position" type="STRING">NODE x:37cm y:14cm index:17</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(&quot;&quot;) val:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<RECORD name="Technical Attributes"></RECORD>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<INTERREF name="Actor"></INTERREF>
+<RECORD name="Assignments"></RECORD>
+<ATTRIBUTE name="Term" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR expr:(&quot;&quot;) val:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="External documentation" type="PROGRAMCALL">ITEM &quot;&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Open questions" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Auslöser</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<INTERREF name="Referenced trigger"></INTERREF>
+<ATTRIBUTE name="Modelling direction" type="EXPRESSION">EXPR expr:(&quot;&quot;) val:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Type" type="ENUMERATION">interrupting</ATTRIBUTE>
+<ATTRIBUTE name="Show name" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16271&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Message" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Timer" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Conditional" type="ENUMERATION">Yes</ATTRIBUTE>
+<ATTRIBUTE name="Signal" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Escalation" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Error" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Compensation" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Parallel" type="ENUMERATION">No</ATTRIBUTE>
+<INTERREF name="Referenced message"></INTERREF>
+<ATTRIBUTE name="Cancel" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="cancelActivity" type="ENUMERATION">No</ATTRIBUTE>
+<RECORD name="Properties"></RECORD>
+<INTERREF name="Attached to">
+<IREF type="objectreference" tmodeltype="Business process diagram (BPMN 2.0)" tmodelname="TitoloUnico_MontiAzzurrSUB" tmodelver="" tclassname="Sub-Process" tobjname="Check Integration"></IREF>
+</INTERREF>
+<ATTRIBUTE name="Auditing" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Monitoring" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Cancel activity" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Collection" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Object type" type="ENUMERATION">Information</ATTRIBUTE>
+<ATTRIBUTE name="Cardinality" type="STRING"></ATTRIBUTE>
+<INTERREF name="Referenced activity"></INTERREF>
+<ATTRIBUTE name="Details" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Timer type" type="ENUMERATION">Date</ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16274" class="Exclusive Gateway" name="integration necessary?">
+<ATTRIBUTE name="Position" type="STRING">NODE x:31.5cm y:13cm index:18</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Variable type" type="ENUMERATION">enumeration</ATTRIBUTE>
+<ATTRIBUTE name="Variable scope" type="ENUMERATION">global</ATTRIBUTE>
+<ATTRIBUTE name="Variable name" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Variable value" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-02] Attribute \&quot;Fontcolor\&quot; (Lane) does not exist!  \&quot;fontcolor\&quot; (Exclusive Gateway)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<RECORD name="Technical Attributes"></RECORD>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<INTERREF name="Actor"></INTERREF>
+<RECORD name="Assignments"></RECORD>
+<ATTRIBUTE name="Term" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Entscheidung</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Open questions" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Sum" type="EXPRESSION">EXPR
+ val:0</ATTRIBUTE>
+<ATTRIBUTE name="Type" type="ENUMERATION">Data-based (without marker)</ATTRIBUTE>
+<ATTRIBUTE name="Show name" type="ENUMERATION">below</ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16274&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Constraints" type="ENUMERATION">Unspecified</ATTRIBUTE>
+<RECORD name="Properties"></RECORD>
+<ATTRIBUTE name="Cardinality" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16277" class="End Event" name="End Event-83081">
+<ATTRIBUTE name="Position" type="STRING">NODE x:49cm y:13cm index:19</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Type" type="ENUMERATION">local</ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-02] Attribute \&quot;Fontcolor\&quot; (Lane) does not exist!  \&quot;fontcolor\&quot; (End Event)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<RECORD name="Technical Attributes"></RECORD>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<INTERREF name="Actor"></INTERREF>
+<ATTRIBUTE name="Representation" type="ENUMERATION">without name</ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Ende</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Show name" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Open questions" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16277&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Message" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Signal" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Escalation" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Error" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Compensation" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Terminate" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Cancel" type="ENUMERATION">No</ATTRIBUTE>
+<RECORD name="Properties"></RECORD>
+<ATTRIBUTE name="Auditing" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Monitoring" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Collection" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Object type" type="ENUMERATION">Information</ATTRIBUTE>
+<ATTRIBUTE name="Cardinality" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Details" type="LONGSTRING"></ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16280" class="Exclusive Gateway" name="manage conf directly?">
+<ATTRIBUTE name="Position" type="STRING">NODE x:22.5cm y:15cm index:21</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Variable type" type="ENUMERATION">enumeration</ATTRIBUTE>
+<ATTRIBUTE name="Variable scope" type="ENUMERATION">global</ATTRIBUTE>
+<ATTRIBUTE name="Variable name" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Variable value" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-02] Attribute \&quot;Fontcolor\&quot; (Lane) does not exist!  \&quot;fontcolor\&quot; (Exclusive Gateway)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<RECORD name="Technical Attributes"></RECORD>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<INTERREF name="Actor"></INTERREF>
+<RECORD name="Assignments"></RECORD>
+<ATTRIBUTE name="Term" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Entscheidung</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Open questions" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Sum" type="EXPRESSION">EXPR
+ val:0</ATTRIBUTE>
+<ATTRIBUTE name="Type" type="ENUMERATION">Data-based (without marker)</ATTRIBUTE>
+<ATTRIBUTE name="Show name" type="ENUMERATION">below</ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16280&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Constraints" type="ENUMERATION">Unspecified</ATTRIBUTE>
+<RECORD name="Properties"></RECORD>
+<ATTRIBUTE name="Cardinality" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16283" class="Exclusive Gateway" name="Exclusive Gateway-83095">
+<ATTRIBUTE name="Position" type="STRING">NODE x:22.5cm y:19cm index:24</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Variable type" type="ENUMERATION">enumeration</ATTRIBUTE>
+<ATTRIBUTE name="Variable scope" type="ENUMERATION">global</ATTRIBUTE>
+<ATTRIBUTE name="Variable name" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Variable value" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-02] Attribute \&quot;Fontcolor\&quot; (Lane) does not exist!  \&quot;fontcolor\&quot; (Exclusive Gateway)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<RECORD name="Technical Attributes"></RECORD>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<INTERREF name="Actor"></INTERREF>
+<RECORD name="Assignments"></RECORD>
+<ATTRIBUTE name="Term" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Entscheidung</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Open questions" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Sum" type="EXPRESSION">EXPR
+ val:0</ATTRIBUTE>
+<ATTRIBUTE name="Type" type="ENUMERATION">Data-based (without marker)</ATTRIBUTE>
+<ATTRIBUTE name="Show name" type="ENUMERATION">do not show</ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16283&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Constraints" type="ENUMERATION">Unspecified</ATTRIBUTE>
+<RECORD name="Properties"></RECORD>
+<ATTRIBUTE name="Cardinality" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16286" class="Exclusive Gateway" name="is decision taken?">
+<ATTRIBUTE name="Position" type="STRING">NODE x:40.5cm y:13cm index:32</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Variable type" type="ENUMERATION">enumeration</ATTRIBUTE>
+<ATTRIBUTE name="Variable scope" type="ENUMERATION">global</ATTRIBUTE>
+<ATTRIBUTE name="Variable name" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Variable value" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(set(targets, ctobjs(&quot;Is inside&quot;)),
+cond
+  (tokcnt(targets,&quot; &quot;)=0,&quot;black&quot;,
+    (cond
+      (tokcnt(targets,&quot; &quot;)=1,aval (VAL ctobjs(&quot;Is inside&quot;), &quot;Fontcolor&quot;),
+    (
+    set(tk,token(targets,0,&quot; &quot;)),
+                set(t,VAL (copy(aval(VAL tk, &quot;Position&quot;),search(aval(VAL tk, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+    fortok(x,targets,&quot; &quot;,
+        (
+        set(c,VAL (copy(aval(VAL x, &quot;Position&quot;),search(aval(VAL x, &quot;Position&quot;),&quot;index&quot;,0)+6,-1))),
+        cond(c&gt;=t,(set(res,x),set(t,c)),&quot;&quot;)
+        )),
+                aval (VAL res, &quot;Fontcolor&quot;)
+    ))
+   )
+  )) val:error:&quot;[acoexpar-02] Attribute \&quot;Fontcolor\&quot; (Lane) does not exist!  \&quot;fontcolor\&quot; (Exclusive Gateway)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<RECORD name="Technical Attributes"></RECORD>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<INTERREF name="Actor"></INTERREF>
+<RECORD name="Assignments"></RECORD>
+<ATTRIBUTE name="Term" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Order" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Entscheidung</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Open questions" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Sum" type="EXPRESSION">EXPR
+ val:0</ATTRIBUTE>
+<ATTRIBUTE name="Type" type="ENUMERATION">Data-based (without marker)</ATTRIBUTE>
+<ATTRIBUTE name="Show name" type="ENUMERATION">below</ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16286&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Constraints" type="ENUMERATION">Unspecified</ATTRIBUTE>
+<RECORD name="Properties"></RECORD>
+<ATTRIBUTE name="Cardinality" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<INSTANCE id="obj.16289" class="Data Object" name="Titolo Unico">
+<ATTRIBUTE name="Position" type="STRING">NODE x:45cm y:16.5cm index:40</ATTRIBUTE>
+<ATTRIBUTE name="External tool coupling" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="fontcolor" type="EXPRESSION">EXPR expr:(&quot;&quot;) val:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<RECORD name="Technical Attributes"></RECORD>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Collection" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Open questions" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Data type" type="ENUMERATION">Data Output</ATTRIBUTE>
+<INTERREF name="Referenced input data (optional)"></INTERREF>
+<INTERREF name="Referenced input data (while executing)"></INTERREF>
+<ATTRIBUTE name="Collection (input)" type="ENUMERATION">No</ATTRIBUTE>
+<INTERREF name="Referenced output data (optional)">
+<IREF type="objectreference" tmodeltype="Document and Knowledge model" tmodelname="Document and Knowledge model TitoloUnico" tmodelver="" tclassname="Document" tobjname="Titolo Unico Authorization Document"></IREF>
+</INTERREF>
+<INTERREF name="Referenced output data (while executing)"></INTERREF>
+<ATTRIBUTE name="Collection (output)" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Capacity" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Unlimited" type="ENUMERATION">No</ATTRIBUTE>
+<INTERREF name="Referenced data store (global)"></INTERREF>
+<ATTRIBUTE name="Auditing" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Monitoring" type="ENUMERATION">No</ATTRIBUTE>
+<RECORD name="Properties"></RECORD>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16289&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Cardinality" type="STRING"></ATTRIBUTE>
+</INSTANCE>
+<CONNECTOR id="con.16292" class="Message Flow">
+<FROM instance="Entrepreneur" class="Pool (collapsed)"></FROM>
+<TO instance="Start Event-83017" class="Start Event"></TO>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 1 x1:7cm y1:5cm index:38</ATTRIBUTE>
+<ATTRIBUTE name="Message Name" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="ParticipantType (from)" type="ENUMERATION">Role</ATTRIBUTE>
+<ATTRIBUTE name="Role (from)" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Entity (from)" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="ParticipantType (to)" type="ENUMERATION">Role</ATTRIBUTE>
+<ATTRIBUTE name="Role (to)" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Entity (to)" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Name" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Message Properties" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;Start Event&quot;</ATTRIBUTE>
+<ATTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Pool (collapsed)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Number" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Show Name" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Show Number" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Representation" type="ENUMERATION">above/below</ATTRIBUTE>
+<ATTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Description" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Show name" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Doku" type="STRING">NOTEBOOK
+
+#-----------------------
+CHAPTER &quot;Description&quot;
+#-----------------------
+ATTR &quot;Name&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+ATTR &quot;Id&quot; </ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16292&quot;</ATTRIBUTE>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16293" class="Is inside">
+<FROM instance="Office SUAP" class="Lane"></FROM>
+<TO instance="Monti Azzurri Consorsium" class="Pool"></TO>
+<ATTRIBUTE name="AutoConnect" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16294" class="Is inside">
+<FROM instance="Start Event-83017" class="Start Event"></FROM>
+<TO instance="Monti Azzurri Consorsium" class="Pool"></TO>
+<ATTRIBUTE name="AutoConnect" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16295" class="Is inside">
+<FROM instance="Start Event-83017" class="Start Event"></FROM>
+<TO instance="Office SUAP" class="Lane"></TO>
+<ATTRIBUTE name="AutoConnect" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16296" class="Subsequent">
+<FROM instance="Start Event-83017" class="Start Event"></FROM>
+<TO instance="Receive Instance" class="Sub-Process"></TO>
+<ATTRIBUTE name="Transition condition" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Transition probability" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualized values" type="ENUMERATION">Denomination</ATTRIBUTE>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 0 index:13</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">1</ATTRIBUTE>
+<ATTRIBUTE name="Representation" type="ENUMERATION">above/below</ATTRIBUTE>
+<ATTRIBUTE name="Font colour" type="ENUMERATION">black</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Info zur Übergangsbedingung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Nachfolger</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Denomination" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Description" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Auditing" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Monitoring" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Default" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Immediate" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Category" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16296&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Color" type="STRING">black</ATTRIBUTE>
+<ATTRIBUTE name="Doku" type="STRING">NOTEBOOK
+
+#-----------------------
+LANG &quot;en&quot;
+#-----------------------
+CHAPTER &quot;Description&quot;
+ATTR &quot;Denomination&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+
+
+CHAPTER &quot;Details (BPMN)&quot;
+
+ATTR &quot;Auditing&quot; 
+ATTR &quot;Monitoring&quot; 
+
+ATTR &quot;Default&quot; 
+ATTR &quot;Immediate&quot; 
+ATTR &quot;Category&quot;
+ATTR &quot;Id&quot; 
+
+
+CHAPTER &quot;Details (Simulation)&quot;
+
+ATTR &quot;Transition condition&quot; dialog:transcond
+
+ATTR &quot;Transition probability&quot;
+
+</ATTRIBUTE>
+<ATTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;Sub-Process&quot;</ATTRIBUTE>
+<ATTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Start Event&quot;</ATTRIBUTE>
+<ATTRIBUTE name="ModelTypeExp" type="EXPRESSION">EXPR val:&quot;Business process diagram (BPMN 2.0)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16297" class="Is inside">
+<FROM instance="Receive Instance" class="Sub-Process"></FROM>
+<TO instance="Monti Azzurri Consorsium" class="Pool"></TO>
+<ATTRIBUTE name="AutoConnect" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16298" class="Is inside">
+<FROM instance="Receive Instance" class="Sub-Process"></FROM>
+<TO instance="Office SUAP" class="Lane"></TO>
+<ATTRIBUTE name="AutoConnect" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16299" class="Subsequent">
+<FROM instance="Receive Instance" class="Sub-Process"></FROM>
+<TO instance="Assess Application" class="Sub-Process"></TO>
+<ATTRIBUTE name="Transition condition" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Transition probability" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualized values" type="ENUMERATION">Denomination</ATTRIBUTE>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 0 index:14</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">2</ATTRIBUTE>
+<ATTRIBUTE name="Representation" type="ENUMERATION">above/below</ATTRIBUTE>
+<ATTRIBUTE name="Font colour" type="ENUMERATION">black</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Info zur Übergangsbedingung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Nachfolger</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Denomination" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Description" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Auditing" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Monitoring" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Default" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Immediate" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Category" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16299&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Color" type="STRING">black</ATTRIBUTE>
+<ATTRIBUTE name="Doku" type="STRING">NOTEBOOK
+
+#-----------------------
+LANG &quot;en&quot;
+#-----------------------
+CHAPTER &quot;Description&quot;
+ATTR &quot;Denomination&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+
+
+CHAPTER &quot;Details (BPMN)&quot;
+
+ATTR &quot;Auditing&quot; 
+ATTR &quot;Monitoring&quot; 
+
+ATTR &quot;Default&quot; 
+ATTR &quot;Immediate&quot; 
+ATTR &quot;Category&quot;
+ATTR &quot;Id&quot; 
+
+
+CHAPTER &quot;Details (Simulation)&quot;
+
+ATTR &quot;Transition condition&quot; dialog:transcond
+
+ATTR &quot;Transition probability&quot;
+
+</ATTRIBUTE>
+<ATTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;Sub-Process&quot;</ATTRIBUTE>
+<ATTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Sub-Process&quot;</ATTRIBUTE>
+<ATTRIBUTE name="ModelTypeExp" type="EXPRESSION">EXPR val:&quot;Business process diagram (BPMN 2.0)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16300" class="Is inside">
+<FROM instance="Assess Application" class="Sub-Process"></FROM>
+<TO instance="Monti Azzurri Consorsium" class="Pool"></TO>
+<ATTRIBUTE name="AutoConnect" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16301" class="Is inside">
+<FROM instance="Assess Application" class="Sub-Process"></FROM>
+<TO instance="Office SUAP" class="Lane"></TO>
+<ATTRIBUTE name="AutoConnect" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16302" class="Subsequent">
+<FROM instance="Assess Application" class="Sub-Process"></FROM>
+<TO instance="reject application?" class="Exclusive Gateway"></TO>
+<ATTRIBUTE name="Transition condition" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Transition probability" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualized values" type="ENUMERATION">Denomination</ATTRIBUTE>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 0 index:15</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">3</ATTRIBUTE>
+<ATTRIBUTE name="Representation" type="ENUMERATION">above/below</ATTRIBUTE>
+<ATTRIBUTE name="Font colour" type="ENUMERATION">black</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Info zur Übergangsbedingung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Nachfolger</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Denomination" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Description" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Auditing" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Monitoring" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Default" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Immediate" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Category" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16302&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Color" type="STRING">black</ATTRIBUTE>
+<ATTRIBUTE name="Doku" type="STRING">NOTEBOOK
+
+#-----------------------
+LANG &quot;en&quot;
+#-----------------------
+CHAPTER &quot;Description&quot;
+ATTR &quot;Denomination&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+
+
+CHAPTER &quot;Details (BPMN)&quot;
+
+ATTR &quot;Auditing&quot; 
+ATTR &quot;Monitoring&quot; 
+
+ATTR &quot;Default&quot; 
+ATTR &quot;Immediate&quot; 
+ATTR &quot;Category&quot;
+ATTR &quot;Id&quot; 
+
+
+CHAPTER &quot;Details (Simulation)&quot;
+
+ATTR &quot;Transition condition&quot; dialog:transcond
+
+ATTR &quot;Transition probability&quot;
+
+</ATTRIBUTE>
+<ATTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;Exclusive Gateway&quot;</ATTRIBUTE>
+<ATTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Sub-Process&quot;</ATTRIBUTE>
+<ATTRIBUTE name="ModelTypeExp" type="EXPRESSION">EXPR val:&quot;Business process diagram (BPMN 2.0)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16303" class="Is inside">
+<FROM instance="Manage of 3rd Party Admin" class="Sub-Process"></FROM>
+<TO instance="Monti Azzurri Consorsium" class="Pool"></TO>
+<ATTRIBUTE name="AutoConnect" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16304" class="Is inside">
+<FROM instance="Manage of 3rd Party Admin" class="Sub-Process"></FROM>
+<TO instance="Office SUAP" class="Lane"></TO>
+<ATTRIBUTE name="AutoConnect" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16305" class="Subsequent">
+<FROM instance="Manage of 3rd Party Admin" class="Sub-Process"></FROM>
+<TO instance="integration necessary?" class="Exclusive Gateway"></TO>
+<ATTRIBUTE name="Transition condition" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Transition probability" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualized values" type="ENUMERATION">Denomination</ATTRIBUTE>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 0 index:29</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">11</ATTRIBUTE>
+<ATTRIBUTE name="Representation" type="ENUMERATION">above/below</ATTRIBUTE>
+<ATTRIBUTE name="Font colour" type="ENUMERATION">black</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Info zur Übergangsbedingung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Nachfolger</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Denomination" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Description" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Auditing" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Monitoring" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Default" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Immediate" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Category" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16305&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Color" type="STRING">black</ATTRIBUTE>
+<ATTRIBUTE name="Doku" type="STRING">NOTEBOOK
+
+#-----------------------
+LANG &quot;en&quot;
+#-----------------------
+CHAPTER &quot;Description&quot;
+ATTR &quot;Denomination&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+
+
+CHAPTER &quot;Details (BPMN)&quot;
+
+ATTR &quot;Auditing&quot; 
+ATTR &quot;Monitoring&quot; 
+
+ATTR &quot;Default&quot; 
+ATTR &quot;Immediate&quot; 
+ATTR &quot;Category&quot;
+ATTR &quot;Id&quot; 
+
+
+CHAPTER &quot;Details (Simulation)&quot;
+
+ATTR &quot;Transition condition&quot; dialog:transcond
+
+ATTR &quot;Transition probability&quot;
+
+</ATTRIBUTE>
+<ATTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;Exclusive Gateway&quot;</ATTRIBUTE>
+<ATTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Sub-Process&quot;</ATTRIBUTE>
+<ATTRIBUTE name="ModelTypeExp" type="EXPRESSION">EXPR val:&quot;Business process diagram (BPMN 2.0)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16306" class="Is inside">
+<FROM instance="Manage Service Conference" class="Sub-Process"></FROM>
+<TO instance="Monti Azzurri Consorsium" class="Pool"></TO>
+<ATTRIBUTE name="AutoConnect" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16307" class="Is inside">
+<FROM instance="Manage Service Conference" class="Sub-Process"></FROM>
+<TO instance="Office SUAP" class="Lane"></TO>
+<ATTRIBUTE name="AutoConnect" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16308" class="Subsequent">
+<FROM instance="Manage Service Conference" class="Sub-Process"></FROM>
+<TO instance="integration necessary?" class="Exclusive Gateway"></TO>
+<ATTRIBUTE name="Transition condition" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Transition probability" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualized values" type="ENUMERATION">Denomination</ATTRIBUTE>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 1 x1:31.5cm y1:21.5cm index:28</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">10</ATTRIBUTE>
+<ATTRIBUTE name="Representation" type="ENUMERATION">above/below</ATTRIBUTE>
+<ATTRIBUTE name="Font colour" type="ENUMERATION">black</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Info zur Übergangsbedingung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Nachfolger</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Denomination" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Description" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Auditing" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Monitoring" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Default" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Immediate" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Category" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16308&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Color" type="STRING">black</ATTRIBUTE>
+<ATTRIBUTE name="Doku" type="STRING">NOTEBOOK
+
+#-----------------------
+LANG &quot;en&quot;
+#-----------------------
+CHAPTER &quot;Description&quot;
+ATTR &quot;Denomination&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+
+
+CHAPTER &quot;Details (BPMN)&quot;
+
+ATTR &quot;Auditing&quot; 
+ATTR &quot;Monitoring&quot; 
+
+ATTR &quot;Default&quot; 
+ATTR &quot;Immediate&quot; 
+ATTR &quot;Category&quot;
+ATTR &quot;Id&quot; 
+
+
+CHAPTER &quot;Details (Simulation)&quot;
+
+ATTR &quot;Transition condition&quot; dialog:transcond
+
+ATTR &quot;Transition probability&quot;
+
+</ATTRIBUTE>
+<ATTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;Exclusive Gateway&quot;</ATTRIBUTE>
+<ATTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Sub-Process&quot;</ATTRIBUTE>
+<ATTRIBUTE name="ModelTypeExp" type="EXPRESSION">EXPR val:&quot;Business process diagram (BPMN 2.0)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16309" class="Is inside">
+<FROM instance="Check Integration" class="Sub-Process"></FROM>
+<TO instance="Monti Azzurri Consorsium" class="Pool"></TO>
+<ATTRIBUTE name="AutoConnect" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16310" class="Is inside">
+<FROM instance="Check Integration" class="Sub-Process"></FROM>
+<TO instance="Office SUAP" class="Lane"></TO>
+<ATTRIBUTE name="AutoConnect" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16311" class="Subsequent">
+<FROM instance="Check Integration" class="Sub-Process"></FROM>
+<TO instance="is decision taken?" class="Exclusive Gateway"></TO>
+<ATTRIBUTE name="Transition condition" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Transition probability" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualized values" type="ENUMERATION">Denomination</ATTRIBUTE>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 0 index:33</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">14</ATTRIBUTE>
+<ATTRIBUTE name="Representation" type="ENUMERATION">above/below</ATTRIBUTE>
+<ATTRIBUTE name="Font colour" type="ENUMERATION">black</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Info zur Übergangsbedingung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Nachfolger</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Denomination" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Description" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Auditing" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Monitoring" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Default" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Immediate" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Category" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16311&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Color" type="STRING">black</ATTRIBUTE>
+<ATTRIBUTE name="Doku" type="STRING">NOTEBOOK
+
+#-----------------------
+LANG &quot;en&quot;
+#-----------------------
+CHAPTER &quot;Description&quot;
+ATTR &quot;Denomination&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+
+
+CHAPTER &quot;Details (BPMN)&quot;
+
+ATTR &quot;Auditing&quot; 
+ATTR &quot;Monitoring&quot; 
+
+ATTR &quot;Default&quot; 
+ATTR &quot;Immediate&quot; 
+ATTR &quot;Category&quot;
+ATTR &quot;Id&quot; 
+
+
+CHAPTER &quot;Details (Simulation)&quot;
+
+ATTR &quot;Transition condition&quot; dialog:transcond
+
+ATTR &quot;Transition probability&quot;
+
+</ATTRIBUTE>
+<ATTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;Exclusive Gateway&quot;</ATTRIBUTE>
+<ATTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Sub-Process&quot;</ATTRIBUTE>
+<ATTRIBUTE name="ModelTypeExp" type="EXPRESSION">EXPR val:&quot;Business process diagram (BPMN 2.0)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16312" class="Is inside">
+<FROM instance="Manage Inhibition" class="Sub-Process"></FROM>
+<TO instance="Monti Azzurri Consorsium" class="Pool"></TO>
+<ATTRIBUTE name="AutoConnect" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16313" class="Is inside">
+<FROM instance="Manage Inhibition" class="Sub-Process"></FROM>
+<TO instance="Office SUAP" class="Lane"></TO>
+<ATTRIBUTE name="AutoConnect" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16314" class="Subsequent">
+<FROM instance="Manage Inhibition" class="Sub-Process"></FROM>
+<TO instance="End Event-83081" class="End Event"></TO>
+<ATTRIBUTE name="Transition condition" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Transition probability" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualized values" type="ENUMERATION">Denomination</ATTRIBUTE>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 1 x1:49cm y1:21.5cm index:36</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">17</ATTRIBUTE>
+<ATTRIBUTE name="Representation" type="ENUMERATION">above/below</ATTRIBUTE>
+<ATTRIBUTE name="Font colour" type="ENUMERATION">black</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Info zur Übergangsbedingung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Nachfolger</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Denomination" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Description" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Auditing" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Monitoring" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Default" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Immediate" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Category" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16314&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Color" type="STRING">black</ATTRIBUTE>
+<ATTRIBUTE name="Doku" type="STRING">NOTEBOOK
+
+#-----------------------
+LANG &quot;en&quot;
+#-----------------------
+CHAPTER &quot;Description&quot;
+ATTR &quot;Denomination&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+
+
+CHAPTER &quot;Details (BPMN)&quot;
+
+ATTR &quot;Auditing&quot; 
+ATTR &quot;Monitoring&quot; 
+
+ATTR &quot;Default&quot; 
+ATTR &quot;Immediate&quot; 
+ATTR &quot;Category&quot;
+ATTR &quot;Id&quot; 
+
+
+CHAPTER &quot;Details (Simulation)&quot;
+
+ATTR &quot;Transition condition&quot; dialog:transcond
+
+ATTR &quot;Transition probability&quot;
+
+</ATTRIBUTE>
+<ATTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;End Event&quot;</ATTRIBUTE>
+<ATTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Sub-Process&quot;</ATTRIBUTE>
+<ATTRIBUTE name="ModelTypeExp" type="EXPRESSION">EXPR val:&quot;Business process diagram (BPMN 2.0)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16315" class="Is inside">
+<FROM instance="Send Authorization Document" class="Task"></FROM>
+<TO instance="Monti Azzurri Consorsium" class="Pool"></TO>
+<ATTRIBUTE name="AutoConnect" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16316" class="Is inside">
+<FROM instance="Send Authorization Document" class="Task"></FROM>
+<TO instance="Office SUAP" class="Lane"></TO>
+<ATTRIBUTE name="AutoConnect" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16317" class="Message Flow">
+<FROM instance="Send Authorization Document" class="Task"></FROM>
+<TO instance="Entrepreneur" class="Pool (collapsed)"></TO>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 1 x1:45cm y1:5cm index:39</ATTRIBUTE>
+<ATTRIBUTE name="Message Name" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="ParticipantType (from)" type="ENUMERATION">Role</ATTRIBUTE>
+<ATTRIBUTE name="Role (from)" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Entity (from)" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="ParticipantType (to)" type="ENUMERATION">Role</ATTRIBUTE>
+<ATTRIBUTE name="Role (to)" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Entity (to)" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Categories" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Documentation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Name" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Message Properties" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;Pool (collapsed)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Task&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Number" type="INTEGER">0</ATTRIBUTE>
+<ATTRIBUTE name="Show Name" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Show Number" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Representation" type="ENUMERATION">above/below</ATTRIBUTE>
+<ATTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Description" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Show name" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Doku" type="STRING">NOTEBOOK
+
+#-----------------------
+CHAPTER &quot;Description&quot;
+#-----------------------
+ATTR &quot;Name&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+ATTR &quot;Id&quot; </ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16317&quot;</ATTRIBUTE>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16318" class="Subsequent">
+<FROM instance="Send Authorization Document" class="Task"></FROM>
+<TO instance="End Event-83081" class="End Event"></TO>
+<ATTRIBUTE name="Transition condition" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Transition probability" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualized values" type="ENUMERATION">Denomination</ATTRIBUTE>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 0 index:42</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">19</ATTRIBUTE>
+<ATTRIBUTE name="Representation" type="ENUMERATION">above/below</ATTRIBUTE>
+<ATTRIBUTE name="Font colour" type="ENUMERATION">black</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Info zur Übergangsbedingung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Nachfolger</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Denomination" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Description" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Auditing" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Monitoring" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Default" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Immediate" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Category" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16318&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Color" type="STRING">black</ATTRIBUTE>
+<ATTRIBUTE name="Doku" type="STRING">NOTEBOOK
+
+#-----------------------
+LANG &quot;en&quot;
+#-----------------------
+CHAPTER &quot;Description&quot;
+ATTR &quot;Denomination&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+
+
+CHAPTER &quot;Details (BPMN)&quot;
+
+ATTR &quot;Auditing&quot; 
+ATTR &quot;Monitoring&quot; 
+
+ATTR &quot;Default&quot; 
+ATTR &quot;Immediate&quot; 
+ATTR &quot;Category&quot;
+ATTR &quot;Id&quot; 
+
+
+CHAPTER &quot;Details (Simulation)&quot;
+
+ATTR &quot;Transition condition&quot; dialog:transcond
+
+ATTR &quot;Transition probability&quot;
+
+</ATTRIBUTE>
+<ATTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;End Event&quot;</ATTRIBUTE>
+<ATTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Task&quot;</ATTRIBUTE>
+<ATTRIBUTE name="ModelTypeExp" type="EXPRESSION">EXPR val:&quot;Business process diagram (BPMN 2.0)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16319" class="Is inside">
+<FROM instance="reject application?" class="Exclusive Gateway"></FROM>
+<TO instance="Monti Azzurri Consorsium" class="Pool"></TO>
+<ATTRIBUTE name="AutoConnect" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16320" class="Is inside">
+<FROM instance="reject application?" class="Exclusive Gateway"></FROM>
+<TO instance="Office SUAP" class="Lane"></TO>
+<ATTRIBUTE name="AutoConnect" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16321" class="Subsequent">
+<FROM instance="reject application?" class="Exclusive Gateway"></FROM>
+<TO instance="End Event-83081" class="End Event"></TO>
+<ATTRIBUTE name="Transition condition" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Transition probability" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualized values" type="ENUMERATION">Denomination</ATTRIBUTE>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 2 x1:19cm y1:10cm x2:49cm y2:10cm index:20</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">4</ATTRIBUTE>
+<ATTRIBUTE name="Representation" type="ENUMERATION">above/below</ATTRIBUTE>
+<ATTRIBUTE name="Font colour" type="ENUMERATION">black</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Info zur Übergangsbedingung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Nachfolger</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Denomination" type="STRING">yes</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Auditing" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Monitoring" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Default" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Immediate" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Category" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16321&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Color" type="STRING">black</ATTRIBUTE>
+<ATTRIBUTE name="Doku" type="STRING">NOTEBOOK
+
+#-----------------------
+LANG &quot;en&quot;
+#-----------------------
+CHAPTER &quot;Description&quot;
+ATTR &quot;Denomination&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+
+
+CHAPTER &quot;Details (BPMN)&quot;
+
+ATTR &quot;Auditing&quot; 
+ATTR &quot;Monitoring&quot; 
+
+ATTR &quot;Default&quot; 
+ATTR &quot;Immediate&quot; 
+ATTR &quot;Category&quot;
+ATTR &quot;Id&quot; 
+
+
+CHAPTER &quot;Details (Simulation)&quot;
+
+ATTR &quot;Transition condition&quot; dialog:transcond
+
+ATTR &quot;Transition probability&quot;
+
+</ATTRIBUTE>
+<ATTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;End Event&quot;</ATTRIBUTE>
+<ATTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Exclusive Gateway&quot;</ATTRIBUTE>
+<ATTRIBUTE name="ModelTypeExp" type="EXPRESSION">EXPR val:&quot;Business process diagram (BPMN 2.0)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16322" class="Subsequent">
+<FROM instance="reject application?" class="Exclusive Gateway"></FROM>
+<TO instance="manage conf directly?" class="Exclusive Gateway"></TO>
+<ATTRIBUTE name="Transition condition" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Transition probability" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualized values" type="ENUMERATION">Denomination</ATTRIBUTE>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 0 index:22</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">5</ATTRIBUTE>
+<ATTRIBUTE name="Representation" type="ENUMERATION">above/below</ATTRIBUTE>
+<ATTRIBUTE name="Font colour" type="ENUMERATION">black</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Info zur Übergangsbedingung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Nachfolger</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Denomination" type="STRING">no</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Auditing" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Monitoring" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Default" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Immediate" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Category" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16322&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Color" type="STRING">black</ATTRIBUTE>
+<ATTRIBUTE name="Doku" type="STRING">NOTEBOOK
+
+#-----------------------
+LANG &quot;en&quot;
+#-----------------------
+CHAPTER &quot;Description&quot;
+ATTR &quot;Denomination&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+
+
+CHAPTER &quot;Details (BPMN)&quot;
+
+ATTR &quot;Auditing&quot; 
+ATTR &quot;Monitoring&quot; 
+
+ATTR &quot;Default&quot; 
+ATTR &quot;Immediate&quot; 
+ATTR &quot;Category&quot;
+ATTR &quot;Id&quot; 
+
+
+CHAPTER &quot;Details (Simulation)&quot;
+
+ATTR &quot;Transition condition&quot; dialog:transcond
+
+ATTR &quot;Transition probability&quot;
+
+</ATTRIBUTE>
+<ATTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;Exclusive Gateway&quot;</ATTRIBUTE>
+<ATTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Exclusive Gateway&quot;</ATTRIBUTE>
+<ATTRIBUTE name="ModelTypeExp" type="EXPRESSION">EXPR val:&quot;Business process diagram (BPMN 2.0)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16323" class="Is inside">
+<FROM instance="Intermediate Event (boundary)-83066" class="Intermediate Event (boundary)"></FROM>
+<TO instance="Monti Azzurri Consorsium" class="Pool"></TO>
+<ATTRIBUTE name="AutoConnect" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16324" class="Is inside">
+<FROM instance="Intermediate Event (boundary)-83066" class="Intermediate Event (boundary)"></FROM>
+<TO instance="Office SUAP" class="Lane"></TO>
+<ATTRIBUTE name="AutoConnect" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16325" class="Subsequent">
+<FROM instance="Intermediate Event (boundary)-83066" class="Intermediate Event (boundary)"></FROM>
+<TO instance="Exclusive Gateway-83095" class="Exclusive Gateway"></TO>
+<ATTRIBUTE name="Transition condition" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Transition probability" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualized values" type="ENUMERATION">Denomination</ATTRIBUTE>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 1 x1:28.5cm y1:19cm index:26</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">8</ATTRIBUTE>
+<ATTRIBUTE name="Representation" type="ENUMERATION">above/below</ATTRIBUTE>
+<ATTRIBUTE name="Font colour" type="ENUMERATION">black</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Info zur Übergangsbedingung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Nachfolger</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Denomination" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Description" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Auditing" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Monitoring" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Default" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Immediate" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Category" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16325&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Color" type="STRING">black</ATTRIBUTE>
+<ATTRIBUTE name="Doku" type="STRING">NOTEBOOK
+
+#-----------------------
+LANG &quot;en&quot;
+#-----------------------
+CHAPTER &quot;Description&quot;
+ATTR &quot;Denomination&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+
+
+CHAPTER &quot;Details (BPMN)&quot;
+
+ATTR &quot;Auditing&quot; 
+ATTR &quot;Monitoring&quot; 
+
+ATTR &quot;Default&quot; 
+ATTR &quot;Immediate&quot; 
+ATTR &quot;Category&quot;
+ATTR &quot;Id&quot; 
+
+
+CHAPTER &quot;Details (Simulation)&quot;
+
+ATTR &quot;Transition condition&quot; dialog:transcond
+
+ATTR &quot;Transition probability&quot;
+
+</ATTRIBUTE>
+<ATTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;Exclusive Gateway&quot;</ATTRIBUTE>
+<ATTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Intermediate Event (boundary)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="ModelTypeExp" type="EXPRESSION">EXPR val:&quot;Business process diagram (BPMN 2.0)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16326" class="Is inside">
+<FROM instance="Intermediate Event (boundary)-83071" class="Intermediate Event (boundary)"></FROM>
+<TO instance="Monti Azzurri Consorsium" class="Pool"></TO>
+<ATTRIBUTE name="AutoConnect" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16327" class="Is inside">
+<FROM instance="Intermediate Event (boundary)-83071" class="Intermediate Event (boundary)"></FROM>
+<TO instance="Office SUAP" class="Lane"></TO>
+<ATTRIBUTE name="AutoConnect" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16328" class="Subsequent">
+<FROM instance="Intermediate Event (boundary)-83071" class="Intermediate Event (boundary)"></FROM>
+<TO instance="Exclusive Gateway-83095" class="Exclusive Gateway"></TO>
+<ATTRIBUTE name="Transition condition" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Transition probability" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualized values" type="ENUMERATION">Denomination</ATTRIBUTE>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 1 x1:37cm y1:19cm index:30</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">12</ATTRIBUTE>
+<ATTRIBUTE name="Representation" type="ENUMERATION">above/below</ATTRIBUTE>
+<ATTRIBUTE name="Font colour" type="ENUMERATION">black</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Info zur Übergangsbedingung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Nachfolger</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Denomination" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Description" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Auditing" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Monitoring" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Default" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Immediate" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Category" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16328&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Color" type="STRING">black</ATTRIBUTE>
+<ATTRIBUTE name="Doku" type="STRING">NOTEBOOK
+
+#-----------------------
+LANG &quot;en&quot;
+#-----------------------
+CHAPTER &quot;Description&quot;
+ATTR &quot;Denomination&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+
+
+CHAPTER &quot;Details (BPMN)&quot;
+
+ATTR &quot;Auditing&quot; 
+ATTR &quot;Monitoring&quot; 
+
+ATTR &quot;Default&quot; 
+ATTR &quot;Immediate&quot; 
+ATTR &quot;Category&quot;
+ATTR &quot;Id&quot; 
+
+
+CHAPTER &quot;Details (Simulation)&quot;
+
+ATTR &quot;Transition condition&quot; dialog:transcond
+
+ATTR &quot;Transition probability&quot;
+
+</ATTRIBUTE>
+<ATTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;Exclusive Gateway&quot;</ATTRIBUTE>
+<ATTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Intermediate Event (boundary)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="ModelTypeExp" type="EXPRESSION">EXPR val:&quot;Business process diagram (BPMN 2.0)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16329" class="Is inside">
+<FROM instance="integration necessary?" class="Exclusive Gateway"></FROM>
+<TO instance="Monti Azzurri Consorsium" class="Pool"></TO>
+<ATTRIBUTE name="AutoConnect" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16330" class="Is inside">
+<FROM instance="integration necessary?" class="Exclusive Gateway"></FROM>
+<TO instance="Office SUAP" class="Lane"></TO>
+<ATTRIBUTE name="AutoConnect" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16331" class="Subsequent">
+<FROM instance="integration necessary?" class="Exclusive Gateway"></FROM>
+<TO instance="Check Integration" class="Sub-Process"></TO>
+<ATTRIBUTE name="Transition condition" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Transition probability" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualized values" type="ENUMERATION">Denomination</ATTRIBUTE>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 0 index:31</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">13</ATTRIBUTE>
+<ATTRIBUTE name="Representation" type="ENUMERATION">above/below</ATTRIBUTE>
+<ATTRIBUTE name="Font colour" type="ENUMERATION">black</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Info zur Übergangsbedingung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Nachfolger</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Denomination" type="STRING">yes</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Auditing" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Monitoring" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Default" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Immediate" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Category" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16331&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Color" type="STRING">black</ATTRIBUTE>
+<ATTRIBUTE name="Doku" type="STRING">NOTEBOOK
+
+#-----------------------
+LANG &quot;en&quot;
+#-----------------------
+CHAPTER &quot;Description&quot;
+ATTR &quot;Denomination&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+
+
+CHAPTER &quot;Details (BPMN)&quot;
+
+ATTR &quot;Auditing&quot; 
+ATTR &quot;Monitoring&quot; 
+
+ATTR &quot;Default&quot; 
+ATTR &quot;Immediate&quot; 
+ATTR &quot;Category&quot;
+ATTR &quot;Id&quot; 
+
+
+CHAPTER &quot;Details (Simulation)&quot;
+
+ATTR &quot;Transition condition&quot; dialog:transcond
+
+ATTR &quot;Transition probability&quot;
+
+</ATTRIBUTE>
+<ATTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;Sub-Process&quot;</ATTRIBUTE>
+<ATTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Exclusive Gateway&quot;</ATTRIBUTE>
+<ATTRIBUTE name="ModelTypeExp" type="EXPRESSION">EXPR val:&quot;Business process diagram (BPMN 2.0)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16332" class="Subsequent">
+<FROM instance="integration necessary?" class="Exclusive Gateway"></FROM>
+<TO instance="is decision taken?" class="Exclusive Gateway"></TO>
+<ATTRIBUTE name="Transition condition" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Transition probability" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualized values" type="ENUMERATION">Denomination</ATTRIBUTE>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 2 x1:31.5cm y1:11cm x2:40.5cm y2:11cm index:37</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">18</ATTRIBUTE>
+<ATTRIBUTE name="Representation" type="ENUMERATION">above/below</ATTRIBUTE>
+<ATTRIBUTE name="Font colour" type="ENUMERATION">black</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Info zur Übergangsbedingung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Nachfolger</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Denomination" type="STRING">no</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Auditing" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Monitoring" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Default" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Immediate" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Category" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16332&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Color" type="STRING">black</ATTRIBUTE>
+<ATTRIBUTE name="Doku" type="STRING">NOTEBOOK
+
+#-----------------------
+LANG &quot;en&quot;
+#-----------------------
+CHAPTER &quot;Description&quot;
+ATTR &quot;Denomination&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+
+
+CHAPTER &quot;Details (BPMN)&quot;
+
+ATTR &quot;Auditing&quot; 
+ATTR &quot;Monitoring&quot; 
+
+ATTR &quot;Default&quot; 
+ATTR &quot;Immediate&quot; 
+ATTR &quot;Category&quot;
+ATTR &quot;Id&quot; 
+
+
+CHAPTER &quot;Details (Simulation)&quot;
+
+ATTR &quot;Transition condition&quot; dialog:transcond
+
+ATTR &quot;Transition probability&quot;
+
+</ATTRIBUTE>
+<ATTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;Exclusive Gateway&quot;</ATTRIBUTE>
+<ATTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Exclusive Gateway&quot;</ATTRIBUTE>
+<ATTRIBUTE name="ModelTypeExp" type="EXPRESSION">EXPR val:&quot;Business process diagram (BPMN 2.0)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16333" class="Is inside">
+<FROM instance="End Event-83081" class="End Event"></FROM>
+<TO instance="Office SUAP" class="Lane"></TO>
+<ATTRIBUTE name="AutoConnect" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16334" class="Is inside">
+<FROM instance="End Event-83081" class="End Event"></FROM>
+<TO instance="Monti Azzurri Consorsium" class="Pool"></TO>
+<ATTRIBUTE name="AutoConnect" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16335" class="Is inside">
+<FROM instance="manage conf directly?" class="Exclusive Gateway"></FROM>
+<TO instance="Monti Azzurri Consorsium" class="Pool"></TO>
+<ATTRIBUTE name="AutoConnect" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16336" class="Is inside">
+<FROM instance="manage conf directly?" class="Exclusive Gateway"></FROM>
+<TO instance="Office SUAP" class="Lane"></TO>
+<ATTRIBUTE name="AutoConnect" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16337" class="Subsequent">
+<FROM instance="manage conf directly?" class="Exclusive Gateway"></FROM>
+<TO instance="Manage of 3rd Party Admin" class="Sub-Process"></TO>
+<ATTRIBUTE name="Transition condition" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Transition probability" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualized values" type="ENUMERATION">Denomination</ATTRIBUTE>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 1 x1:22.5cm y1:13cm index:23</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">6</ATTRIBUTE>
+<ATTRIBUTE name="Representation" type="ENUMERATION">above/below</ATTRIBUTE>
+<ATTRIBUTE name="Font colour" type="ENUMERATION">black</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Info zur Übergangsbedingung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Nachfolger</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Denomination" type="STRING">no</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Auditing" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Monitoring" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Default" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Immediate" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Category" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16337&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Color" type="STRING">black</ATTRIBUTE>
+<ATTRIBUTE name="Doku" type="STRING">NOTEBOOK
+
+#-----------------------
+LANG &quot;en&quot;
+#-----------------------
+CHAPTER &quot;Description&quot;
+ATTR &quot;Denomination&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+
+
+CHAPTER &quot;Details (BPMN)&quot;
+
+ATTR &quot;Auditing&quot; 
+ATTR &quot;Monitoring&quot; 
+
+ATTR &quot;Default&quot; 
+ATTR &quot;Immediate&quot; 
+ATTR &quot;Category&quot;
+ATTR &quot;Id&quot; 
+
+
+CHAPTER &quot;Details (Simulation)&quot;
+
+ATTR &quot;Transition condition&quot; dialog:transcond
+
+ATTR &quot;Transition probability&quot;
+
+</ATTRIBUTE>
+<ATTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;Sub-Process&quot;</ATTRIBUTE>
+<ATTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Exclusive Gateway&quot;</ATTRIBUTE>
+<ATTRIBUTE name="ModelTypeExp" type="EXPRESSION">EXPR val:&quot;Business process diagram (BPMN 2.0)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16338" class="Subsequent">
+<FROM instance="manage conf directly?" class="Exclusive Gateway"></FROM>
+<TO instance="Exclusive Gateway-83095" class="Exclusive Gateway"></TO>
+<ATTRIBUTE name="Transition condition" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Transition probability" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualized values" type="ENUMERATION">Denomination</ATTRIBUTE>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 0 index:25</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">7</ATTRIBUTE>
+<ATTRIBUTE name="Representation" type="ENUMERATION">above/below</ATTRIBUTE>
+<ATTRIBUTE name="Font colour" type="ENUMERATION">black</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Info zur Übergangsbedingung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Nachfolger</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Denomination" type="STRING">yes</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Auditing" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Monitoring" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Default" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Immediate" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Category" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16338&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Color" type="STRING">black</ATTRIBUTE>
+<ATTRIBUTE name="Doku" type="STRING">NOTEBOOK
+
+#-----------------------
+LANG &quot;en&quot;
+#-----------------------
+CHAPTER &quot;Description&quot;
+ATTR &quot;Denomination&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+
+
+CHAPTER &quot;Details (BPMN)&quot;
+
+ATTR &quot;Auditing&quot; 
+ATTR &quot;Monitoring&quot; 
+
+ATTR &quot;Default&quot; 
+ATTR &quot;Immediate&quot; 
+ATTR &quot;Category&quot;
+ATTR &quot;Id&quot; 
+
+
+CHAPTER &quot;Details (Simulation)&quot;
+
+ATTR &quot;Transition condition&quot; dialog:transcond
+
+ATTR &quot;Transition probability&quot;
+
+</ATTRIBUTE>
+<ATTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;Exclusive Gateway&quot;</ATTRIBUTE>
+<ATTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Exclusive Gateway&quot;</ATTRIBUTE>
+<ATTRIBUTE name="ModelTypeExp" type="EXPRESSION">EXPR val:&quot;Business process diagram (BPMN 2.0)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16339" class="Is inside">
+<FROM instance="Exclusive Gateway-83095" class="Exclusive Gateway"></FROM>
+<TO instance="Monti Azzurri Consorsium" class="Pool"></TO>
+<ATTRIBUTE name="AutoConnect" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16340" class="Is inside">
+<FROM instance="Exclusive Gateway-83095" class="Exclusive Gateway"></FROM>
+<TO instance="Office SUAP" class="Lane"></TO>
+<ATTRIBUTE name="AutoConnect" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16341" class="Subsequent">
+<FROM instance="Exclusive Gateway-83095" class="Exclusive Gateway"></FROM>
+<TO instance="Manage Service Conference" class="Sub-Process"></TO>
+<ATTRIBUTE name="Transition condition" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Transition probability" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualized values" type="ENUMERATION">Denomination</ATTRIBUTE>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 1 x1:22.5cm y1:21.5cm index:27</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">9</ATTRIBUTE>
+<ATTRIBUTE name="Representation" type="ENUMERATION">above/below</ATTRIBUTE>
+<ATTRIBUTE name="Font colour" type="ENUMERATION">black</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Info zur Übergangsbedingung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Nachfolger</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Denomination" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Description" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Auditing" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Monitoring" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Default" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Immediate" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Category" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16341&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Color" type="STRING">black</ATTRIBUTE>
+<ATTRIBUTE name="Doku" type="STRING">NOTEBOOK
+
+#-----------------------
+LANG &quot;en&quot;
+#-----------------------
+CHAPTER &quot;Description&quot;
+ATTR &quot;Denomination&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+
+
+CHAPTER &quot;Details (BPMN)&quot;
+
+ATTR &quot;Auditing&quot; 
+ATTR &quot;Monitoring&quot; 
+
+ATTR &quot;Default&quot; 
+ATTR &quot;Immediate&quot; 
+ATTR &quot;Category&quot;
+ATTR &quot;Id&quot; 
+
+
+CHAPTER &quot;Details (Simulation)&quot;
+
+ATTR &quot;Transition condition&quot; dialog:transcond
+
+ATTR &quot;Transition probability&quot;
+
+</ATTRIBUTE>
+<ATTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;Sub-Process&quot;</ATTRIBUTE>
+<ATTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Exclusive Gateway&quot;</ATTRIBUTE>
+<ATTRIBUTE name="ModelTypeExp" type="EXPRESSION">EXPR val:&quot;Business process diagram (BPMN 2.0)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16342" class="Is inside">
+<FROM instance="is decision taken?" class="Exclusive Gateway"></FROM>
+<TO instance="Monti Azzurri Consorsium" class="Pool"></TO>
+<ATTRIBUTE name="AutoConnect" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16343" class="Is inside">
+<FROM instance="is decision taken?" class="Exclusive Gateway"></FROM>
+<TO instance="Office SUAP" class="Lane"></TO>
+<ATTRIBUTE name="AutoConnect" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16344" class="Subsequent">
+<FROM instance="is decision taken?" class="Exclusive Gateway"></FROM>
+<TO instance="Send Authorization Document" class="Task"></TO>
+<ATTRIBUTE name="Transition condition" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Transition probability" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualized values" type="ENUMERATION">Denomination</ATTRIBUTE>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 0 index:34</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">15</ATTRIBUTE>
+<ATTRIBUTE name="Representation" type="ENUMERATION">above/below</ATTRIBUTE>
+<ATTRIBUTE name="Font colour" type="ENUMERATION">black</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Info zur Übergangsbedingung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Nachfolger</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Denomination" type="STRING">yes</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Auditing" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Monitoring" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Default" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Immediate" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Category" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16344&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Color" type="STRING">black</ATTRIBUTE>
+<ATTRIBUTE name="Doku" type="STRING">NOTEBOOK
+
+#-----------------------
+LANG &quot;en&quot;
+#-----------------------
+CHAPTER &quot;Description&quot;
+ATTR &quot;Denomination&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+
+
+CHAPTER &quot;Details (BPMN)&quot;
+
+ATTR &quot;Auditing&quot; 
+ATTR &quot;Monitoring&quot; 
+
+ATTR &quot;Default&quot; 
+ATTR &quot;Immediate&quot; 
+ATTR &quot;Category&quot;
+ATTR &quot;Id&quot; 
+
+
+CHAPTER &quot;Details (Simulation)&quot;
+
+ATTR &quot;Transition condition&quot; dialog:transcond
+
+ATTR &quot;Transition probability&quot;
+
+</ATTRIBUTE>
+<ATTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;Task&quot;</ATTRIBUTE>
+<ATTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Exclusive Gateway&quot;</ATTRIBUTE>
+<ATTRIBUTE name="ModelTypeExp" type="EXPRESSION">EXPR val:&quot;Business process diagram (BPMN 2.0)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16345" class="Subsequent">
+<FROM instance="is decision taken?" class="Exclusive Gateway"></FROM>
+<TO instance="Manage Inhibition" class="Sub-Process"></TO>
+<ATTRIBUTE name="Transition condition" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Transition probability" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualized values" type="ENUMERATION">Denomination</ATTRIBUTE>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 0 index:35</ATTRIBUTE>
+<ATTRIBUTE name="VisibleAttrs" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Visualization" type="ENUMERATION">RELATION</ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Connector number" type="INTEGER">16</ATTRIBUTE>
+<ATTRIBUTE name="Representation" type="ENUMERATION">above/below</ATTRIBUTE>
+<ATTRIBUTE name="Font colour" type="ENUMERATION">black</ATTRIBUTE>
+<ATTRIBUTE name="Kommentar" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Info zur Übergangsbedingung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Language" type="EXPRESSION">EXPR val:&quot;System&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Bezeichnung" type="STRING">Nachfolger</ATTRIBUTE>
+<ATTRIBUTE name="Beschreibung" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Denomination" type="STRING">no</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="__Variants__" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Auditing" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Monitoring" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Default" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Immediate" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Category" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16345&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Color" type="STRING">black</ATTRIBUTE>
+<ATTRIBUTE name="Doku" type="STRING">NOTEBOOK
+
+#-----------------------
+LANG &quot;en&quot;
+#-----------------------
+CHAPTER &quot;Description&quot;
+ATTR &quot;Denomination&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+
+
+CHAPTER &quot;Details (BPMN)&quot;
+
+ATTR &quot;Auditing&quot; 
+ATTR &quot;Monitoring&quot; 
+
+ATTR &quot;Default&quot; 
+ATTR &quot;Immediate&quot; 
+ATTR &quot;Category&quot;
+ATTR &quot;Id&quot; 
+
+
+CHAPTER &quot;Details (Simulation)&quot;
+
+ATTR &quot;Transition condition&quot; dialog:transcond
+
+ATTR &quot;Transition probability&quot;
+
+</ATTRIBUTE>
+<ATTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;Sub-Process&quot;</ATTRIBUTE>
+<ATTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Exclusive Gateway&quot;</ATTRIBUTE>
+<ATTRIBUTE name="ModelTypeExp" type="EXPRESSION">EXPR val:&quot;Business process diagram (BPMN 2.0)&quot;</ATTRIBUTE>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16346" class="Is inside">
+<FROM instance="Titolo Unico" class="Data Object"></FROM>
+<TO instance="Monti Azzurri Consorsium" class="Pool"></TO>
+<ATTRIBUTE name="AutoConnect" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16347" class="Is inside">
+<FROM instance="Titolo Unico" class="Data Object"></FROM>
+<TO instance="Office SUAP" class="Lane"></TO>
+<ATTRIBUTE name="AutoConnect" type="STRING"></ATTRIBUTE>
+</CONNECTOR>
+<CONNECTOR id="con.16348" class="Data Association">
+<FROM instance="Titolo Unico" class="Data Object"></FROM>
+<TO instance="Send Authorization Document" class="Task"></TO>
+<ATTRIBUTE name="Positions" type="STRING">EDGE 0 index:41</ATTRIBUTE>
+<ATTRIBUTE name="Name" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Representation" type="ENUMERATION">above/below</ATTRIBUTE>
+<ATTRIBUTE name="Rotate the visualised values by 90 degrees" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Description" type="LONGSTRING"></ATTRIBUTE>
+<ATTRIBUTE name="Show name" type="ENUMERATION">No</ATTRIBUTE>
+<ATTRIBUTE name="Comment" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Doku" type="STRING">#-----------------------
+CHAPTER &quot;Description&quot;
+#-----------------------
+ATTR &quot;Name&quot;
+ATTR &quot;Description&quot; 
+ATTR &quot;Comment&quot; 
+ATTR &quot;Id&quot; </ATTRIBUTE>
+<ATTRIBUTE name="FromType" type="EXPRESSION">EXPR val:&quot;Data Object&quot;</ATTRIBUTE>
+<ATTRIBUTE name="ToType" type="EXPRESSION">EXPR val:&quot;Task&quot;</ATTRIBUTE>
+<ATTRIBUTE name="Id" type="EXPRESSION">EXPR val:&quot;16348&quot;</ATTRIBUTE>
+<ATTRIBUTE name="id_bpmndi" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Annotation" type="STRING"></ATTRIBUTE>
+<ATTRIBUTE name="Set Annotation" type="PROGRAMCALL">ITEM &quot;Set Annotation&quot; param:&quot;&quot;</ATTRIBUTE>
+</CONNECTOR>
+</MODEL>
+</MODELS>
+<MODELGROUPS>
+<MODELGROUP name="TitoloUnico">
+<MODELREFERENCE name="TitoloUnico_MontiAzzurrSUB" version="" modeltype="Business process diagram (BPMN 2.0)" libtype="bp"></MODELREFERENCE>
+<MODELREFERENCE name="TitoloUnico_MontiAzzurrSUB_3" version="" modeltype="Business process diagram (BPMN 2.0)" libtype="bp"></MODELREFERENCE>
+<MODELREFERENCE name="TitoloUnico_MonitAzzurrSUB_4" version="" modeltype="Business process diagram (BPMN 2.0)" libtype="bp"></MODELREFERENCE>
+<MODELREFERENCE name="Competency model TitoloUnico" version="" modeltype="Competency model" libtype="bp"></MODELREFERENCE>
+<MODELREFERENCE name="BMM TitoloUnico" version="" modeltype="BMM" libtype="bp"></MODELREFERENCE>
+<MODELREFERENCE name="Document and Knowledge model TitoloUnico" version="" modeltype="Document and Knowledge model" libtype="bp"></MODELREFERENCE>
+<MODELREFERENCE name="Org Model Monti Azzurri" version="" modeltype="Organizational structure" libtype="we"></MODELREFERENCE>
+<MODELREFERENCE name="Org Model Senigallia Municipality" version="1" modeltype="Organizational structure" libtype="we"></MODELREFERENCE>
+<MODELREFERENCE name="Org Model Sarnano Municipality" version="1" modeltype="Organizational structure" libtype="we"></MODELREFERENCE>
+</MODELGROUP>
+</MODELGROUPS>
+</ADOXML>


### PR DESCRIPTION
I'm trying to add Titolo Unico into the process but I'll need your help @Bitico.  I first added the Adoxx file as an XML.  Then, I saw that some transformations was needed in order to make it XMI (add namespaces, change uppercase to lowercase for first letter of element).  You can find both files (XML and XMI) in the current Pull Request.  Then I tried to run `eu.learnpad.transformations.run.MainTest` to do the transformation (I changed the model file for the input).  This is the result.

```
The input file exist!
[Fatal Error] :1:57: Le type d'élément "Ado:ADOXMLTypexmi" doit être suivi des spécifications d'attribut, ">" ou "/>".
Exception in thread "main" org.xml.sax.SAXParseException; lineNumber: 1; columnNumber: 57; Le type d'élément "Ado:ADOXMLTypexmi" doit être suivi des spécifications d'attribut, ">" ou "/>".
	at com.sun.org.apache.xerces.internal.parsers.DOMParser.parse(DOMParser.java:257)
	at com.sun.org.apache.xerces.internal.jaxp.DocumentBuilderImpl.parse(DocumentBuilderImpl.java:347)
	at eu.learnpad.transformations.preprocessing.Utils.readXml(Utils.java:69)
	at eu.learnpad.transformations.preprocessing.Alignment.getAllTagsName(Alignment.java:136)
	at eu.learnpad.transformations.preprocessing.Alignment.sanitizer(Alignment.java:80)
	at eu.learnpad.transformations.run.MainTest.main(MainTest.java:97)
```

Sorry it's in French but basically, it can be translated by

> The element "Ado:ADOXMLTypexmi" must be followed by the attribut specifications, ">" or "/>".

Note that I also tried to convert to ASCII but since there is some accentuated character in the XML files (see [line 1950](https://github.com/xwiki-labs/learnpad/blob/titolo-unico/lp-collaborative-workspace/lp-cw-bridge/lp-cw-bridge-transformer/resources/model/TitoloUnico.xml#L1946) for example), it doesn't work well (we could do it but we would loose some information).  Is `UTF-8` a problem for the transformation?