### PR TITLE
[build] Do not use 'start' if not needed

### DIFF
--- a/build-system/postbuild.sh
+++ b/build-system/postbuild.sh
@@ -49,11 +49,14 @@ then
 	postbuild_installdependencies "$( cat ${RUNDEPS_FILE} )"
 fi
 declare -r START_FILE="${OUT_PATH}/start"
-customlog "INFO" "[${COMPONENT_NAME}] Start the component"
-bash "${START_FILE}"
-declare -r STOP_FILE="${OUT_PATH}/stop"
-customlog "INFO" "[${COMPONENT_NAME}] Stop the component"
-bash "${STOP_FILE}"
+if [ -f "$START_FILE" ]
+then
+	customlog "INFO" "[${COMPONENT_NAME}] Start the component"
+	bash "${START_FILE}"
+	declare -r STOP_FILE="${OUT_PATH}/stop"
+	customlog "INFO" "[${COMPONENT_NAME}] Stop the component"
+	bash "${STOP_FILE}"
+fi
 }
 
 function postbuild_installdependencies() {


### PR DESCRIPTION
Improve the build tool: when no `start` exists, don't run it.