### PR TITLE
Improve interaction with the Simulator

### DIFF
--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/data/ProcessInstanceData.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/data/ProcessInstanceData.java
@@ -35,6 +35,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public class ProcessInstanceData {
 
 	public String processartifactid;
+	public String processartifactkey;
 	public Map<String, Object> parameters;
 	public Collection<String> users;
 	public Map<String, Collection<String>> routes;
@@ -45,10 +46,12 @@ public class ProcessInstanceData {
 	@JsonCreator
 	public ProcessInstanceData(
 			@JsonProperty("processartifactid") String processartifactid,
+			@JsonProperty("processartifactkey") String processartifactkey,
 			@JsonProperty("parameters") Map<String, Object> parameters,
 			@JsonProperty("users") Collection<String> users,
 			@JsonProperty("routes") Map<String, Collection<String>> routes) {
 		this.processartifactid = processartifactid;
+		this.processartifactkey = processartifactkey;
 		this.parameters = parameters;
 		this.users = users;
 		this.routes = routes;

--- a/lp-simulation-environment/src/main/java/eu/learnpad/simulator/IProcessManager.java
+++ b/lp-simulation-environment/src/main/java/eu/learnpad/simulator/IProcessManager.java
@@ -28,6 +28,7 @@ import java.io.InputStream;
 import java.util.Collection;
 import java.util.Map;
 
+import eu.learnpad.sim.rest.data.ProcessInstanceData;
 import eu.learnpad.simulator.datastructures.LearnPadTask;
 import eu.learnpad.simulator.datastructures.LearnPadTaskGameInfos;
 import eu.learnpad.simulator.datastructures.LearnPadTaskSubmissionResult;
@@ -147,10 +148,9 @@ public interface IProcessManager {
 	 *
 	 * @param processInstanceId
 	 *            the ID of the process instance
-	 * @return a collection of the IDs of the involved users
+	 * @return the data associated with this process instance
 	 */
-	public Collection<String> getProcessInstanceInvolvedUsers(
-			String processInstanceId);
+	public ProcessInstanceData getProcessInstanceInfos(String processInstanceId);
 
 	/**
 	 * Signal the completion of a given task for a given process, along with the

--- a/lp-simulation-environment/src/main/java/eu/learnpad/simulator/IProcessManager.java
+++ b/lp-simulation-environment/src/main/java/eu/learnpad/simulator/IProcessManager.java
@@ -51,6 +51,13 @@ public interface IProcessManager {
 
 	/**
 	 *
+	 * @param processDefinitionKey
+	 * @return the process definition Id associated to the definition key
+	 */
+	public String getProcessDefIdFromDefKey(String processDefinitionKey);
+
+	/**
+	 *
 	 * @param resource
 	 *            the path to a valid BPMN 2.0 file
 	 * @return a collection containing the ID of the created process definitions
@@ -129,8 +136,8 @@ public interface IProcessManager {
 
 	/**
 	 *
-	 * @param projectDefinitionId
-	 *            the process definition id of the process to instantiate
+	 * @param projectDefinitionKey
+	 *            the process definition key of the process to instantiate
 	 * @param parameters
 	 *            the parameter list for the process
 	 * @param users
@@ -140,7 +147,7 @@ public interface IProcessManager {
 	 *            associated with several users)
 	 * @return the ID of the created process instance
 	 */
-	public String startProjectInstance(String projectDefinitionId,
+	public String startProjectInstance(String projectDefinitionKey,
 			Map<String, Object> parameters, Collection<String> users,
 			Map<String, Collection<String>> route);
 

--- a/lp-simulation-environment/src/main/java/eu/learnpad/simulator/api/impl/SimulatorBridgeImpl.java
+++ b/lp-simulation-environment/src/main/java/eu/learnpad/simulator/api/impl/SimulatorBridgeImpl.java
@@ -177,13 +177,12 @@ public class SimulatorBridgeImpl implements BridgeInterface {
 	public String addProcessInstance(String processId,
 			Collection<UserData> potentialUsers, String currentUser) {
 
+		// add users that were not yet present in the platform
 		Collection<String> users = simulator.userHandler().getUsers();
-		for (String user : users) {
-			simulator.userHandler().removeUser(user);
-		}
-
 		for (UserData user : potentialUsers) {
-			simulator.userHandler().addUser(user.id);
+			if (!users.contains(user)) {
+				simulator.userHandler().addUser(user.id);
+			}
 		}
 
 		return "uisingleprocess?processid=" + processId + "&" + "userid="

--- a/lp-simulation-environment/src/main/java/eu/learnpad/simulator/api/impl/SimulatorBridgeImpl.java
+++ b/lp-simulation-environment/src/main/java/eu/learnpad/simulator/api/impl/SimulatorBridgeImpl.java
@@ -188,8 +188,8 @@ public class SimulatorBridgeImpl implements BridgeInterface {
 	public ProcessInstanceData getProcessInstanceInfos(String processInstanceId) {
 		if (simulator.processManager().getCurrentProcessInstances()
 				.contains(processInstanceId)) {
-			return new ProcessInstanceData("", null, simulator.processManager()
-					.getProcessInstanceInvolvedUsers(processInstanceId), null);
+			return simulator.processManager().getProcessInstanceInfos(
+					processInstanceId);
 		} else {
 			throw new NotFoundException();
 		}

--- a/lp-simulation-environment/src/main/java/eu/learnpad/simulator/api/impl/SimulatorBridgeImpl.java
+++ b/lp-simulation-environment/src/main/java/eu/learnpad/simulator/api/impl/SimulatorBridgeImpl.java
@@ -16,6 +16,8 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriInfo;
 
+import org.jboss.resteasy.spi.ResteasyProviderFactory;
+
 import eu.learnpad.sim.BridgeInterface;
 import eu.learnpad.sim.rest.data.ProcessData;
 import eu.learnpad.sim.rest.data.ProcessInstanceData;
@@ -52,7 +54,6 @@ public class SimulatorBridgeImpl implements BridgeInterface {
 
 	// this will allow us to return specific response codes (specifically for
 	// POST methods)
-	@Context
 	private HttpServletResponse response;
 	@Context
 	private UriInfo infos;
@@ -70,13 +71,23 @@ public class SimulatorBridgeImpl implements BridgeInterface {
 	 * @param relativePath
 	 */
 	private void setResponseToCreated(String relativePath) {
-		response.setStatus(Status.CREATED.getStatusCode());
-		response.setHeader("Location", infos.getAbsolutePath() + relativePath);
 
-		try {
-			response.flushBuffer();
-		} catch (IOException e) {
-			e.printStackTrace();
+		response = ResteasyProviderFactory
+				.getContextData(HttpServletResponse.class);
+
+		// in some cases (as when calling the API programmatically), no response
+		// will be captured (response == null), not really sure why. But since
+		// this is not really critical setting the response on a best-effort
+		// basis should be enough.
+		if (response != null) {
+			response.setStatus(Status.CREATED.getStatusCode());
+			response.setHeader("Location", infos.getAbsolutePath()
+					+ relativePath);
+			try {
+				response.flushBuffer();
+			} catch (IOException e) {
+				e.printStackTrace();
+			}
 		}
 
 	}

--- a/lp-simulation-environment/src/main/java/eu/learnpad/simulator/monitoring/activiti/ActivitiProbe.java
+++ b/lp-simulation-environment/src/main/java/eu/learnpad/simulator/monitoring/activiti/ActivitiProbe.java
@@ -111,7 +111,7 @@ ActivitiEventListener {
 				}
 
 				monitoringEvent = new GlimpseBaseEventBPMN<String>(null,
-						event.getProcessInstanceId(),
+						p.getProcessDefinitionKey(),
 						System.currentTimeMillis(), "PROCESS_CREATED", false,
 						"", event.getProcessInstanceId(), null, null, null,
 						subprocessId, null);
@@ -134,7 +134,7 @@ ActivitiEventListener {
 				}
 
 				monitoringEvent = new GlimpseBaseEventBPMN<String>(null,
-						event.getProcessInstanceId(),
+						p.getProcessDefinitionKey(),
 						System.currentTimeMillis(), "PROCESS_COMPLETED", false,
 						"", event.getProcessInstanceId(), null, null, null,
 						subprocessId, null);

--- a/lp-simulation-environment/src/main/java/eu/learnpad/simulator/processmanager/AbstractProcessDispatcher.java
+++ b/lp-simulation-environment/src/main/java/eu/learnpad/simulator/processmanager/AbstractProcessDispatcher.java
@@ -26,6 +26,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
+import eu.learnpad.sim.rest.data.ProcessInstanceData;
 import eu.learnpad.simulator.IProcessEventReceiver;
 import eu.learnpad.simulator.IProcessManager;
 import eu.learnpad.simulator.datastructures.LearnPadTask;
@@ -40,6 +41,7 @@ import eu.learnpad.simulator.processmanager.gamification.TaskScorer;
  */
 public abstract class AbstractProcessDispatcher implements IProcessDispatcher {
 
+	private final ProcessInstanceData processInstanceData;
 	protected final String processId;
 	protected final Collection<String> involvedUsers;
 	private final IProcessManager manager;
@@ -52,15 +54,15 @@ public abstract class AbstractProcessDispatcher implements IProcessDispatcher {
 	private final Map<String, TaskScorer> taskScorers = new HashMap<String, TaskScorer>();
 
 	public AbstractProcessDispatcher(
+			ProcessInstanceData processInstanceData,
 			IProcessManager manager,
 			IProcessEventReceiver processEventReceiver,
-			String processId,
-			Collection<String> involvedUsers,
 			ITaskRouter router,
 			ITaskValidator<Map<String, Object>, Map<String, Object>> taskValidator) {
 		super();
-		this.processId = processId;
-		this.involvedUsers = involvedUsers;
+		this.processInstanceData = processInstanceData;
+		this.processId = processInstanceData.processartifactid;
+		this.involvedUsers = processInstanceData.users;
 		this.manager = manager;
 		this.processEventReceiver = processEventReceiver;
 		this.router = router;
@@ -71,6 +73,10 @@ public abstract class AbstractProcessDispatcher implements IProcessDispatcher {
 		}
 
 		System.out.println("Created dispatcher for process " + processId);
+	}
+
+	public ProcessInstanceData getProcessInstanceInfos() {
+		return processInstanceData;
 	}
 
 	/**

--- a/lp-simulation-environment/src/main/java/eu/learnpad/simulator/processmanager/IProcessDispatcher.java
+++ b/lp-simulation-environment/src/main/java/eu/learnpad/simulator/processmanager/IProcessDispatcher.java
@@ -26,6 +26,7 @@ package eu.learnpad.simulator.processmanager;
 
 import java.util.Map;
 
+import eu.learnpad.sim.rest.data.ProcessInstanceData;
 import eu.learnpad.simulator.datastructures.LearnPadTask;
 import eu.learnpad.simulator.datastructures.LearnPadTaskGameInfos;
 import eu.learnpad.simulator.datastructures.LearnPadTaskSubmissionResult;
@@ -43,6 +44,12 @@ import eu.learnpad.simulator.datastructures.LearnPadTaskSubmissionResult;
  *
  */
 public interface IProcessDispatcher {
+
+	/**
+	 *
+	 * @return the process instance data info of the associated process instance
+	 */
+	public ProcessInstanceData getProcessInstanceInfos();
 
 	/**
 	 * Signal the completion of a given task, along with the corresponding

--- a/lp-simulation-environment/src/main/java/eu/learnpad/simulator/processmanager/activiti/ActivitiProcessManager.java
+++ b/lp-simulation-environment/src/main/java/eu/learnpad/simulator/processmanager/activiti/ActivitiProcessManager.java
@@ -237,13 +237,19 @@ public class ActivitiProcessManager implements IProcessManager {
 
 		// open the BPMN model of the process
 		BpmnModel model = repositoryService.getBpmnModel(processDefinitionId);
-		for (FlowElement element : model.getMainProcess().getFlowElements()) {
-			// filter to keep only user tasks
-			if (element instanceof UserTask) {
-				UserTask task = (UserTask) element;
-				result.addAll(task.getCandidateUsers());
+
+		// in order to handle collaboration diagrams, we need to get the users
+		// of *all* the processes
+		for (org.activiti.bpmn.model.Process process : model.getProcesses()) {
+			for (FlowElement element : process.getFlowElements()) {
+				// filter to keep only user tasks
+				if (element instanceof UserTask) {
+					UserTask task = (UserTask) element;
+					result.addAll(task.getCandidateUsers());
+				}
 			}
 		}
+
 		return result;
 	}
 
@@ -259,11 +265,16 @@ public class ActivitiProcessManager implements IProcessManager {
 
 		// open the BPMN model of the process
 		BpmnModel model = repositoryService.getBpmnModel(processDefinitionId);
-		for (FlowElement element : model.getMainProcess().getFlowElements()) {
-			// filter to keep only user tasks
-			if (element instanceof UserTask) {
-				UserTask task = (UserTask) element;
-				result.addAll(task.getCandidateGroups());
+
+		// in order to handle collaboration diagrams, we need to get the users
+		// of *all* the processes
+		for (org.activiti.bpmn.model.Process process : model.getProcesses()) {
+			for (FlowElement element : process.getFlowElements()) {
+				// filter to keep only user tasks
+				if (element instanceof UserTask) {
+					UserTask task = (UserTask) element;
+					result.addAll(task.getCandidateGroups());
+				}
 			}
 		}
 		return result;

--- a/lp-simulation-environment/src/main/java/eu/learnpad/simulator/processmanager/activiti/ActivitiProcessManager.java
+++ b/lp-simulation-environment/src/main/java/eu/learnpad/simulator/processmanager/activiti/ActivitiProcessManager.java
@@ -118,6 +118,13 @@ public class ActivitiProcessManager implements IProcessManager {
 		this(processEngine, processEventReceiverProvider, explorerRepo, true);
 	}
 
+	@Override
+	public String getProcessDefIdFromDefKey(String processDefinitionKey) {
+		return repositoryService.createProcessDefinitionQuery()
+				.processDefinitionKey(processDefinitionKey).singleResult()
+				.getId();
+	}
+
 	/*
 	 * (non-Javadoc)
 	 * 
@@ -286,24 +293,25 @@ public class ActivitiProcessManager implements IProcessManager {
 	 * @see activitipoc.IProcessManager#startProjectInstance(java.lang.String,
 	 * java.util.Map, activitipoc.ITaskRouter)
 	 */
-	public String startProjectInstance(String projectDefinitionId,
+	public String startProjectInstance(String projectDefinitionKey,
 			Map<String, Object> parameters, Collection<String> users,
 			Map<String, Collection<String>> router) {
 
-		ProcessInstance process = runtimeService.startProcessInstanceById(
-				projectDefinitionId, parameters);
+		ProcessInstance process = runtimeService.startProcessInstanceByKey(
+				projectDefinitionKey, parameters);
 
 		ProcessInstanceData data = new ProcessInstanceData(process.getId(),
-				parameters, users, router);
+				projectDefinitionKey, parameters, users, router);
 
 		processDispatchers.put(
 				process.getId(),
 				new ActivitiProcessDispatcher(data, this,
 						this.processEventReceiverProvider
-						.processEventReceiver(), taskService,
+								.processEventReceiver(), taskService,
 						runtimeService, historyService, new ActivitiTaskRouter(
 								taskService, router), taskValidator,
-								explorerRepo.getExplorer(projectDefinitionId)));
+						explorerRepo.getExplorer(process
+								.getProcessDefinitionId())));
 
 		// we are ready, so we can start the dispatcher
 		processDispatchers.get(process.getId()).start();

--- a/lp-simulation-environment/src/main/java/eu/learnpad/simulator/processmanager/activiti/processdispatcher/ActivitiProcessDispatcher.java
+++ b/lp-simulation-environment/src/main/java/eu/learnpad/simulator/processmanager/activiti/processdispatcher/ActivitiProcessDispatcher.java
@@ -41,6 +41,7 @@ import org.activiti.engine.delegate.event.ActivitiEventType;
 import org.activiti.engine.runtime.ProcessInstance;
 import org.activiti.engine.task.Task;
 
+import eu.learnpad.sim.rest.data.ProcessInstanceData;
 import eu.learnpad.simulator.IProcessEventReceiver;
 import eu.learnpad.simulator.datastructures.LearnPadTask;
 import eu.learnpad.simulator.datastructures.document.LearnPadDocument;
@@ -96,19 +97,17 @@ public class ActivitiProcessDispatcher extends AbstractProcessDispatcher
 	private boolean processFinished = false;
 
 	public ActivitiProcessDispatcher(
+			ProcessInstanceData processInstanceData,
 			ActivitiProcessManager processManager,
 			IProcessEventReceiver processEventReceiver,
-			ProcessInstance process,
 			TaskService taskService,
 			RuntimeService runtimeService,
 			HistoryService historyService,
 			ITaskRouter router,
 			ITaskValidator<Map<String, Object>, Map<String, Object>> taskValidator,
-			Collection<String> involvedUsers, BPMNExplorer explorer
-
-	) {
-		super(processManager, processEventReceiver, process.getId(),
-				involvedUsers, router, taskValidator);
+			BPMNExplorer explorer) {
+		super(processInstanceData, processManager, processEventReceiver,
+				router, taskValidator);
 		this.taskService = taskService;
 		this.runtimeService = runtimeService;
 		this.historyService = historyService;

--- a/lp-simulation-environment/src/main/java/eu/learnpad/simulator/uihandler/webserver/msg/process/send/ProcessData.java
+++ b/lp-simulation-environment/src/main/java/eu/learnpad/simulator/uihandler/webserver/msg/process/send/ProcessData.java
@@ -57,7 +57,8 @@ public class ProcessData implements IProcessMsg {
 				.getAvailableProcessDefintion()) {
 			processes
 			.add(new ProcessDescr(
-					processDefId,
+					processManager
+					.getProcessDefinitionKey(processDefId),
 					processManager
 					.getProcessDefinitionName(processDefId),
 					processManager

--- a/lp-simulation-environment/src/test/java/eu/learnpad/simulator/processmanager/activiti/ActivitiProcessManagerTest.java
+++ b/lp-simulation-environment/src/test/java/eu/learnpad/simulator/processmanager/activiti/ActivitiProcessManagerTest.java
@@ -140,9 +140,11 @@ public class ActivitiProcessManagerTest {
 
 		assertTrue(manager.getCurrentProcessInstances().size() == 0);
 
-		String processInstanceId = manager.startProjectInstance(
-				processDefinitionId, null,
-				Arrays.asList("user1", "user2", "user3"),
+		String processDefKey = manager
+				.getProcessDefinitionKey(processDefinitionId);
+
+		String processInstanceId = manager.startProjectInstance(processDefKey,
+				null, Arrays.asList("user1", "user2", "user3"),
 				new HashMap<String, Collection<String>>() {
 					{
 						put("user1", Arrays.asList("user1"));

--- a/lp-simulation-environment/src/test/java/eu/learnpad/simulator/processmanager/activiti/processdispatcher/ActivitiProcessDispatcherTest.java
+++ b/lp-simulation-environment/src/test/java/eu/learnpad/simulator/processmanager/activiti/processdispatcher/ActivitiProcessDispatcherTest.java
@@ -58,6 +58,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
+import eu.learnpad.sim.rest.data.ProcessInstanceData;
 import eu.learnpad.simulator.IProcessEventReceiver;
 import eu.learnpad.simulator.Main;
 import eu.learnpad.simulator.datastructures.LearnPadTask;
@@ -86,6 +87,7 @@ public class ActivitiProcessDispatcherTest {
 	static ProcessEngine processEngine;
 
 	ProcessInstance processInstance;
+	ProcessInstanceData processInstanceData;
 
 	@BeforeClass
 	public static void initActivitiEngine() {
@@ -113,6 +115,10 @@ public class ActivitiProcessDispatcherTest {
 		// start process
 		processInstance = processEngine.getRuntimeService()
 				.startProcessInstanceByKey(TEST_PROCESS_KEY);
+
+		processInstanceData = new ProcessInstanceData(processInstance.getId(),
+				new HashMap<String, Object>(), TEST_PROCESS_USES,
+				new HashMap<String, Collection<String>>());
 	}
 
 	@SuppressWarnings("unchecked")
@@ -122,12 +128,11 @@ public class ActivitiProcessDispatcherTest {
 		ActivitiProcessManager processManger = mock(ActivitiProcessManager.class);
 		IProcessEventReceiver processEventReceiver = mock(IProcessEventReceiver.class);
 
-		new ActivitiProcessDispatcher(processManger, processEventReceiver,
-				processInstance, processEngine.getTaskService(),
+		new ActivitiProcessDispatcher(processInstanceData, processManger,
+				processEventReceiver, processEngine.getTaskService(),
 				processEngine.getRuntimeService(),
 				processEngine.getHistoryService(), mock(ITaskRouter.class),
-				mock(ITaskValidator.class), TEST_PROCESS_USES,
-				mock(BPMNExplorer.class)).start();
+				mock(ITaskValidator.class), mock(BPMNExplorer.class)).start();
 
 		// dispatcher should have dispatched first task
 		// (since task processing is multithreaded to avoid blocking,
@@ -158,11 +163,11 @@ public class ActivitiProcessDispatcherTest {
 						any(Map.class))).thenReturn(true);
 
 		final ActivitiProcessDispatcher dispatcher = new ActivitiProcessDispatcher(
-				processManger, processEventReceiver, processInstance,
+				processInstanceData, processManger, processEventReceiver,
 				processEngine.getTaskService(),
 				processEngine.getRuntimeService(),
 				processEngine.getHistoryService(), taskRouter, taskValidator,
-				TEST_PROCESS_USES, mock(BPMNExplorer.class));
+				mock(BPMNExplorer.class));
 		dispatcher.start();
 
 		validateAllTasks(dispatcher, taskRouter, processEventReceiver);
@@ -209,11 +214,11 @@ public class ActivitiProcessDispatcherTest {
 						any(Map.class))).thenReturn(true);
 
 		final ActivitiProcessDispatcher dispatcher = new ActivitiProcessDispatcher(
-				processManger, processEventReceiver, processInstance,
+				processInstanceData, processManger, processEventReceiver,
 				processEngine.getTaskService(),
 				processEngine.getRuntimeService(),
 				processEngine.getHistoryService(), taskRouter, taskValidator,
-				TEST_PROCESS_USES, mock(BPMNExplorer.class));
+				mock(BPMNExplorer.class));
 		dispatcher.start();
 
 		// dispatcher should have dispatched first task
@@ -291,11 +296,11 @@ public class ActivitiProcessDispatcherTest {
 						any(Map.class))).thenReturn(true);
 
 		final ActivitiProcessDispatcher dispatcher = new ActivitiProcessDispatcher(
-				processManager, processEventReceiver, processInstance,
+				processInstanceData, processManager, processEventReceiver,
 				processEngine.getTaskService(),
 				processEngine.getRuntimeService(),
 				processEngine.getHistoryService(), taskRouter, taskValidator,
-				TEST_PROCESS_USES, mock(BPMNExplorer.class));
+				mock(BPMNExplorer.class));
 		dispatcher.start();
 
 		validateAllTasks(dispatcher, taskRouter, processEventReceiver);
@@ -333,11 +338,11 @@ public class ActivitiProcessDispatcherTest {
 						any(Map.class))).thenReturn(true);
 
 		final ActivitiProcessDispatcher dispatcher = new ActivitiProcessDispatcher(
-				processManager, processEventReceiver, processInstance,
+				processInstanceData, processManager, processEventReceiver,
 				processEngine.getTaskService(),
 				processEngine.getRuntimeService(),
 				processEngine.getHistoryService(), taskRouter, taskValidator,
-				TEST_PROCESS_USES, mock(BPMNExplorer.class));
+				mock(BPMNExplorer.class));
 		dispatcher.start();
 
 		// reach end of process

--- a/lp-simulation-environment/src/test/java/eu/learnpad/simulator/processmanager/activiti/processdispatcher/ActivitiProcessDispatcherTest.java
+++ b/lp-simulation-environment/src/test/java/eu/learnpad/simulator/processmanager/activiti/processdispatcher/ActivitiProcessDispatcherTest.java
@@ -117,6 +117,7 @@ public class ActivitiProcessDispatcherTest {
 				.startProcessInstanceByKey(TEST_PROCESS_KEY);
 
 		processInstanceData = new ProcessInstanceData(processInstance.getId(),
+				processInstance.getProcessDefinitionKey(),
 				new HashMap<String, Object>(), TEST_PROCESS_USES,
 				new HashMap<String, Collection<String>>());
 	}


### PR DESCRIPTION
Previous version of the simulator made references to internal process definition ID differing from the ones defined in the BPMN files.
This made interactions with the Simulator more complicated and error-prone.

This PR modify the simulator to use the process definition IDs defined in the BPMN files in its external APIs (along with various minors fixes).