### PR TITLE
[cp] Remove scripts start/stop

### DIFF
--- a/lp-core-platform/build
+++ b/lp-core-platform/build
@@ -39,9 +39,9 @@ echo "[INFO] Nothing to test"
 # This is where you need to publish material into the `out' directory
 function component_install() {
 mkdir -p ${__OUT_PATH__}
-cp "scripts/start" "${__OUT_START_FILE__}"
-cp "scripts/stop" "${__OUT_STOP_FILE__}"
 echo "openjdk-7-jre" > "${__OUT_RUNDEPS_FILE__}"
+# cp "scripts/start" "${__OUT_START_FILE__}"
+# cp "scripts/stop" "${__OUT_STOP_FILE__}"
 # These is no configuration file to copy
 #cp <path_to>/file.cfg ${__OUT_CONF_PATH__}/
 }

--- a/lp-core-platform/scripts/start
+++ b/lp-core-platform/scripts/start
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-declare -r __PATH__="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-cd ${__PATH__} &&
-	echo "[INFO] Nothing to start"

--- a/lp-core-platform/scripts/stop
+++ b/lp-core-platform/scripts/stop
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-echo "[INFO] Nothing to stop"


### PR DESCRIPTION
These scripts are not need in `lp-core-platform` which is only a dependency of `lp-platform`.