### PR TITLE
Fix the CW CoreFacadeRestResurce on Simulator

### DIFF
--- a/lp-core-platform/lp-cp-xwiki-implementation/src/main/java/eu/learnpad/core/impl/cw/XwikiCoreFacadeRestResource.java
+++ b/lp-core-platform/lp-cp-xwiki-implementation/src/main/java/eu/learnpad/core/impl/cw/XwikiCoreFacadeRestResource.java
@@ -49,8 +49,6 @@ import eu.learnpad.sim.rest.data.UserData;
 public class XwikiCoreFacadeRestResource extends RestResource implements
 		CoreFacade {
 	
-	eu.learnpad.sim.BridgeInterface sim;
-
 	public XwikiCoreFacadeRestResource() {
 		this("localhost", 8080);
 	}
@@ -59,7 +57,6 @@ public class XwikiCoreFacadeRestResource extends RestResource implements
 			int coreFacadeHostPort) {
 		// This constructor could change in the future
 		this.updateConfiguration(coreFacadeHostname, coreFacadeHostPort);
-		this.sim = new eu.learnpad.core.impl.sim.XwikiBridgeInterfaceRestResource();
 	}
 
 	public void updateConfiguration(String coreFacadeHostname,
@@ -117,7 +114,14 @@ public class XwikiCoreFacadeRestResource extends RestResource implements
 	@Override
 	public String startSimulation(String modelId, String currentUser,
 			Collection<UserData> potentialUsers) throws LpRestException {
-		return this.sim.addProcessInstance(modelId, potentialUsers, currentUser);
+// This method should implement an HTTP request to the remote REST resource
+// on the corresponding core facade on the LCP. Specifically, it should
+// invoke "eu.learnpad.core.impl.cw.XwikiController.startSimulation" as REST
+// and return back the result as String.
+//
+// See for example how it is implemented "getRecommendations" 
+// in this class.
+		return null;
 	}
 
 	@Override


### PR DESCRIPTION
This is a proposal to remove the direct connection between the CW CoreFacadeRestResurce
and the Simulator.

In fact as discussed already in PR #111, the CoreFacadeRestResource implements HTTP
requests to the remote REST resources on the corresponding Core Facade on the LCP.