### PR TITLE
[sim] Java 7 nio file path bug workaround

### DIFF
--- a/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/utils/BPMNExplorer.java
+++ b/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/utils/BPMNExplorer.java
@@ -24,13 +24,11 @@ package eu.learnpad.simulator.utils;
  * #L%
  */
 
+import java.io.BufferedReader;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.net.URISyntaxException;
-import java.nio.charset.Charset;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -108,25 +106,31 @@ public class BPMNExplorer {
 		// for all data objects, read its attributes
 		for (String dataObject : mutDataObjects) {
 
-			Path path;
 			try {
-				path = Paths.get(this
-						.getClass()
-						.getClassLoader()
-						.getResource(
-								DATA_OBJECTS_FOLDER
-								+ "/"
-								+ mutDataObjectsIdtoName
-								.get(dataObject)).toURI());
 
-				List<String> elements = Files.readAllLines(path,
-						Charset.defaultCharset());
+				List<String> elements = new ArrayList<String>();
+
+				try (BufferedReader br = new BufferedReader(
+						new InputStreamReader(this
+
+								.getClass()
+								.getClassLoader()
+								.getResourceAsStream(
+										DATA_OBJECTS_FOLDER
+										+ "/"
+										+ mutDataObjectsIdtoName
+										.get(dataObject))));
+
+						) {
+					String line;
+					while ((line = br.readLine()) != null) {
+						elements.add(line);
+					}
+				}
 
 				mutDataObjectContent.put(dataObject, elements);
 			} catch (IOException e) {
 				e.printStackTrace();
-			} catch (URISyntaxException e1) {
-				e1.printStackTrace();
 			}
 		}
 


### PR DESCRIPTION
Java 7 has a bug regarding nio package and archive files (see
http://bugs.java.com/bugdatabase/view_bug.do?bug_id=7156873).
To avoid this bug, replace nio use with more "traditional" file opening
method.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/learnpad/learnpad/163)
<!-- Reviewable:end -->
