### PR TITLE
[sim] save and restore submitted form values

### DIFF
--- a/lp-simulation-environment/simulator/src/main/resources/static/Task-jsonform.js
+++ b/lp-simulation-environment/simulator/src/main/resources/static/Task-jsonform.js
@@ -21,16 +21,30 @@
 'use strict';
 
 function taskFormGenerate(taskid, data, formContainer, formId, callback) {
+    // check if we stored a previous submission for the task
+    // if yes, use it for default form values
+    var values = retrieveFormContent(taskid);
+
     $('#' + formContainer).html('<form id="' +
                         formId + '"  class="well"></form>');
 
     $('#' + formId).jsonForm({
         schema: JSON.parse(data.form).schema,
         form: JSON.parse(data.form).form,
+        value: values,
         onSubmit: function(errors, values) {
             if (!errors) {
+                // store submission to restore values in other tries
+                saveFormContent(taskid, values);
                 callback(JSON.stringify(values));
             }
         }});
 }
 
+function saveFormContent(taskid, values) {
+    sessionStorage.setItem(taskid, JSON.stringify(values));
+}
+
+function retrieveFormContent(taskid) {
+    return JSON.parse(sessionStorage.getItem(taskid));
+}


### PR DESCRIPTION
The form handler now saves the submitted values (in a session storage)
and restores them if the user has to resubmit the form (when previous
submission was incorrect).

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/learnpad/learnpad/171)
<!-- Reviewable:end -->
