### PR TITLE
[sim] Change Sim web UI to be more session-oriented

### DIFF
--- a/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/uihandler/webserver/TaskServlet.java
+++ b/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/uihandler/webserver/TaskServlet.java
@@ -212,6 +212,7 @@ public class TaskServlet extends WebSocketServlet {
 						mapper.writeValueAsString(new Resubmit(
 								task.name,
 								task.desc.replaceAll("\n", "<p/>"),
+								task.sessionId,
 								task.processId,
 								processManager
 								.getProcessDefinitionName(processManager
@@ -277,6 +278,7 @@ public class TaskServlet extends WebSocketServlet {
 												task.name,
 												task.desc.replaceAll("\n",
 												"<p/>"),
+												task.sessionId,
 												task.processId,
 												processManager
 														.getProcessDefinitionName(processManager

--- a/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/uihandler/webserver/UIHandlerWebImpl.java
+++ b/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/uihandler/webserver/UIHandlerWebImpl.java
@@ -137,7 +137,10 @@ public class UIHandlerWebImpl implements IUserHandler, IProcessEventReceiver {
 
 	@Override
 	public void receiveSimulationEndEvent(SimulationEndSimEvent event) {
-		// nothing to do
+		for (String userId : event.involvedusers) {
+			((UIServlet) usersMap.get(userId).getServletInstance())
+			.completeSession(event.simulationsessionid);
+		}
 	}
 
 	@Override
@@ -147,10 +150,7 @@ public class UIHandlerWebImpl implements IUserHandler, IProcessEventReceiver {
 
 	@Override
 	public void receiveProcessEndEvent(ProcessEndSimEvent event) {
-		for (String userId : event.involvedusers) {
-			((UIServlet) usersMap.get(userId).getServletInstance())
-			.completeProcess(event.processInstance.processartifactid);
-		}
+		// nothing to do
 	}
 
 	@Override

--- a/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/uihandler/webserver/UIServlet.java
+++ b/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/uihandler/webserver/UIServlet.java
@@ -40,7 +40,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import eu.learnpad.simulator.uihandler.webserver.msg.user.send.AddTask;
 import eu.learnpad.simulator.uihandler.webserver.msg.user.send.DeleteTask;
-import eu.learnpad.simulator.uihandler.webserver.msg.user.send.ProcessFinished;
+import eu.learnpad.simulator.uihandler.webserver.msg.user.send.SessionFinished;
 
 /**
  * @author Tom Jorquera - Linagora
@@ -116,13 +116,13 @@ public class UIServlet extends WebSocketServlet {
 		}
 	}
 
-	public void completeProcess(String processId) {
+	public void completeSession(String sessionId) {
 		for (UISocket session : activeSockets) {
 			try {
 				session.getRemote()
 				.sendString(
-						mapper.writeValueAsString(new ProcessFinished(
-								processId)));
+						mapper.writeValueAsString(new SessionFinished(
+										sessionId)));
 			} catch (IOException e) {
 				e.printStackTrace();
 			}

--- a/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/uihandler/webserver/msg/task/send/Resubmit.java
+++ b/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/uihandler/webserver/msg/task/send/Resubmit.java
@@ -37,6 +37,7 @@ public class Resubmit implements ITaskMsg {
 
 	public String name;
 	public String description;
+	public String sessionid;
 	public String processid;
 	public String processname;
 	public long startingtime;
@@ -47,13 +48,14 @@ public class Resubmit implements ITaskMsg {
 	public int nbattempts;
 	public long expectedtime;
 
-	public Resubmit(String name, String description, String processid,
-			String processname, long startingtime, String form,
-			Collection<LearnPadDocument> documents, int nbattempts,
-			long expectedtime) {
+	public Resubmit(String name, String description, String sessionid,
+			String processid, String processname, long startingtime,
+			String form, Collection<LearnPadDocument> documents,
+			int nbattempts, long expectedtime) {
 		super();
 		this.name = name;
 		this.description = description;
+		this.sessionid = sessionid;
 		this.processid = processid;
 		this.processname = processname;
 		this.startingtime = startingtime;

--- a/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/uihandler/webserver/msg/task/send/TaskDesc.java
+++ b/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/uihandler/webserver/msg/task/send/TaskDesc.java
@@ -41,12 +41,12 @@ public class TaskDesc extends Resubmit implements ITaskMsg {
 
 	public long expectedTime;
 
-	public TaskDesc(String name, String description, String process,
-			String processname, long startingtime, String form,
+	public TaskDesc(String name, String description, String sessionid,
+			String process, String processname, long startingtime, String form,
 			Collection<LearnPadDocument> documents, Integer totalscore,
 			int nbAttempts, long expectedTime) {
-		super(name, description, process, processname, startingtime, form,
-				documents, nbAttempts, expectedTime);
+		super(name, description, sessionid, process, processname, startingtime,
+				form, documents, nbAttempts, expectedTime);
 		this.totalscore = totalscore;
 	}
 

--- a/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/uihandler/webserver/msg/user/send/SessionFinished.java
+++ b/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/uihandler/webserver/msg/user/send/SessionFinished.java
@@ -1,7 +1,7 @@
 /**
  *
  */
-package eu.learnpad.simulator.uihandler.webserver.msg.user;
+package eu.learnpad.simulator.uihandler.webserver.msg.user.send;
 
 /*
  * #%L
@@ -24,18 +24,31 @@ package eu.learnpad.simulator.uihandler.webserver.msg.user;
  * #L%
  */
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import eu.learnpad.simulator.uihandler.webserver.msg.user.IUserMsg;
 
 /**
  * @author Tom Jorquera - Linagora
  *
  */
-public interface IUserMsg {
-	static enum TYPE {
-		ADDTASK, DELTASK, FINISHED, SESSION_FINISHED
+public class SessionFinished implements IUserMsg {
+
+	public String sessionid;
+
+	/**
+	 * @param processid
+	 */
+	public SessionFinished(String sessionid) {
+		super();
+		this.sessionid = sessionid;
 	}
 
-	@JsonProperty("type")
-	public TYPE getType();
+	/*
+	 * (non-Javadoc)
+	 *
+	 * @see activitipoc.uihandler.webserver.msg.user.UserMsg#getType()
+	 */
+	public TYPE getType() {
+		return TYPE.SESSION_FINISHED;
+	}
 
 }

--- a/lp-simulation-environment/simulator/src/main/resources/static/Task.js
+++ b/lp-simulation-environment/simulator/src/main/resources/static/Task.js
@@ -71,55 +71,55 @@ function task(address, taskid, user, integratedMode) {
 
         case 'TASKDESC':
             // memorize process id
-            this.processid = data.processid;
+            this.sessionid = data.sessionid;
 
-            if (!$('#processcontainer' + data.processid).length) {
+            if (!$('#processcontainer' + data.sessionid).length) {
 
                 // create new tab for new process
                 $('#taskstable').append(
                     '<li role="presentation"><a data-toggle="tab" href="#processcontainer' +
-                        data.processid + '">' + data.processname +
+                        data.sessionid + '">' + data.processname +
                         '</a></li>'
                 );
                 var tasksDiv = $('#tasks');
                 var processDiv = document.createElement('div');
-                processDiv.id = 'processcontainer' + data.processid;
+                processDiv.id = 'processcontainer' + data.sessionid;
                 processDiv.className = 'tab-pane';
                 tasksDiv.append(processDiv);
 
                 var processMainDiv = document.createElement('div');
-                processMainDiv.id = 'processmain' + data.processid;
+                processMainDiv.id = 'processmain' + data.sessionid;
                 processMainDiv.className = 'col-sm-8';
                 processDiv.appendChild(processMainDiv);
 
                 var processSideDiv = document.createElement('div');
-                processSideDiv.id = 'processside' + data.processid;
+                processSideDiv.id = 'processside' + data.sessionid;
                 processSideDiv.className = 'col-sm-4';
                 processDiv.appendChild(processSideDiv);
 
                 if(!integratedMode) {
-                    users(user).setUserList('processside' + data.processid);
+                    users(user).setUserList('processside' + data.sessionid);
                 }
 
                 // add gamification panel to side div
                 var scoreHelpText = "Your score is calculated based on how well you perform each task.<p>Each successfully completed task gives you points based of your number of attempts and how long did you take regarding the expected time.<p>Faster completion and less mistakes will award more points.";
-                $('#processside' + data.processid).append(
-                    '<div id="gamification' + data.processid +
+                $('#processside' + data.sessionid).append(
+                    '<div id="gamification' + data.sessionid +
                         '" class="game-panel panel panel-default">' +
                         '<div class="panel-body">' +
-                        '<div><h4><em id="score' + data.processid +
+                        '<div><h4><em id="score' + data.sessionid +
                         '"></em> <span style="float:right" class="glyphicon glyphicon-question-sign"' +
                         ' data-toggle="popover" data-trigger="focus" tabindex="0" ' +
                         'data-placement="bottom" data-content="' + scoreHelpText +
                         '"></span></h4></div></div></div>'
                 );
                 // initialize help popover
-                $('#gamification' + data.processid + ' [data-toggle="popover"]').popover({'html': true});
+                $('#gamification' + data.sessionid + ' [data-toggle="popover"]').popover({'html': true});
 
                 // this element can cause page height change, so we need to
                 // monitor it
-                heightMon.monitor('#gamification' + data.processid + ' [data-toggle="popover"]');
-                $('#gamification' + data.processid + ' [data-toggle="popover"]').bind(
+                heightMon.monitor('#gamification' + data.sessionid + ' [data-toggle="popover"]');
+                $('#gamification' + data.sessionid + ' [data-toggle="popover"]').bind(
                     'transitionend', heightMon.checkForChangeNotification);
 
                 // check if it is the first tab
@@ -129,9 +129,9 @@ function task(address, taskid, user, integratedMode) {
                 }
 
                 // add the process diagram
-                $('#processmain' + data.processid).append(
+                $('#processmain' + data.sessionid).append(
                 '<div class="panel-group diagram" id="accordion' +
-                    data.processid +
+                    data.sessionid +
                     '" role="tablist" aria-multiselectable="true">' +
                     '<div class="panel panel-default">' +
                     '<div class="panel-heading" role="tab" id="diagramHeading' + taskid +
@@ -153,8 +153,8 @@ function task(address, taskid, user, integratedMode) {
 
                 // this element can cause page height change, so we need to
                 // monitor it
-                heightMon.monitor('#accordion' + data.processid);
-                document.getElementById('accordion' + data.processid).addEventListener(
+                heightMon.monitor('#accordion' + data.sessionid);
+                document.getElementById('accordion' + data.sessionid).addEventListener(
                     "transitionend",
                     heightMon.checkForChangeNotification);
 
@@ -169,7 +169,7 @@ function task(address, taskid, user, integratedMode) {
                 '">Attempts: ' + data.nbattempts + '</em></h4></div>' +
                 '</p><div id="taskFormDiv' + taskid + '"></div><hr>';
 
-            $('#accordion' + data.processid).before(taskDiv);
+            $('#accordion' + data.sessionid).before(taskDiv);
 
             $('#taskdata' + taskid).html(
                 '<h4>' + '<em>' + data.name + '</em></h4>' +
@@ -226,11 +226,11 @@ function task(address, taskid, user, integratedMode) {
             }, 1000);
 
             // update score
-            $('#score' + data.processid).html(
+            $('#score' + data.sessionid).html(
                 'Score: ' + data.totalscore
             );
 
-            $('#processcontainer' + data.processid + ' .diagramImg').attr(
+            $('#processcontainer' + data.sessionid + ' .diagramImg').attr(
                 'src',
                 'diagram/processinstance/' + data.processid + '/' + taskid
             );
@@ -266,7 +266,7 @@ function task(address, taskid, user, integratedMode) {
             );
 
             // update score
-            $('#score' + this.processid).html(
+            $('#score' + this.sessionid).html(
                 'Score: ' + data.totalscore
             );
 

--- a/lp-simulation-environment/simulator/src/main/resources/static/TaskReceiver.js
+++ b/lp-simulation-environment/simulator/src/main/resources/static/TaskReceiver.js
@@ -41,14 +41,14 @@ function taskReceiver(address, user, integratedMode) {
         var msg = JSON.parse(m.data);
         switch (msg.type) {
 
-        case 'FINISHED':
-            var containerDiv = $('#processmain' + msg.processid);
+        case 'SESSION_FINISHED':
+            var containerDiv = $('#processmain' + msg.sessionid);
             var processFinished = document.createElement('p');
             processFinished.innerHTML = '<h4>Congratulations, you successfully completed the simulation</h4>'
             containerDiv.append(processFinished);
 
             // remove process diagram
-            $('#accordion' + msg.processid).remove();
+            $('#accordion' + msg.sessionid).remove();
 
             break;
 


### PR DESCRIPTION
This PR introduces a series of changes aiming at making the simulator web ui more session oriented.
Previous version would work on a "process" basis, sorting tasks by processes and sending notifications on process end. This was not very consistent with the principle of sessions.
This version changes the UI logic to work on a "session" basis instead. Meaning that a user will receive tasks from the same session at the same place (even if they belong to different processes), and will be notified of completion when the session end.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/learnpad/learnpad/193)
<!-- Reviewable:end -->
