### PR TITLE
Correct Sim user infos API path annotations

### DIFF
--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/IUserInfosAPI.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/IUserInfosAPI.java
@@ -34,17 +34,16 @@ import eu.learnpad.sim.rest.data.UserData;
  * @author Tom Jorquera - Linagora
  *
  */
-@Path("/learnpad/sim/users")
 @Consumes(MediaType.APPLICATION_JSON)
 @Produces(MediaType.APPLICATION_JSON)
 public interface IUserInfosAPI {
 
 	@GET
-	@Path("/")
+	@Path("/users/")
 	public List<String> getUsers();
 
 	@GET
-	@Path("/{userartifactid:.*}")
+	@Path("/users/{userartifactid:.*}")
 	public UserData getUserData(
 			@PathParam("userartifactid") String userartifactid);
 }


### PR DESCRIPTION
The path annotations on the IUserInfosAPI interface were incorrect. A
base path was set at the interface level, and relative path at the
methods level. This does not works as the interface is implemented by a
class with its own base path.

The annotations are now corrected to be at the methods level only.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/learnpad/learnpad/199)
<!-- Reviewable:end -->
