### PR TITLE
[sim] Correct bug in Web UI user id parsing

### DIFF
--- a/lp-simulation-environment/simulator/src/main/resources/ui.html
+++ b/lp-simulation-environment/simulator/src/main/resources/ui.html
@@ -263,7 +263,7 @@
              }
          } else {
              $('#connectBn').click(function(event) {
-                 userid = $('#uiid').val().toLowerCase();
+                 userid = $('#uiid').val();
                  taskReceiver(#serveripaddress#, userid, integratedMode);
                  if(!integratedMode) {
                      chat('chatcontainer', #serveripaddress#, userid);


### PR DESCRIPTION
Previous versions of the web ui would convert the passed username to
lower case for demo purpose (being able to type 'Barnaby' for the id
'barnaby').
Now that we have a cleaner handling of users, this causes bugs when the
user id is not in lower case.
Fixing this by removing lower case conversion.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/learnpad/learnpad/201)
<!-- Reviewable:end -->
