### PR TITLE
[sim] Correct CORS mistake in Sim WebUI client

### DIFF
--- a/lp-simulation-environment/simulator/src/main/resources/static/Task.js
+++ b/lp-simulation-environment/simulator/src/main/resources/static/Task.js
@@ -98,7 +98,7 @@ function task(address, taskid, user, integratedMode) {
                 processDiv.appendChild(processSideDiv);
 
                 if (!integratedMode) {
-                    users(user, data.processid).
+                    users(address, user, data.processid).
                         setUserList('processside' + data.sessionid);
                 }
 

--- a/lp-simulation-environment/simulator/src/main/resources/static/Users.js
+++ b/lp-simulation-environment/simulator/src/main/resources/static/Users.js
@@ -18,13 +18,13 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  * #L%
  */
-function users(userid, processid) {
+function users(address, userid, processid) {
 
     var userInfos = {};
 
     var req = new XMLHttpRequest();
     req.open('GET',
-             'http://localhost:8081/learnpad/sim/instances/' + processid,
+             'http://' + address + '/learnpad/sim/instances/' + processid,
              false);
     req.send(null);
 
@@ -35,7 +35,7 @@ function users(userid, processid) {
             otherId = data.users[i];
             req = new XMLHttpRequest();
             req.open('GET',
-                     'http://localhost:8081/learnpad/sim/users/' + otherId,
+                     'http://' + address + '/learnpad/sim/users/' + otherId,
                      false);
             req.send(null);
             userInfos[otherId] = JSON.parse(req.responseText);


### PR DESCRIPTION
The user data handling part of the WebUI contained a mistake that could
cause it to try to violate a CORS restriction. This bug would not appear
when tested on the localhost.
This commit fixes the bug by setting the destination address explicitely.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/learnpad/learnpad/202)
<!-- Reviewable:end -->
