### PR TITLE
Fixed a typo in the API, and all the related classes.

### DIFF
--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/qm/rest/NotificationsFromBridge.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/qm/rest/NotificationsFromBridge.java
@@ -27,8 +27,8 @@ import eu.learnpad.exception.LpRestException;
 
 public interface NotificationsFromBridge {
 
-	@Path("/genrationcompleted/{questionnairesid}")
+	@Path("/generationcompleted/{questionnairesid}")
 	@PUT
-	void genrationCompleted(@PathParam("questionnairesid") String questionnairesId)
+	void generationCompleted(@PathParam("questionnairesid") String questionnairesId)
 					throws LpRestException;
 }

--- a/lp-core-platform/lp-cp-xwiki-implementation/src/main/java/eu/learnpad/core/impl/qm/XwikiController.java
+++ b/lp-core-platform/lp-cp-xwiki-implementation/src/main/java/eu/learnpad/core/impl/qm/XwikiController.java
@@ -89,11 +89,11 @@ System.err.println("Done!");
 	}
 
 	@Override
-	public void genrationCompleted(String questionnairesId)
+	public void generationCompleted(String questionnairesId)
 			throws LpRestExceptionImpl {
 /**
-* THIS IMPLEMENTATION OF THIS METHOD 
-* HAS BEEN DEVELOPED ONLY eu.learnpad.core.impl.qm.XwikiCoreFacadeRestResource FOR TESTING .
+* THE IMPLEMENTATION OF THIS METHOD 
+* HAS BEEN DEVELOPED ONLY FOR TESTING eu.learnpad.core.impl.qm.XwikiCoreFacadeRestResource .
 * IT WILL CHANGE IN THE FUTURE
 */
 		System.err.println("Received: \t" + questionnairesId);		

--- a/lp-core-platform/lp-cp-xwiki-implementation/src/main/java/eu/learnpad/core/impl/qm/XwikiCoreFacadeRestResource.java
+++ b/lp-core-platform/lp-cp-xwiki-implementation/src/main/java/eu/learnpad/core/impl/qm/XwikiCoreFacadeRestResource.java
@@ -87,7 +87,7 @@ public class XwikiCoreFacadeRestResource extends RestResource implements CoreFac
 	}
 
 	@Override
-	public void genrationCompleted(String questionnairesId)
+	public void generationCompleted(String questionnairesId)
 			throws LpRestException {
 		// Now actually notifying the CP via REST
 		HttpClient httpClient = RestResource.getClient();

--- a/lp-questionnaire-manager/src/test/java/eu/learnpad/qm/tests/learnpad/XwikiCoreFacadeRestResourceTest.java
+++ b/lp-questionnaire-manager/src/test/java/eu/learnpad/qm/tests/learnpad/XwikiCoreFacadeRestResourceTest.java
@@ -34,7 +34,7 @@ public class XwikiCoreFacadeRestResourceTest extends AbstractUnitTest{
 	public void generationCompletedTest(){
 		this.cf = new XwikiCoreFacadeRestResource();
 		try {
-			cf.genrationCompleted("this-is-foo");
+			cf.generationCompleted("this-is-foo");
 		} catch (LpRestException e) {
 			Assert.assertFalse(e.getMessage(),true);
 		}


### PR DESCRIPTION
Probably this change will impact on the PR#192 :

see https://github.com/LearnPAd/learnpad/pull/192/files#diff-75edf02b4f75a1c8e20e9a1c2565b92eR165

Thus a simple fix is requred also there.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/learnpad/learnpad/219)
<!-- Reviewable:end -->
