### PR TITLE
[sim] Update sim API to declare LpRestException

### DIFF
--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/IEventReceiver.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/IEventReceiver.java
@@ -22,6 +22,7 @@ package eu.learnpad.sim.rest;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 
+import eu.learnpad.exception.LpRestException;
 import eu.learnpad.sim.rest.event.impl.ProcessEndEvent;
 import eu.learnpad.sim.rest.event.impl.ProcessStartEvent;
 import eu.learnpad.sim.rest.event.impl.SessionScoreUpdateEvent;
@@ -40,34 +41,41 @@ public interface IEventReceiver {
 
 	@POST
 	@Path("/simulationstart")
-	public void receiveSimulationStartEvent(SimulationStartEvent event);
+	public void receiveSimulationStartEvent(SimulationStartEvent event)
+			throws LpRestException;
 
 	@POST
 	@Path("/simulationend")
-	public void receiveSimulationEndEvent(SimulationEndEvent event);
+	public void receiveSimulationEndEvent(SimulationEndEvent event)
+			throws LpRestException;
 
 	@POST
 	@Path("/processstart")
-	public void receiveProcessStartEvent(ProcessStartEvent event);
+	public void receiveProcessStartEvent(ProcessStartEvent event)
+			throws LpRestException;
 
 	@POST
 	@Path("/processend")
-	public void receiveProcessEndEvent(ProcessEndEvent event);
+	public void receiveProcessEndEvent(ProcessEndEvent event)
+			throws LpRestException;
 
 	@POST
 	@Path("/taskstart")
-	public void receiveTaskStartEvent(TaskStartEvent event);
+	public void receiveTaskStartEvent(TaskStartEvent event)
+			throws LpRestException;
 
 	@POST
 	@Path("/taskend")
-	public void receiveTaskEndEvent(TaskEndEvent event);
+	public void receiveTaskEndEvent(TaskEndEvent event) throws LpRestException;
 
 	@POST
 	@Path("/taskfailed")
-	public void receiveTaskFailedEvent(TaskFailedEvent event);
+	public void receiveTaskFailedEvent(TaskFailedEvent event)
+			throws LpRestException;
 
 	@POST
 	@Path("/sessionscoreupdate")
-	public void receiveSessionScoreUpdateEvent(SessionScoreUpdateEvent event);
+	public void receiveSessionScoreUpdateEvent(SessionScoreUpdateEvent event)
+			throws LpRestException;
 
 }

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/IProcessHandlingAPI.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/IProcessHandlingAPI.java
@@ -30,6 +30,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
+import eu.learnpad.exception.LpRestException;
 import eu.learnpad.sim.rest.data.ProcessData;
 import eu.learnpad.sim.rest.data.ProcessInstanceData;
 import eu.learnpad.sim.rest.data.UserData;
@@ -52,7 +53,7 @@ public interface IProcessHandlingAPI {
 	 */
 	@GET
 	@Path("/processes")
-	public Collection<String> getProcessDefinitions();
+	public Collection<String> getProcessDefinitions() throws LpRestException;
 
 	/**
 	 *
@@ -63,7 +64,7 @@ public interface IProcessHandlingAPI {
 	@POST
 	@Path("/processes")
 	public Collection<String> addProcessDefinition(
-			String processDefinitionFileURL);
+			String processDefinitionFileURL) throws LpRestException;
 
 	/**
 	 *
@@ -74,7 +75,8 @@ public interface IProcessHandlingAPI {
 	@GET
 	@Path("/processes/{artifactid:.*}")
 	public ProcessData getProcessInfos(
-			@PathParam("artifactid") String processArtifactId);
+			@PathParam("artifactid") String processArtifactId)
+			throws LpRestException;
 
 	/**
 	 *
@@ -82,7 +84,7 @@ public interface IProcessHandlingAPI {
 	 */
 	@GET
 	@Path("/instances")
-	public Collection<String> getProcessInstances();
+	public Collection<String> getProcessInstances() throws LpRestException;
 
 	/**
 	 *
@@ -92,7 +94,8 @@ public interface IProcessHandlingAPI {
 	 */
 	@POST
 	@Path("/instances")
-	public String addProcessInstance(ProcessInstanceData data);
+	public String addProcessInstance(ProcessInstanceData data)
+			throws LpRestException;
 
 	/**
 	 *
@@ -109,7 +112,8 @@ public interface IProcessHandlingAPI {
 	@Path("/instances/{artifactid:.*}")
 	public String addProcessInstance(@PathParam("artifactid") String processId,
 			Collection<UserData> potentialUsers,
-			@QueryParam("currentuser") String currentUser);
+			@QueryParam("currentuser") String currentUser)
+			throws LpRestException;
 
 	/**
 	 *
@@ -120,5 +124,6 @@ public interface IProcessHandlingAPI {
 	@GET
 	@Path("/instances/{artifactid:.*}")
 	public ProcessInstanceData getProcessInstanceInfos(
-			@PathParam("artifactid") String processInstanceArtifactId);
+			@PathParam("artifactid") String processInstanceArtifactId)
+			throws LpRestException;
 }

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/ISimulationMonitoringAPI.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/ISimulationMonitoringAPI.java
@@ -27,6 +27,8 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
+import eu.learnpad.exception.LpRestException;
+
 /**
  *
  * This interface describes the REST API functionalities related to simulation
@@ -47,7 +49,8 @@ public interface ISimulationMonitoringAPI {
 	@Path("/results/instances/{processinstanceartifactid:.*}")
 	@Produces(MediaType.APPLICATION_OCTET_STREAM)
 	public InputStream getProcessInstanceResults(
-			@PathParam("processinstanceartifactid") String processinstanceartifactid);
+			@PathParam("processinstanceartifactid") String processinstanceartifactid)
+			throws LpRestException;
 
 	/**
 	 * Get the results file associated with a learner
@@ -59,7 +62,8 @@ public interface ISimulationMonitoringAPI {
 	@Path("/results/users/{userartifactid:.*}")
 	@Produces(MediaType.APPLICATION_OCTET_STREAM)
 	public InputStream getUserResults(
-			@PathParam("userartifactid") String userartifactid);
+			@PathParam("userartifactid") String userartifactid)
+			throws LpRestException;
 
 	/**
 	 * Get the results file associated with a process
@@ -71,6 +75,7 @@ public interface ISimulationMonitoringAPI {
 	@Path("/results/processes/{processartifactid:.*}")
 	@Produces(MediaType.APPLICATION_OCTET_STREAM)
 	public InputStream getProcessResults(
-			@PathParam("processartifactid") String processartifactid);
+			@PathParam("processartifactid") String processartifactid)
+			throws LpRestException;
 
 }

--- a/lp-simulation-environment/simulator/src/test/java/eu/learnpad/simulator/api/rest/corefacade/SimRestAPICoreFacadeTest.java
+++ b/lp-simulation-environment/simulator/src/test/java/eu/learnpad/simulator/api/rest/corefacade/SimRestAPICoreFacadeTest.java
@@ -22,6 +22,7 @@ package eu.learnpad.simulator.api.rest.corefacade;
  */
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -33,6 +34,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import eu.learnpad.exception.LpRestException;
 import eu.learnpad.sim.rest.data.UserData;
 import eu.learnpad.sim.rest.event.impl.ProcessEndEvent;
 import eu.learnpad.sim.rest.event.impl.ProcessStartEvent;
@@ -96,35 +98,46 @@ public class SimRestAPICoreFacadeTest {
 		assertEquals(server.nbSessionScoreUpdateEvents, 0);
 
 		// send events
-		receiverClient.receiveSimulationEndEvent(new SimulationEndEvent(System
-				.currentTimeMillis(), "1", Arrays.asList("test")));
+		try {
+			receiverClient.receiveSimulationEndEvent(new SimulationEndEvent(
+					System.currentTimeMillis(), "1", Arrays.asList("test")));
 
-		receiverClient.receiveSimulationStartEvent(new SimulationStartEvent(
-				System.currentTimeMillis(), "1", Arrays.asList("test")));
+			receiverClient
+					.receiveSimulationStartEvent(new SimulationStartEvent(
+							System.currentTimeMillis(), "1", Arrays
+									.asList("test")));
 
-		receiverClient.receiveProcessEndEvent(new ProcessEndEvent(System
-				.currentTimeMillis(), "1", Arrays.asList("test"), "1", "1"));
+			receiverClient
+					.receiveProcessEndEvent(new ProcessEndEvent(System
+							.currentTimeMillis(), "1", Arrays.asList("test"),
+							"1", "1"));
 
-		receiverClient.receiveProcessStartEvent(new ProcessStartEvent(System
-				.currentTimeMillis(), "1", Arrays.asList("test"), "1", "1"));
+			receiverClient.receiveProcessStartEvent(new ProcessStartEvent(
+					System.currentTimeMillis(), "1", Arrays.asList("test"),
+					"1", "1"));
 
-		receiverClient.receiveTaskEndEvent(new TaskEndEvent(System
-				.currentTimeMillis(), "1", Arrays.asList("test"), "1", "1",
-				"1", Arrays.asList("test"), "test",
-				new HashMap<String, Object>()));
+			receiverClient.receiveTaskEndEvent(new TaskEndEvent(System
+					.currentTimeMillis(), "1", Arrays.asList("test"), "1", "1",
+					"1", Arrays.asList("test"), "test",
+					new HashMap<String, Object>()));
 
-		receiverClient.receiveTaskFailedEvent(new TaskFailedEvent(System
-				.currentTimeMillis(), "1", Arrays.asList("test"), "1", "1",
-				"1", Arrays.asList("test"), "test",
-				new HashMap<String, Object>()));
+			receiverClient.receiveTaskFailedEvent(new TaskFailedEvent(System
+					.currentTimeMillis(), "1", Arrays.asList("test"), "1", "1",
+					"1", Arrays.asList("test"), "test",
+					new HashMap<String, Object>()));
 
-		receiverClient.receiveTaskStartEvent(new TaskStartEvent(System
-				.currentTimeMillis(), "1", Arrays.asList("test"), "1", "1",
-				"1", Arrays.asList("test")));
-		receiverClient
-		.receiveSessionScoreUpdateEvent(new SessionScoreUpdateEvent(
-				System.currentTimeMillis(), "1", Arrays.asList("test"),
-				"1", "1", 1L));
+			receiverClient.receiveTaskStartEvent(new TaskStartEvent(System
+					.currentTimeMillis(), "1", Arrays.asList("test"), "1", "1",
+					"1", Arrays.asList("test")));
+			receiverClient
+					.receiveSessionScoreUpdateEvent(new SessionScoreUpdateEvent(
+							System.currentTimeMillis(), "1", Arrays
+									.asList("test"), "1", "1", 1L));
+
+		} catch (LpRestException e) {
+			e.printStackTrace();
+			fail("Exception thrown");
+		}
 
 		// verify that all events has been registered
 		assertEquals(server.nbSimulationEndEvents, 1);


### PR DESCRIPTION
sim REST API methods now declare that they can throw a LpRestException.
This will allow for a better and more consistent handling of error
during calls to these methods.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/learnpad/learnpad/235)
<!-- Reviewable:end -->
