### PR TITLE
Update Sim API and impl to store modelsetid information

### DIFF
--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/IProcessHandlingAPI.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/IProcessHandlingAPI.java
@@ -64,7 +64,9 @@ public interface IProcessHandlingAPI {
 	@POST
 	@Path("/processes")
 	public Collection<String> addProcessDefinition(
-			String processDefinitionFileURL) throws LpRestException;
+			String processDefinitionFileURL,
+			@QueryParam("modelsetartifactid") String modelSetId)
+			throws LpRestException;
 
 	/**
 	 *

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/AbstractEvent.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/AbstractEvent.java
@@ -31,17 +31,19 @@ public abstract class AbstractEvent {
 	public Long timestamp;
 	public String simulationsessionid;
 	public List<String> involvedusers;
+	public String modelsetid;
 
 	public AbstractEvent() {
 		super();
 	}
 
 	public AbstractEvent(Long timeStamp, String simulationsessionid,
-			List<String> involvedusers) {
+			List<String> involvedusers, String modelsetid) {
 		super();
 		this.timestamp = timeStamp;
 		this.simulationsessionid = simulationsessionid;
 		this.involvedusers = involvedusers;
+		this.modelsetid = modelsetid;
 	}
 
 }

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/ProcessEndEvent.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/ProcessEndEvent.java
@@ -33,10 +33,10 @@ public class ProcessEndEvent extends ProcessStartEvent {
 	}
 
 	public ProcessEndEvent(Long timestamp, String simulationsessionid,
-			List<String> involvedusers, String processid,
+			List<String> involvedusers, String modelsetid, String processid,
 			String processdefinitionid) {
-		super(timestamp, simulationsessionid, involvedusers, processid,
-				processdefinitionid);
+		super(timestamp, simulationsessionid, involvedusers, modelsetid,
+				processid, processdefinitionid);
 	}
 
 }

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/ProcessStartEvent.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/ProcessStartEvent.java
@@ -45,9 +45,9 @@ public class ProcessStartEvent extends AbstractEvent {
 	}
 
 	public ProcessStartEvent(Long timestamp, String simulationsessionid,
-			List<String> involvedusers, String processid,
+			List<String> involvedusers, String modelsetid, String processid,
 			String processdefinitionid) {
-		super(timestamp, simulationsessionid, involvedusers);
+		super(timestamp, simulationsessionid, involvedusers, modelsetid);
 		this.processid = processid;
 		this.processdefinitionid = processdefinitionid;
 	}

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/SessionScoreUpdateEvent.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/SessionScoreUpdateEvent.java
@@ -50,9 +50,9 @@ public class SessionScoreUpdateEvent extends AbstractEvent {
 	}
 
 	public SessionScoreUpdateEvent(Long timestamp, String simulationsessionid,
-			List<String> involvedusers, String processid, String user,
-			Long sessionScore) {
-		super(timestamp, simulationsessionid, involvedusers);
+			List<String> involvedusers, String modelsetid, String processid,
+			String user, Long sessionScore) {
+		super(timestamp, simulationsessionid, involvedusers, modelsetid);
 		this.processid = processid;
 		this.sessionscore = sessionScore;
 	}

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/SimulationEndEvent.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/SimulationEndEvent.java
@@ -33,8 +33,8 @@ public class SimulationEndEvent extends SimulationStartEvent {
 	}
 
 	public SimulationEndEvent(Long timestamp, String simulationsessionid,
-			List<String> involvedusers) {
-		super(timestamp, simulationsessionid, involvedusers);
+			List<String> involvedusers, String modelsetid) {
+		super(timestamp, simulationsessionid, involvedusers, modelsetid);
 	}
 
 }

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/SimulationStartEvent.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/SimulationStartEvent.java
@@ -35,8 +35,8 @@ public class SimulationStartEvent extends AbstractEvent {
 	}
 
 	public SimulationStartEvent(Long timestamp, String simulationsessionid,
-			List<String> involvedusers) {
-		super(timestamp, simulationsessionid, involvedusers);
+			List<String> involvedusers, String modelsetid) {
+		super(timestamp, simulationsessionid, involvedusers, modelsetid);
 	}
 
 }

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/TaskEndEvent.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/TaskEndEvent.java
@@ -37,11 +37,11 @@ public class TaskEndEvent extends TaskStartEvent {
 	}
 
 	public TaskEndEvent(Long timestamp, String simulationsessionid,
-			List<String> involvedusers, String processid, String taskid,
-			String taskdefid, List<String> assignedusers,
+			List<String> involvedusers, String modelsetid, String processid,
+			String taskid, String taskdefid, List<String> assignedusers,
 			String completingUser, Map<String, Object> submittedData) {
-		super(timestamp, simulationsessionid, involvedusers, processid, taskid,
-				taskdefid, assignedusers);
+		super(timestamp, simulationsessionid, involvedusers, modelsetid,
+				processid, taskid, taskdefid, assignedusers);
 		this.completingUser = completingUser;
 		this.submittedData = submittedData;
 	}

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/TaskFailedEvent.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/TaskFailedEvent.java
@@ -34,11 +34,12 @@ public class TaskFailedEvent extends TaskEndEvent {
 	}
 
 	public TaskFailedEvent(Long timestamp, String simulationsessionid,
-			List<String> involvedusers, String processid, String taskid,
-			String taskdefid, List<String> assignedusers,
+			List<String> involvedusers, String modelsetid, String processid,
+			String taskid, String taskdefid, List<String> assignedusers,
 			String completingUser, Map<String, Object> submittedData) {
-		super(timestamp, simulationsessionid, involvedusers, processid, taskid,
-				taskdefid, assignedusers, completingUser, submittedData);
+		super(timestamp, simulationsessionid, involvedusers, modelsetid,
+				processid, taskid, taskdefid, assignedusers, completingUser,
+				submittedData);
 	}
 
 }

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/TaskStartEvent.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/TaskStartEvent.java
@@ -55,9 +55,9 @@ public class TaskStartEvent extends AbstractEvent {
 	}
 
 	public TaskStartEvent(Long timestamp, String simulationsessionid,
-			List<String> involvedusers, String processid, String taskid,
-			String taskdefid, List<String> assignedusers) {
-		super(timestamp, simulationsessionid, involvedusers);
+			List<String> involvedusers, String modelsetid, String processid,
+			String taskid, String taskdefid, List<String> assignedusers) {
+		super(timestamp, simulationsessionid, involvedusers, modelsetid);
 		this.processid = processid;
 		this.taskid = taskid;
 		this.taskdefid = taskdefid;

--- a/lp-core-platform/lp-cp-xwiki-implementation/src/main/java/eu/learnpad/core/impl/mv/XwikiController.java
+++ b/lp-core-platform/lp-cp-xwiki-implementation/src/main/java/eu/learnpad/core/impl/mv/XwikiController.java
@@ -208,7 +208,7 @@ public class XwikiController extends Controller implements XWikiRestComponent, I
                 Iterator<String> uriIterator = uriCollection.iterator();
                 while (importedInTheSimulator && uriIterator.hasNext()) {
                     String bpmnFileURL = uriIterator.next();
-                    Collection<String> savedProcessesList = this.sim.addProcessDefinition(bpmnFileURL);
+                    Collection<String> savedProcessesList = this.sim.addProcessDefinition(bpmnFileURL, modelSetId);
                     importedInTheSimulator = this.verifyImportedProcesses(savedProcessesList, bpmnFileURL);
                 }
             }

--- a/lp-core-platform/lp-cp-xwiki-implementation/src/main/java/eu/learnpad/core/impl/sim/XwikiBridgeInterfaceRestResource.java
+++ b/lp-core-platform/lp-cp-xwiki-implementation/src/main/java/eu/learnpad/core/impl/sim/XwikiBridgeInterfaceRestResource.java
@@ -108,8 +108,14 @@ import eu.learnpad.sim.rest.data.UserData;
 	public Collection<String> addProcessDefinition(
 			String processDefinitionFileURL, String modelSetId) throws LpRestException {
 		HttpClient httpClient = RestResource.getAnonymousClient();
-		String uri = String.format("%s/learnpad/sim/bridge/processes",
-				RestResource.SIM_REST_URI);
+		String uri;
+		if(modelSetId != null) {
+			uri = String.format("%s/learnpad/sim/bridge/processes?modelsetartifactid=%s",
+					RestResource.SIM_REST_URI, modelSetId);
+		} else {
+			uri = String.format("%s/learnpad/sim/bridge/processes",
+					RestResource.SIM_REST_URI);
+		}
 
 		PostMethod postMethod = new PostMethod(uri);
 		postMethod.addRequestHeader("Content-Type", "application/json");

--- a/lp-core-platform/lp-cp-xwiki-implementation/src/main/java/eu/learnpad/core/impl/sim/XwikiBridgeInterfaceRestResource.java
+++ b/lp-core-platform/lp-cp-xwiki-implementation/src/main/java/eu/learnpad/core/impl/sim/XwikiBridgeInterfaceRestResource.java
@@ -106,7 +106,7 @@ import eu.learnpad.sim.rest.data.UserData;
 
 	@Override
 	public Collection<String> addProcessDefinition(
-			String processDefinitionFileURL) throws LpRestException {
+			String processDefinitionFileURL, String modelSetId) throws LpRestException {
 		HttpClient httpClient = RestResource.getAnonymousClient();
 		String uri = String.format("%s/learnpad/sim/bridge/processes",
 				RestResource.SIM_REST_URI);

--- a/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/IProcessManager.java
+++ b/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/IProcessManager.java
@@ -237,4 +237,21 @@ public interface IProcessManager {
 	 */
 	public LearnPadTaskGameInfos getGameInfos(LearnPadTask task, String userId);
 
+	// ModelSetId-related methods
+
+	/**
+	 * Associate a modelset id to a process definition id
+	 *
+	 * @param processDefId
+	 * @param modelSetId
+	 */
+	public void setModelSetId(String processDefId, String modelSetId);
+
+	/**
+	 *
+	 * @param processDefId
+	 * @return the model set id associated with a process definition id, or null
+	 *         if no model set is associated to the process def id
+	 */
+	public String getModelSetId(String processDefId);
 }

--- a/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/api/impl/SimulatorBridgeImpl.java
+++ b/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/api/impl/SimulatorBridgeImpl.java
@@ -142,6 +142,11 @@ public class SimulatorBridgeImpl implements BridgeInterface, IUserInfosAPI {
 			for (String id : processDefIds) {
 				processDefKeys.add(simulator.processManager()
 						.getProcessDefinitionKey(id));
+
+				// register modelsetid if provided
+				if (modelSetId != null) {
+					simulator.processManager().setModelSetId(id, modelSetId);
+				}
 			}
 			return processDefKeys;
 		} catch (IOException e) {

--- a/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/api/impl/SimulatorBridgeImpl.java
+++ b/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/api/impl/SimulatorBridgeImpl.java
@@ -126,7 +126,7 @@ public class SimulatorBridgeImpl implements BridgeInterface, IUserInfosAPI {
 	 * addProcessDefinition(java.lang.String)
 	 */
 	public Collection<String> addProcessDefinition(
-			String processDefinitionFilePath) {
+			String processDefinitionFilePath, String modelSetId) {
 
 		// since we are potentially creating several resources we do not return
 		// the location of a specific one.

--- a/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/processmanager/activiti/ActivitiProcessManager.java
+++ b/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/processmanager/activiti/ActivitiProcessManager.java
@@ -37,6 +37,7 @@ import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 
@@ -594,6 +595,20 @@ public class ActivitiProcessManager implements IProcessManager,
 	@Override
 	public boolean isFailOnException() {
 		return false;
+	}
+
+	// // ModelSetId related methods
+
+	private final Map<String, String> processDefToModelSet = new ConcurrentHashMap<String, String>();
+
+	@Override
+	public void setModelSetId(String processDefId, String modelSetId) {
+		processDefToModelSet.put(processDefId, modelSetId);
+	}
+
+	@Override
+	public String getModelSetId(String processDefId) {
+		return processDefToModelSet.get(processDefId);
 	}
 
 }

--- a/lp-simulation-environment/simulator/src/test/java/eu/learnpad/simulator/api/rest/corefacade/SimRestAPICoreFacadeTest.java
+++ b/lp-simulation-environment/simulator/src/test/java/eu/learnpad/simulator/api/rest/corefacade/SimRestAPICoreFacadeTest.java
@@ -100,39 +100,39 @@ public class SimRestAPICoreFacadeTest {
 		// send events
 		try {
 			receiverClient.receiveSimulationEndEvent(new SimulationEndEvent(
-					System.currentTimeMillis(), "1", Arrays.asList("test")));
+					System.currentTimeMillis(), "1", Arrays.asList("test"),
+					null));
 
 			receiverClient
-					.receiveSimulationStartEvent(new SimulationStartEvent(
-							System.currentTimeMillis(), "1", Arrays
-									.asList("test")));
+			.receiveSimulationStartEvent(new SimulationStartEvent(
+					System.currentTimeMillis(), "1", Arrays
+					.asList("test"), null));
 
-			receiverClient
-					.receiveProcessEndEvent(new ProcessEndEvent(System
-							.currentTimeMillis(), "1", Arrays.asList("test"),
-							"1", "1"));
+			receiverClient.receiveProcessEndEvent(new ProcessEndEvent(System
+					.currentTimeMillis(), "1", Arrays.asList("test"), null,
+					"1", "1"));
 
 			receiverClient.receiveProcessStartEvent(new ProcessStartEvent(
 					System.currentTimeMillis(), "1", Arrays.asList("test"),
-					"1", "1"));
+					null, "1", "1"));
 
 			receiverClient.receiveTaskEndEvent(new TaskEndEvent(System
-					.currentTimeMillis(), "1", Arrays.asList("test"), "1", "1",
-					"1", Arrays.asList("test"), "test",
+					.currentTimeMillis(), "1", Arrays.asList("test"), null,
+					"1", "1", "1", Arrays.asList("test"), "test",
 					new HashMap<String, Object>()));
 
 			receiverClient.receiveTaskFailedEvent(new TaskFailedEvent(System
-					.currentTimeMillis(), "1", Arrays.asList("test"), "1", "1",
-					"1", Arrays.asList("test"), "test",
+					.currentTimeMillis(), "1", Arrays.asList("test"), null,
+					"1", "1", "1", Arrays.asList("test"), "test",
 					new HashMap<String, Object>()));
 
 			receiverClient.receiveTaskStartEvent(new TaskStartEvent(System
-					.currentTimeMillis(), "1", Arrays.asList("test"), "1", "1",
-					"1", Arrays.asList("test")));
+					.currentTimeMillis(), "1", Arrays.asList("test"), null,
+					"1", "1", "1", Arrays.asList("test")));
 			receiverClient
-					.receiveSessionScoreUpdateEvent(new SessionScoreUpdateEvent(
-							System.currentTimeMillis(), "1", Arrays
-									.asList("test"), "1", "1", 1L));
+			.receiveSessionScoreUpdateEvent(new SessionScoreUpdateEvent(
+					System.currentTimeMillis(), "1", Arrays
+					.asList("test"), null, "1", "1", 1L));
 
 		} catch (LpRestException e) {
 			e.printStackTrace();


### PR DESCRIPTION
This serie of commits update the Sim REST API and implementation to store and send back optional modelsetid associated with processes.

Note that it does not (yet) update the monitoring part in charge of sending events associated with the new API, nor the required modelsetid passing from the simulator to the monitoring.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/learnpad/learnpad/241)
<!-- Reviewable:end -->
