### PR TITLE
Add simulation session data to all Sim API events

### DIFF
--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/AbstractEvent.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/AbstractEvent.java
@@ -20,6 +20,7 @@
 package eu.learnpad.sim.rest.event;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  *
@@ -32,18 +33,21 @@ public abstract class AbstractEvent {
 	public String simulationsessionid;
 	public List<String> involvedusers;
 	public String modelsetid;
+	public Map<String, Object> simulationSessionData;
 
 	public AbstractEvent() {
 		super();
 	}
 
 	public AbstractEvent(Long timeStamp, String simulationsessionid,
-			List<String> involvedusers, String modelsetid) {
+			List<String> involvedusers, String modelsetid,
+			Map<String, Object> simulationSessionData) {
 		super();
 		this.timestamp = timeStamp;
 		this.simulationsessionid = simulationsessionid;
 		this.involvedusers = involvedusers;
 		this.modelsetid = modelsetid;
+		this.simulationSessionData = simulationSessionData;
 	}
 
 }

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/ProcessEndEvent.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/ProcessEndEvent.java
@@ -20,6 +20,7 @@
 package eu.learnpad.sim.rest.event.impl;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  *
@@ -33,10 +34,10 @@ public class ProcessEndEvent extends ProcessStartEvent {
 	}
 
 	public ProcessEndEvent(Long timestamp, String simulationsessionid,
-			List<String> involvedusers, String modelsetid, String processid,
+			List<String> involvedusers, String modelsetid,
+			Map<String, Object> simulationSessionData, String processid,
 			String processdefinitionid) {
 		super(timestamp, simulationsessionid, involvedusers, modelsetid,
-				processid, processdefinitionid);
+				simulationSessionData, processid, processdefinitionid);
 	}
-
 }

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/ProcessStartEvent.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/ProcessStartEvent.java
@@ -20,6 +20,7 @@
 package eu.learnpad.sim.rest.event.impl;
 
 import java.util.List;
+import java.util.Map;
 
 import eu.learnpad.sim.rest.event.AbstractEvent;
 
@@ -45,9 +46,11 @@ public class ProcessStartEvent extends AbstractEvent {
 	}
 
 	public ProcessStartEvent(Long timestamp, String simulationsessionid,
-			List<String> involvedusers, String modelsetid, String processid,
+			List<String> involvedusers, String modelsetid,
+			Map<String, Object> simulationSessionData, String processid,
 			String processdefinitionid) {
-		super(timestamp, simulationsessionid, involvedusers, modelsetid);
+		super(timestamp, simulationsessionid, involvedusers, modelsetid,
+				simulationSessionData);
 		this.processid = processid;
 		this.processdefinitionid = processdefinitionid;
 	}

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/SessionScoreUpdateEvent.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/SessionScoreUpdateEvent.java
@@ -20,6 +20,7 @@
 package eu.learnpad.sim.rest.event.impl;
 
 import java.util.List;
+import java.util.Map;
 
 import eu.learnpad.sim.rest.event.AbstractEvent;
 
@@ -50,9 +51,11 @@ public class SessionScoreUpdateEvent extends AbstractEvent {
 	}
 
 	public SessionScoreUpdateEvent(Long timestamp, String simulationsessionid,
-			List<String> involvedusers, String modelsetid, String processid,
+			List<String> involvedusers, String modelsetid,
+			Map<String, Object> simulationSessionData, String processid,
 			String user, Long sessionScore) {
-		super(timestamp, simulationsessionid, involvedusers, modelsetid);
+		super(timestamp, simulationsessionid, involvedusers, modelsetid,
+				simulationSessionData);
 		this.processid = processid;
 		this.sessionscore = sessionScore;
 		this.user = user;

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/SimulationEndEvent.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/SimulationEndEvent.java
@@ -20,6 +20,7 @@
 package eu.learnpad.sim.rest.event.impl;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  *
@@ -33,8 +34,10 @@ public class SimulationEndEvent extends SimulationStartEvent {
 	}
 
 	public SimulationEndEvent(Long timestamp, String simulationsessionid,
-			List<String> involvedusers, String modelsetid) {
-		super(timestamp, simulationsessionid, involvedusers, modelsetid);
+			List<String> involvedusers, String modelsetid,
+			Map<String, Object> simulationSessionData) {
+		super(timestamp, simulationsessionid, involvedusers, modelsetid,
+				simulationSessionData);
 	}
 
 }

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/SimulationStartEvent.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/SimulationStartEvent.java
@@ -20,6 +20,7 @@
 package eu.learnpad.sim.rest.event.impl;
 
 import java.util.List;
+import java.util.Map;
 
 import eu.learnpad.sim.rest.event.AbstractEvent;
 
@@ -35,8 +36,10 @@ public class SimulationStartEvent extends AbstractEvent {
 	}
 
 	public SimulationStartEvent(Long timestamp, String simulationsessionid,
-			List<String> involvedusers, String modelsetid) {
-		super(timestamp, simulationsessionid, involvedusers, modelsetid);
+			List<String> involvedusers, String modelsetid,
+			Map<String, Object> simulationSessionData) {
+		super(timestamp, simulationsessionid, involvedusers, modelsetid,
+				simulationSessionData);
 	}
 
 }

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/TaskEndEvent.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/TaskEndEvent.java
@@ -37,11 +37,13 @@ public class TaskEndEvent extends TaskStartEvent {
 	}
 
 	public TaskEndEvent(Long timestamp, String simulationsessionid,
-			List<String> involvedusers, String modelsetid, String processid,
+			List<String> involvedusers, String modelsetid,
+			Map<String, Object> simulationSessionData, String processid,
 			String taskid, String taskdefid, List<String> assignedusers,
 			String completingUser, Map<String, Object> submittedData) {
 		super(timestamp, simulationsessionid, involvedusers, modelsetid,
-				processid, taskid, taskdefid, assignedusers);
+				simulationSessionData, processid, taskid, taskdefid,
+				assignedusers);
 		this.completingUser = completingUser;
 		this.submittedData = submittedData;
 	}

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/TaskFailedEvent.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/TaskFailedEvent.java
@@ -34,12 +34,13 @@ public class TaskFailedEvent extends TaskEndEvent {
 	}
 
 	public TaskFailedEvent(Long timestamp, String simulationsessionid,
-			List<String> involvedusers, String modelsetid, String processid,
+			List<String> involvedusers, String modelsetid,
+			Map<String, Object> simulationSessionData, String processid,
 			String taskid, String taskdefid, List<String> assignedusers,
 			String completingUser, Map<String, Object> submittedData) {
 		super(timestamp, simulationsessionid, involvedusers, modelsetid,
-				processid, taskid, taskdefid, assignedusers, completingUser,
-				submittedData);
+				simulationSessionData, processid, taskid, taskdefid,
+				assignedusers, completingUser, submittedData);
 	}
 
 }

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/TaskStartEvent.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/TaskStartEvent.java
@@ -20,6 +20,7 @@
 package eu.learnpad.sim.rest.event.impl;
 
 import java.util.List;
+import java.util.Map;
 
 import eu.learnpad.sim.rest.event.AbstractEvent;
 
@@ -55,9 +56,11 @@ public class TaskStartEvent extends AbstractEvent {
 	}
 
 	public TaskStartEvent(Long timestamp, String simulationsessionid,
-			List<String> involvedusers, String modelsetid, String processid,
+			List<String> involvedusers, String modelsetid,
+			Map<String, Object> simulationSessionData, String processid,
 			String taskid, String taskdefid, List<String> assignedusers) {
-		super(timestamp, simulationsessionid, involvedusers, modelsetid);
+		super(timestamp, simulationsessionid, involvedusers, modelsetid,
+				simulationSessionData);
 		this.processid = processid;
 		this.taskid = taskid;
 		this.taskdefid = taskdefid;

--- a/lp-simulation-environment/monitoring/src/main/java/eu/learnpad/simulator/mon/manager/RestNotifier.java
+++ b/lp-simulation-environment/monitoring/src/main/java/eu/learnpad/simulator/mon/manager/RestNotifier.java
@@ -47,8 +47,8 @@ public class RestNotifier extends Thread {
 	public void run() {
 	}
 	
-	public static void notifySimulationStart(Long processTimeStamp, List<String> involvedUsers, String sessionID, String modelSetID) {
-		SimulationStartEvent event = new SimulationStartEvent(processTimeStamp, sessionID, involvedUsers, modelSetID);
+	public static void notifySimulationStart(Long processTimeStamp, List<String> involvedUsers, String sessionID, String modelSetID, Map<String, Object> simulationSessionData) {
+		SimulationStartEvent event = new SimulationStartEvent(processTimeStamp, sessionID, involvedUsers, modelSetID, simulationSessionData);
 		try {
 			RestNotifier.getCoreFacade().receiveSimulationStartEvent(event);
 			DebugMessages.println(TimeStamp.getCurrentTime(), RestNotifier.class.getSimpleName(), "SimulatioStartEvent sent");
@@ -57,8 +57,8 @@ public class RestNotifier extends Thread {
 		}
 	}
 		
-	public static void notifySimulationStop(Long processTimeStamp, List<String> involvedUsers, String sessionID, String modelSetID) {
-		SimulationEndEvent event = new SimulationEndEvent(processTimeStamp, sessionID, involvedUsers, modelSetID);
+	public static void notifySimulationStop(Long processTimeStamp, List<String> involvedUsers, String sessionID, String modelSetID, Map<String, Object> simulationSessionData) {
+		SimulationEndEvent event = new SimulationEndEvent(processTimeStamp, sessionID, involvedUsers, modelSetID, simulationSessionData);
 		try {
 			RestNotifier.getCoreFacade().receiveSimulationEndEvent(event);
 			DebugMessages.println(TimeStamp.getCurrentTime(), RestNotifier.class.getSimpleName(), "SimulatioStopEvent sent");
@@ -67,8 +67,8 @@ public class RestNotifier extends Thread {
 		}
 	}
 		
-	public static void notifyProcessStart(Long processTimeStamp, List<String> involvedUsers, String sessionID, String modelSetID, String processID, String processDefinitionID) {
-		ProcessStartEvent event = new ProcessStartEvent(processTimeStamp, sessionID, involvedUsers, modelSetID, processID, processDefinitionID);
+	public static void notifyProcessStart(Long processTimeStamp, List<String> involvedUsers, String sessionID, String modelSetID, Map<String, Object> simulationSessionData, String processID, String processDefinitionID) {
+		ProcessStartEvent event = new ProcessStartEvent(processTimeStamp, sessionID, involvedUsers, modelSetID, simulationSessionData, processID, processDefinitionID);
 		try {
 			RestNotifier.getCoreFacade().receiveProcessStartEvent(event);
 			DebugMessages.println(TimeStamp.getCurrentTime(), RestNotifier.class.getSimpleName(), "ProcessStartEvent sent");
@@ -77,8 +77,8 @@ public class RestNotifier extends Thread {
 		}
 	}
 	
-	public static void notifyProcessStop(Long processTimeStamp, List<String> involvedUsers, String sessionID, String modelSetID, String processID, String processDefinitionID) {
-		ProcessEndEvent event = new ProcessEndEvent(processTimeStamp, sessionID, involvedUsers, modelSetID, processID, processDefinitionID);
+	public static void notifyProcessStop(Long processTimeStamp, List<String> involvedUsers, String sessionID, String modelSetID, Map<String, Object> simulationSessionData, String processID, String processDefinitionID) {
+		ProcessEndEvent event = new ProcessEndEvent(processTimeStamp, sessionID, involvedUsers, modelSetID, simulationSessionData, processID, processDefinitionID);
 		try {
 			RestNotifier.getCoreFacade().receiveProcessEndEvent(event);
 			DebugMessages.println(TimeStamp.getCurrentTime(), RestNotifier.class.getSimpleName(), "ProcessStopEvent sent");
@@ -87,8 +87,8 @@ public class RestNotifier extends Thread {
 		}
 	}
 	
-	public static void notifyTaskStart(Long processTimeStamp, String sessionID, List<String> involvedUsers, String modelSetID, String processID, String taskID, String taskDefinitionID, List<String> assignedUsers) {
-		TaskStartEvent event = new TaskStartEvent(processTimeStamp, sessionID, involvedUsers, modelSetID, processID, taskID, taskDefinitionID, assignedUsers);
+	public static void notifyTaskStart(Long processTimeStamp, String sessionID, List<String> involvedUsers, String modelSetID, Map<String, Object> simulationSessionData, String processID, String taskID, String taskDefinitionID, List<String> assignedUsers) {
+		TaskStartEvent event = new TaskStartEvent(processTimeStamp, sessionID, involvedUsers, modelSetID, simulationSessionData, processID, taskID, taskDefinitionID, assignedUsers);
 		try {
 			RestNotifier.getCoreFacade().receiveTaskStartEvent(event);
 			DebugMessages.println(TimeStamp.getCurrentTime(), RestNotifier.class.getSimpleName(), "TaskStartEvent sent");
@@ -97,8 +97,8 @@ public class RestNotifier extends Thread {
 		}
 	}
 	
-	public static void notifyTaskStop(Long processTimeStamp, String sessionID, List<String> involvedUsers, String modelSetID, String processID, String taskID, String taskDefinitionID, List<String> assignedUsers, String completingUserID, Map<String,Object> submittedData) {
-		TaskEndEvent event = new TaskEndEvent(processTimeStamp, sessionID, involvedUsers, modelSetID, processID, taskID, taskDefinitionID, assignedUsers, completingUserID, submittedData);
+	public static void notifyTaskStop(Long processTimeStamp, String sessionID, List<String> involvedUsers, String modelSetID, Map<String, Object> simulationSessionData, String processID, String taskID, String taskDefinitionID, List<String> assignedUsers, String completingUserID, Map<String,Object> submittedData) {
+		TaskEndEvent event = new TaskEndEvent(processTimeStamp, sessionID, involvedUsers, modelSetID, simulationSessionData, processID, taskID, taskDefinitionID, assignedUsers, completingUserID, submittedData);
 		try {
 			RestNotifier.getCoreFacade().receiveTaskEndEvent(event);
 			DebugMessages.println(TimeStamp.getCurrentTime(), RestNotifier.class.getSimpleName(), "TaskEndEvent sent");
@@ -107,8 +107,8 @@ public class RestNotifier extends Thread {
 		}
 	}
 	
-	public static void notifySessionScoreUpdate(Long processTimeStamp, String sessionID, List<String> involvedUsers, String modelSetID, String processID, String userID, Long sessionScore) {
-		SessionScoreUpdateEvent event = new SessionScoreUpdateEvent(processTimeStamp, sessionID, involvedUsers, modelSetID, processID, userID, sessionScore);
+	public static void notifySessionScoreUpdate(Long processTimeStamp, String sessionID, List<String> involvedUsers, String modelSetID, Map<String, Object> simulationSessionData, String processID, String userID, Long sessionScore) {
+		SessionScoreUpdateEvent event = new SessionScoreUpdateEvent(processTimeStamp, sessionID, involvedUsers, modelSetID, simulationSessionData, processID, userID, sessionScore);
 		try {
 			RestNotifier.getCoreFacade().receiveSessionScoreUpdateEvent(event);
 			DebugMessages.println(TimeStamp.getCurrentTime(), RestNotifier.class.getSimpleName(), "SessionScoreUpdateEvent sent");

--- a/lp-simulation-environment/monitoring/src/test/java/eu/learnpad/simulator/mon/TestSimulatorMonCoreFacadeRESTResource.java
+++ b/lp-simulation-environment/monitoring/src/test/java/eu/learnpad/simulator/mon/TestSimulatorMonCoreFacadeRESTResource.java
@@ -1,5 +1,6 @@
 package eu.learnpad.simulator.mon;
 
+import java.util.HashMap;
 import java.util.Vector;
 
 import org.apache.commons.net.ntp.TimeStamp;
@@ -18,7 +19,7 @@ public class TestSimulatorMonCoreFacadeRESTResource {
 		involvedUsers.add("involvedUsers2");
 		
 		SimulationStartEvent event = new SimulationStartEvent(TimeStamp.getCurrentTime().getTime(),
-				"theSimsessionID",involvedUsers,"theModelSetID");
+				"theSimsessionID",involvedUsers,"theModelSetID", new HashMap<String, Object>());
 		
 		try {
 			simMinRest.receiveSimulationStartEvent(event);

--- a/lp-simulation-environment/simulator/src/test/java/eu/learnpad/simulator/api/rest/corefacade/SimRestAPICoreFacadeTest.java
+++ b/lp-simulation-environment/simulator/src/test/java/eu/learnpad/simulator/api/rest/corefacade/SimRestAPICoreFacadeTest.java
@@ -101,38 +101,38 @@ public class SimRestAPICoreFacadeTest {
 		try {
 			receiverClient.receiveSimulationEndEvent(new SimulationEndEvent(
 					System.currentTimeMillis(), "1", Arrays.asList("test"),
-					null));
+					null, null));
 
 			receiverClient
 			.receiveSimulationStartEvent(new SimulationStartEvent(
 					System.currentTimeMillis(), "1", Arrays
-					.asList("test"), null));
+					.asList("test"), null, null));
 
 			receiverClient.receiveProcessEndEvent(new ProcessEndEvent(System
 					.currentTimeMillis(), "1", Arrays.asList("test"), null,
-					"1", "1"));
+					null, "1", "1"));
 
 			receiverClient.receiveProcessStartEvent(new ProcessStartEvent(
 					System.currentTimeMillis(), "1", Arrays.asList("test"),
-					null, "1", "1"));
+					null, null, "1", "1"));
 
 			receiverClient.receiveTaskEndEvent(new TaskEndEvent(System
 					.currentTimeMillis(), "1", Arrays.asList("test"), null,
-					"1", "1", "1", Arrays.asList("test"), "test",
+					null, "1", "1", "1", Arrays.asList("test"), "test",
 					new HashMap<String, Object>()));
 
 			receiverClient.receiveTaskFailedEvent(new TaskFailedEvent(System
 					.currentTimeMillis(), "1", Arrays.asList("test"), null,
-					"1", "1", "1", Arrays.asList("test"), "test",
+					null, "1", "1", "1", Arrays.asList("test"), "test",
 					new HashMap<String, Object>()));
 
 			receiverClient.receiveTaskStartEvent(new TaskStartEvent(System
 					.currentTimeMillis(), "1", Arrays.asList("test"), null,
-					"1", "1", "1", Arrays.asList("test")));
+					null, "1", "1", "1", Arrays.asList("test")));
 			receiverClient
 			.receiveSessionScoreUpdateEvent(new SessionScoreUpdateEvent(
 					System.currentTimeMillis(), "1", Arrays
-					.asList("test"), null, "1", "1", 1L));
+					.asList("test"), null, null, "1", "1", 1L));
 
 		} catch (LpRestException e) {
 			e.printStackTrace();


### PR DESCRIPTION
The sim events defined in the API now all include the data associated
with the simulation session.

Updated implementation and tests accordingly.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/learnpad/learnpad/251)
<!-- Reviewable:end -->
