### PR TITLE
[sim][mon] Update probe event format

### DIFF
--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/AbstractEvent.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/AbstractEvent.java
@@ -29,6 +29,7 @@ import java.util.Map;
  */
 public abstract class AbstractEvent {
 
+	public EventType type;
 	public Long timestamp;
 	public String simulationsessionid;
 	public List<String> involvedusers;
@@ -39,10 +40,11 @@ public abstract class AbstractEvent {
 		super();
 	}
 
-	public AbstractEvent(Long timeStamp, String simulationsessionid,
-			List<String> involvedusers, String modelsetid,
-			Map<String, Object> simulationSessionData) {
+	public AbstractEvent(EventType type, Long timeStamp,
+			String simulationsessionid, List<String> involvedusers,
+			String modelsetid, Map<String, Object> simulationSessionData) {
 		super();
+		this.type = type;
 		this.timestamp = timeStamp;
 		this.simulationsessionid = simulationsessionid;
 		this.involvedusers = involvedusers;

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/AbstractEvent.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/AbstractEvent.java
@@ -52,4 +52,12 @@ public abstract class AbstractEvent {
 		this.simulationSessionData = simulationSessionData;
 	}
 
+	@Override
+	public String toString() {
+		return "Event: " + "type=" + type + " timestamp=" + timestamp
+				+ " simulationsessionid=" + simulationsessionid
+				+ " involvedusers=" + involvedusers + " modelsetid="
+				+ modelsetid + " simulationSessionData="
+				+ simulationSessionData;
+	}
 }

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/EventType.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/EventType.java
@@ -1,0 +1,5 @@
+package eu.learnpad.sim.rest.event;
+
+public enum EventType {
+	PROCESS_END, PROCESS_START, SESSION_SCORE_UPDATE, SIMULATION_END, SIMULATION_START, TASK_END, TASK_FAILED, TASK_START
+}

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/ProcessEndEvent.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/ProcessEndEvent.java
@@ -22,12 +22,25 @@ package eu.learnpad.sim.rest.event.impl;
 import java.util.List;
 import java.util.Map;
 
+import eu.learnpad.sim.rest.event.AbstractEvent;
+import eu.learnpad.sim.rest.event.EventType;
+
 /**
  *
  * @author Tom Jorquera - Linagora
  *
  */
-public class ProcessEndEvent extends ProcessStartEvent {
+public class ProcessEndEvent extends AbstractEvent {
+
+	/**
+	 * Unique ID of the process instance
+	 */
+	public String processid;
+
+	/**
+	 * ID used to identify the process in the BP definition
+	 */
+	public String processdefinitionid;
 
 	public ProcessEndEvent() {
 		super();
@@ -37,7 +50,9 @@ public class ProcessEndEvent extends ProcessStartEvent {
 			List<String> involvedusers, String modelsetid,
 			Map<String, Object> simulationSessionData, String processid,
 			String processdefinitionid) {
-		super(timestamp, simulationsessionid, involvedusers, modelsetid,
-				simulationSessionData, processid, processdefinitionid);
+		super(EventType.PROCESS_END, timestamp, simulationsessionid,
+				involvedusers, modelsetid, simulationSessionData);
+		this.processid = processid;
+		this.processdefinitionid = processdefinitionid;
 	}
 }

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/ProcessEndEvent.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/ProcessEndEvent.java
@@ -55,4 +55,10 @@ public class ProcessEndEvent extends AbstractEvent {
 		this.processid = processid;
 		this.processdefinitionid = processdefinitionid;
 	}
+
+	@Override
+	public String toString() {
+		return super.toString() + " processid=" + processid
+				+ " processdefinitionid=" + processdefinitionid;
+	}
 }

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/ProcessStartEvent.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/ProcessStartEvent.java
@@ -56,4 +56,9 @@ public class ProcessStartEvent extends AbstractEvent {
 		this.processdefinitionid = processdefinitionid;
 	}
 
+	@Override
+	public String toString() {
+		return super.toString() + " processid=" + processid
+				+ " processdefinitionid=" + processdefinitionid;
+	}
 }

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/ProcessStartEvent.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/ProcessStartEvent.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 
 import eu.learnpad.sim.rest.event.AbstractEvent;
+import eu.learnpad.sim.rest.event.EventType;
 
 /**
  *
@@ -49,8 +50,8 @@ public class ProcessStartEvent extends AbstractEvent {
 			List<String> involvedusers, String modelsetid,
 			Map<String, Object> simulationSessionData, String processid,
 			String processdefinitionid) {
-		super(timestamp, simulationsessionid, involvedusers, modelsetid,
-				simulationSessionData);
+		super(EventType.PROCESS_START, timestamp, simulationsessionid,
+				involvedusers, modelsetid, simulationSessionData);
 		this.processid = processid;
 		this.processdefinitionid = processdefinitionid;
 	}

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/SessionScoreUpdateEvent.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/SessionScoreUpdateEvent.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 
 import eu.learnpad.sim.rest.event.AbstractEvent;
+import eu.learnpad.sim.rest.event.EventType;
 
 /**
  *
@@ -54,8 +55,8 @@ public class SessionScoreUpdateEvent extends AbstractEvent {
 			List<String> involvedusers, String modelsetid,
 			Map<String, Object> simulationSessionData, String processid,
 			String user, Long sessionScore) {
-		super(timestamp, simulationsessionid, involvedusers, modelsetid,
-				simulationSessionData);
+		super(EventType.SESSION_SCORE_UPDATE, timestamp, simulationsessionid,
+				involvedusers, modelsetid, simulationSessionData);
 		this.processid = processid;
 		this.sessionscore = sessionScore;
 		this.user = user;

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/SessionScoreUpdateEvent.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/SessionScoreUpdateEvent.java
@@ -62,4 +62,9 @@ public class SessionScoreUpdateEvent extends AbstractEvent {
 		this.user = user;
 	}
 
+	@Override
+	public String toString() {
+		return super.toString() + " processid=" + processid + " user=" + user
+				+ " sessionscore=" + sessionscore;
+	}
 }

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/SimulationEndEvent.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/SimulationEndEvent.java
@@ -22,12 +22,15 @@ package eu.learnpad.sim.rest.event.impl;
 import java.util.List;
 import java.util.Map;
 
+import eu.learnpad.sim.rest.event.AbstractEvent;
+import eu.learnpad.sim.rest.event.EventType;
+
 /**
  *
  * @author Tom Jorquera - Linagora
  *
  */
-public class SimulationEndEvent extends SimulationStartEvent {
+public class SimulationEndEvent extends AbstractEvent {
 
 	public SimulationEndEvent() {
 		super();
@@ -36,8 +39,8 @@ public class SimulationEndEvent extends SimulationStartEvent {
 	public SimulationEndEvent(Long timestamp, String simulationsessionid,
 			List<String> involvedusers, String modelsetid,
 			Map<String, Object> simulationSessionData) {
-		super(timestamp, simulationsessionid, involvedusers, modelsetid,
-				simulationSessionData);
+		super(EventType.SIMULATION_END, timestamp, simulationsessionid,
+				involvedusers, modelsetid, simulationSessionData);
 	}
 
 }

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/SimulationStartEvent.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/SimulationStartEvent.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 
 import eu.learnpad.sim.rest.event.AbstractEvent;
+import eu.learnpad.sim.rest.event.EventType;
 
 /**
  *
@@ -38,8 +39,8 @@ public class SimulationStartEvent extends AbstractEvent {
 	public SimulationStartEvent(Long timestamp, String simulationsessionid,
 			List<String> involvedusers, String modelsetid,
 			Map<String, Object> simulationSessionData) {
-		super(timestamp, simulationsessionid, involvedusers, modelsetid,
-				simulationSessionData);
+		super(EventType.SIMULATION_START, timestamp, simulationsessionid,
+				involvedusers, modelsetid, simulationSessionData);
 	}
 
 }

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/TaskEndEvent.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/TaskEndEvent.java
@@ -74,4 +74,11 @@ public class TaskEndEvent extends AbstractEvent {
 		this.submittedData = submittedData;
 	}
 
+	@Override
+	public String toString() {
+		return super.toString() + " processid=" + processid + " taskid="
+				+ taskid + " taskdefid=" + taskdefid + " assignedusers="
+				+ assignedusers + " completingUser=" + completingUser
+				+ " submittedData=" + submittedData;
+	}
 }

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/TaskEndEvent.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/TaskEndEvent.java
@@ -22,12 +22,35 @@ package eu.learnpad.sim.rest.event.impl;
 import java.util.List;
 import java.util.Map;
 
+import eu.learnpad.sim.rest.event.AbstractEvent;
+import eu.learnpad.sim.rest.event.EventType;
+
 /**
  *
  * @author Tom Jorquera - Linagora
  *
  */
-public class TaskEndEvent extends TaskStartEvent {
+public class TaskEndEvent extends AbstractEvent {
+
+	/**
+	 * Unique ID of the process instance
+	 */
+	public String processid;
+
+	/**
+	 * Unique ID of the task instance
+	 */
+	public String taskid;
+
+	/**
+	 * ID used to identify the task in the BP definition
+	 */
+	public String taskdefid;
+
+	/**
+	 * The LearnPAd users that have been assigned to this task
+	 */
+	public List<String> assignedusers;
 
 	public String completingUser;
 	public Map<String, Object> submittedData;
@@ -41,9 +64,12 @@ public class TaskEndEvent extends TaskStartEvent {
 			Map<String, Object> simulationSessionData, String processid,
 			String taskid, String taskdefid, List<String> assignedusers,
 			String completingUser, Map<String, Object> submittedData) {
-		super(timestamp, simulationsessionid, involvedusers, modelsetid,
-				simulationSessionData, processid, taskid, taskdefid,
-				assignedusers);
+		super(EventType.TASK_END, timestamp, simulationsessionid,
+				involvedusers, modelsetid, simulationSessionData);
+		this.processid = processid;
+		this.taskid = taskid;
+		this.taskdefid = taskdefid;
+		this.assignedusers = assignedusers;
 		this.completingUser = completingUser;
 		this.submittedData = submittedData;
 	}

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/TaskFailedEvent.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/TaskFailedEvent.java
@@ -22,12 +22,39 @@ package eu.learnpad.sim.rest.event.impl;
 import java.util.List;
 import java.util.Map;
 
+import eu.learnpad.sim.rest.event.AbstractEvent;
+import eu.learnpad.sim.rest.event.EventType;
+
 /**
  *
  * @author Tom Jorquera - Linagora
  *
  */
-public class TaskFailedEvent extends TaskEndEvent {
+public class TaskFailedEvent extends AbstractEvent {
+
+	/**
+	 * Unique ID of the process instance
+	 */
+	public String processid;
+
+	/**
+	 * Unique ID of the task instance
+	 */
+	public String taskid;
+
+	/**
+	 * ID used to identify the task in the BP definition
+	 */
+	public String taskdefid;
+
+	/**
+	 * The LearnPAd users that have been assigned to this task
+	 */
+	public List<String> assignedusers;
+
+	public String completingUser;
+
+	public Map<String, Object> submittedData;
 
 	public TaskFailedEvent() {
 		super();
@@ -38,9 +65,14 @@ public class TaskFailedEvent extends TaskEndEvent {
 			Map<String, Object> simulationSessionData, String processid,
 			String taskid, String taskdefid, List<String> assignedusers,
 			String completingUser, Map<String, Object> submittedData) {
-		super(timestamp, simulationsessionid, involvedusers, modelsetid,
-				simulationSessionData, processid, taskid, taskdefid,
-				assignedusers, completingUser, submittedData);
+		super(EventType.TASK_FAILED, timestamp, simulationsessionid,
+				involvedusers, modelsetid, simulationSessionData);
+		this.processid = processid;
+		this.taskid = taskid;
+		this.taskdefid = taskdefid;
+		this.assignedusers = assignedusers;
+		this.completingUser = completingUser;
+		this.submittedData = submittedData;
 	}
 
 }

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/TaskFailedEvent.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/TaskFailedEvent.java
@@ -75,4 +75,11 @@ public class TaskFailedEvent extends AbstractEvent {
 		this.submittedData = submittedData;
 	}
 
+	@Override
+	public String toString() {
+		return super.toString() + " processid=" + processid + " taskid="
+				+ taskid + " taskdefid=" + taskdefid + " assignedusers="
+				+ assignedusers + " completingUser=" + completingUser
+				+ " submittedData=" + submittedData;
+	}
 }

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/TaskStartEvent.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/TaskStartEvent.java
@@ -68,4 +68,11 @@ public class TaskStartEvent extends AbstractEvent {
 		this.assignedusers = assignedusers;
 	}
 
+	@Override
+	public String toString() {
+		return super.toString() + " processid=" + processid + " taskid="
+				+ taskid + " taskdefid=" + taskdefid + " assignedusers="
+				+ assignedusers;
+	}
+
 }

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/TaskStartEvent.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/TaskStartEvent.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 
 import eu.learnpad.sim.rest.event.AbstractEvent;
+import eu.learnpad.sim.rest.event.EventType;
 
 /**
  *
@@ -59,8 +60,8 @@ public class TaskStartEvent extends AbstractEvent {
 			List<String> involvedusers, String modelsetid,
 			Map<String, Object> simulationSessionData, String processid,
 			String taskid, String taskdefid, List<String> assignedusers) {
-		super(timestamp, simulationsessionid, involvedusers, modelsetid,
-				simulationSessionData);
+		super(EventType.TASK_START, timestamp, simulationsessionid,
+				involvedusers, modelsetid, simulationSessionData);
 		this.processid = processid;
 		this.taskid = taskid;
 		this.taskdefid = taskdefid;

--- a/lp-simulation-environment/monitoring/src/main/java/eu/learnpad/simulator/mon/event/GlimpseBaseEventBPMN.java
+++ b/lp-simulation-environment/monitoring/src/main/java/eu/learnpad/simulator/mon/event/GlimpseBaseEventBPMN.java
@@ -1,67 +1,26 @@
 package eu.learnpad.simulator.mon.event;
 
-import eu.learnpad.simulator.mon.event.GlimpseBaseEventGeneric;
+import eu.learnpad.sim.rest.event.AbstractEvent;
 
 public class GlimpseBaseEventBPMN<T> extends GlimpseBaseEventGeneric<String> {
 
 	private static final long serialVersionUID = 1L;
-	public String sessionID;
-	public int assigneeID;
-	public String taskID;
-	public String subProcessID;
-	public String desideredCompletionTime;
-	
-	public GlimpseBaseEventBPMN(
-			String data, String probeID, Long timeStamp,
-			String eventName, boolean isException, String extraDataField, 
-			String sessionID, int assigneeID, String taskID,
-			String subProcessID, String desideredCompletionTime) {
-		
+	public AbstractEvent event;
+
+	public GlimpseBaseEventBPMN(String data, String probeID, Long timeStamp,
+			String eventName, boolean isException, String extraDataField,
+			AbstractEvent event) {
+
 		super(data, probeID, timeStamp, eventName, isException, extraDataField);
-		
-		this.sessionID = sessionID;
-		this.assigneeID = assigneeID;		
-		this.taskID = taskID;
-		this.subProcessID = subProcessID;
-		this.desideredCompletionTime = desideredCompletionTime;
+
+		this.event = event;
 	}
-	
-	public String getDesideredCompletionTime() {
-		return this.desideredCompletionTime;
+
+	public AbstractEvent getEvent() {
+		return this.event;
 	}
-	
-	public void setDesideredCompletionTimeID(String desideredCompletionTime) {
-		this.desideredCompletionTime = desideredCompletionTime;
-	}
-	
-	public String getSessionID() {
-		return this.sessionID;
-	}
-	
-	public void setSessionID(String sessionID) {
-		this.sessionID = sessionID;
-	}
-	
-	public int getAssigneeID() {
-		return this.assigneeID;
-	}
-	
-	public void setAssigneeID(int assigneeID) {
-		this.assigneeID = assigneeID;
-	}
-	
-	public String getTaskID() {
-		return this.taskID;
-	}
-	
-	public void setTaskID(String taskID) {
-		this.taskID = taskID;
-	}	
-	public String getSubProcessID() {
-		return this.subProcessID;
-	}
-	
-	public void setSubProcessID(String subProcessID) {
-		this.subProcessID = subProcessID;
+
+	public void setEvent(AbstractEvent event) {
+		this.event = event;
 	}
 }

--- a/lp-simulation-environment/monitoring/src/main/java/eu/learnpad/simulator/mon/impl/ComplexEventProcessorImpl.java
+++ b/lp-simulation-environment/monitoring/src/main/java/eu/learnpad/simulator/mon/impl/ComplexEventProcessorImpl.java
@@ -173,11 +173,7 @@ public class ComplexEventProcessorImpl extends ComplexEventProcessor implements 
 								"eventData: " + receivedEvent.getEventData() + "\n" +
 								"eventName: " + receivedEvent.getEventName() + "\n" +
 								"timestamp: " + receivedEvent.getTimeStamp() + "\n" +
-								"sessionID: " + ((GlimpseBaseEventBPMN<?>) receivedEvent).getSessionID() + "\n" +
-								"usersInvolved: " + ((GlimpseBaseEventBPMN<?>) receivedEvent).getAssigneeID() + "\n" +
-								"taskID: " + ((GlimpseBaseEventBPMN<?>) receivedEvent).getTaskID() + "\n" +
-								"subProcessID: " + ((GlimpseBaseEventBPMN<?>) receivedEvent).getSubProcessID() + "\n" +
-								"desideredCompletionTime: " + ((GlimpseBaseEventBPMN<?>) receivedEvent).getDesideredCompletionTime()
+								"event: " + ((GlimpseBaseEventBPMN<?>) receivedEvent).getEvent()
 								);	
 						} else {
 						DebugMessages.println(TimeStamp.getCurrentTime(), this.getClass().getSimpleName(),

--- a/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/IProcessManager.java
+++ b/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/IProcessManager.java
@@ -254,4 +254,13 @@ public interface IProcessManager {
 	 *         if no model set is associated to the process def id
 	 */
 	public String getModelSetId(String processDefId);
+
+	/**
+	 *
+	 * @param simulationSessionId
+	 * @return the parameters data that have been used to instanciate the
+	 *         session
+	 */
+	public Map<String, Object> getSimulationSessionParametersData(
+			String simulationSessionId);
 }

--- a/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/Simulator.java
+++ b/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/Simulator.java
@@ -104,7 +104,7 @@ public class Simulator implements IProcessManagerProvider,
 
 		if (monitoringEnabled) {
 			// register a probe to monitor events
-			eventDispatcher.subscribe(new ProbeEventReceiver());
+			eventDispatcher.subscribe(new ProbeEventReceiver(processManager));
 		}
 
 	}

--- a/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/monitoring/event/impl/SessionScoreUpdateSimEvent.java
+++ b/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/monitoring/event/impl/SessionScoreUpdateSimEvent.java
@@ -65,11 +65,11 @@ public class SessionScoreUpdateSimEvent extends AbstractSimEvent {
 	/**
 	 * The new session score of the user
 	 */
-	public Integer sessionscore;
+	public long sessionscore;
 
 	public SessionScoreUpdateSimEvent(Long timestamp,
 			String simulationsessionid, Collection<String> involvedusers,
-			String processid, String user, Integer sessionScore) {
+			String processid, String user, long sessionScore) {
 		super(timestamp, simulationsessionid, involvedusers);
 		this.processid = processid;
 		this.sessionscore = sessionScore;

--- a/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/monitoring/event/impl/TaskEndSimEvent.java
+++ b/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/monitoring/event/impl/TaskEndSimEvent.java
@@ -41,6 +41,7 @@ package eu.learnpad.simulator.monitoring.event.impl;
  */
 
 import java.util.Collection;
+import java.util.Map;
 
 import eu.learnpad.simulator.datastructures.LearnPadTask;
 import eu.learnpad.simulator.datastructures.LearnPadTaskSubmissionResult;
@@ -54,13 +55,16 @@ import eu.learnpad.simulator.monitoring.event.SimEventType;
 public class TaskEndSimEvent extends TaskStartSimEvent {
 
 	public final String completingUser;
+	public Map<String, Object> submittedData;
 	public final LearnPadTaskSubmissionResult submissionResult;
 
 	public TaskEndSimEvent(Long timestamp, String simulationsessionid,
 			Collection<String> involvedusers, LearnPadTask task,
-			String completingUser, LearnPadTaskSubmissionResult submissionResult) {
+			String completingUser, Map<String, Object> submittedData,
+			LearnPadTaskSubmissionResult submissionResult) {
 		super(timestamp, simulationsessionid, involvedusers, task);
 		this.completingUser = completingUser;
+		this.submittedData = submittedData;
 		this.submissionResult = submissionResult;
 	}
 

--- a/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/processmanager/AbstractProcessDispatcher.java
+++ b/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/processmanager/AbstractProcessDispatcher.java
@@ -218,7 +218,7 @@ public abstract class AbstractProcessDispatcher implements IProcessDispatcher {
 		// signal task end event
 		processEventReceiver.receiveTaskEndEvent(new TaskEndSimEvent(System
 				.currentTimeMillis(), simulationSessionId, involvedUsers, task,
-				completingUser, submissionResult));
+				completingUser, data, submissionResult));
 
 	};
 

--- a/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/processmanager/activiti/ActivitiProcessManager.java
+++ b/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/processmanager/activiti/ActivitiProcessManager.java
@@ -110,6 +110,8 @@ public class ActivitiProcessManager implements IProcessManager,
 	private final Map<String, Integer> nbProcessesBySession = new HashMap<>();
 	private final Map<String, Collection<String>> usersBySession = new HashMap<>();
 
+	private final Map<String, Map<String, Object>> sessionParametersData = new HashMap<>();
+
 	public ActivitiProcessManager(
 			ProcessEngine processEngine,
 			IProcessEventReceiver.IProcessEventReceiverProvider processEventReceiverProvider,
@@ -338,6 +340,9 @@ public class ActivitiProcessManager implements IProcessManager,
 					.createProcessDefinitionQuery()
 					.processDefinitionKey(projectDefinitionKey).singleResult();
 
+			// register session parameters data
+			sessionParametersData.put(simSession, parameters);
+
 			// signal simulation session start
 			// signal process start
 			this.processEventReceiverProvider.processEventReceiver()
@@ -461,6 +466,7 @@ public class ActivitiProcessManager implements IProcessManager,
 
 			nbProcessesBySession.remove(simSession);
 			usersBySession.remove(simSession);
+			sessionParametersData.remove(simSession);
 		}
 
 	}
@@ -609,6 +615,12 @@ public class ActivitiProcessManager implements IProcessManager,
 	@Override
 	public String getModelSetId(String processDefId) {
 		return processDefToModelSet.get(processDefId);
+	}
+
+	@Override
+	public Map<String, Object> getSimulationSessionParametersData(
+			String simulationSessionId) {
+		return sessionParametersData.get(simulationSessionId);
 	}
 
 }

--- a/lp-simulation-environment/simulator/src/test/java/eu/learnpad/simulator/uihandler/webserver/UIHandlerWebImplTest.java
+++ b/lp-simulation-environment/simulator/src/test/java/eu/learnpad/simulator/uihandler/webserver/UIHandlerWebImplTest.java
@@ -263,7 +263,8 @@ public class UIHandlerWebImplTest {
 			uiHandler.receiveTaskEndEvent(new TaskEndSimEvent(System
 					.currentTimeMillis(), "", tasksToUsers.get(task),
 					new LearnPadTask("session1", "session1", task, "", null,
-							null, null, null, 0L), "", null));
+							null, null, null, 0L), "",
+					new HashMap<String, Object>(), null));
 		}
 
 		// check all user has been notified of its tasks completion


### PR DESCRIPTION
This PR introduces a serie of commits whose ultimate goal is to change the probe format for communication between the simulator and the monitoring submodules.

In this new format, instead of the probe events containing a list of fields, they simply contain an event object, based on the events defined in the Sim REST API.

This change ensures that the sim always pass to the mon all the required infos regarding the content of the events.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/learnpad/learnpad/261)
<!-- Reviewable:end -->
