### PR TITLE
Made Sim Rest API events serializable

### DIFF
--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/AbstractEvent.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/AbstractEvent.java
@@ -27,7 +27,12 @@ import java.util.Map;
  * @author Tom Jorquera - Linagora
  *
  */
-public abstract class AbstractEvent {
+public abstract class AbstractEvent implements java.io.Serializable {
+
+	/**
+	 *
+	 */
+	private static final long serialVersionUID = -4734413104214101930L;
 
 	public EventType type;
 	public Long timestamp;

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/ProcessEndEvent.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/ProcessEndEvent.java
@@ -33,6 +33,11 @@ import eu.learnpad.sim.rest.event.EventType;
 public class ProcessEndEvent extends AbstractEvent {
 
 	/**
+	 *
+	 */
+	private static final long serialVersionUID = -5642476078427106808L;
+
+	/**
 	 * Unique ID of the process instance
 	 */
 	public String processid;

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/ProcessStartEvent.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/ProcessStartEvent.java
@@ -33,6 +33,11 @@ import eu.learnpad.sim.rest.event.EventType;
 public class ProcessStartEvent extends AbstractEvent {
 
 	/**
+	 *
+	 */
+	private static final long serialVersionUID = -4855894406498460958L;
+
+	/**
 	 * Unique ID of the process instance
 	 */
 	public String processid;

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/SessionScoreUpdateEvent.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/SessionScoreUpdateEvent.java
@@ -33,6 +33,11 @@ import eu.learnpad.sim.rest.event.EventType;
 public class SessionScoreUpdateEvent extends AbstractEvent {
 
 	/**
+	 *
+	 */
+	private static final long serialVersionUID = -8719161124674249926L;
+
+	/**
 	 * Unique ID of the process instance
 	 */
 	public String processid;

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/SimulationEndEvent.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/SimulationEndEvent.java
@@ -32,6 +32,11 @@ import eu.learnpad.sim.rest.event.EventType;
  */
 public class SimulationEndEvent extends AbstractEvent {
 
+	/**
+	 *
+	 */
+	private static final long serialVersionUID = -7172924346295091973L;
+
 	public SimulationEndEvent() {
 		super();
 	}

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/SimulationStartEvent.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/SimulationStartEvent.java
@@ -32,6 +32,11 @@ import eu.learnpad.sim.rest.event.EventType;
  */
 public class SimulationStartEvent extends AbstractEvent {
 
+	/**
+	 *
+	 */
+	private static final long serialVersionUID = -2632601182542203292L;
+
 	public SimulationStartEvent() {
 		super();
 	}

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/TaskEndEvent.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/TaskEndEvent.java
@@ -33,6 +33,11 @@ import eu.learnpad.sim.rest.event.EventType;
 public class TaskEndEvent extends AbstractEvent {
 
 	/**
+	 *
+	 */
+	private static final long serialVersionUID = -5328814254042585792L;
+
+	/**
 	 * Unique ID of the process instance
 	 */
 	public String processid;

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/TaskFailedEvent.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/TaskFailedEvent.java
@@ -33,6 +33,11 @@ import eu.learnpad.sim.rest.event.EventType;
 public class TaskFailedEvent extends AbstractEvent {
 
 	/**
+	 *
+	 */
+	private static final long serialVersionUID = 8801597168699684284L;
+
+	/**
 	 * Unique ID of the process instance
 	 */
 	public String processid;

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/TaskStartEvent.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/TaskStartEvent.java
@@ -33,6 +33,11 @@ import eu.learnpad.sim.rest.event.EventType;
 public class TaskStartEvent extends AbstractEvent {
 
 	/**
+	 *
+	 */
+	private static final long serialVersionUID = 6565005567809009748L;
+
+	/**
 	 * Unique ID of the process instance
 	 */
 	public String processid;

--- a/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/IProcessManager.java
+++ b/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/IProcessManager.java
@@ -207,6 +207,15 @@ public interface IProcessManager {
 	public Integer getInstanceScore(String processInstanceId, String userId);
 
 	/**
+	 * @param sessionId
+	 * @param userId
+	 * @return the detailed score for each task associated with the given user
+	 *         in the given session.
+	 */
+	public Map<LearnPadTask, Integer> getDetailedInstanceScore(
+			String sessionId, String userId);
+
+	/**
 	 * @param processDefinitionKey
 	 *            the definition key of the process for which we want the
 	 *            diagram.

--- a/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/uihandler/webserver/UIHandlerWebImpl.java
+++ b/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/uihandler/webserver/UIHandlerWebImpl.java
@@ -91,8 +91,8 @@ public class UIHandlerWebImpl implements IUserHandler, IProcessEventReceiver {
 
 		// instanciate users UI
 		for (String user : users) {
-			usersMap.put(user,
-					this.webserver.addUIServlet(new UIServlet(user), user));
+			usersMap.put(user, this.webserver.addUIServlet(new UIServlet(user,
+					userEventReceiverProvider.processManager()), user));
 		}
 
 	}
@@ -104,8 +104,8 @@ public class UIHandlerWebImpl implements IUserHandler, IProcessEventReceiver {
 	 */
 	public void addUser(UserData user) {
 		if (!usersMap.containsKey(user.id)) {
-			usersMap.put(user.id,
-					webserver.addUIServlet(new UIServlet(user.id), user.id));
+			usersMap.put(user.id, webserver.addUIServlet(new UIServlet(user.id,
+					userEventReceiverProvider.processManager()), user.id));
 			usersInfos.put(user.id, user);
 		}
 	}

--- a/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/uihandler/webserver/msg/user/send/SessionFinished.java
+++ b/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/uihandler/webserver/msg/user/send/SessionFinished.java
@@ -24,6 +24,8 @@ package eu.learnpad.simulator.uihandler.webserver.msg.user.send;
  * #L%
  */
 
+import java.util.Map;
+
 import eu.learnpad.simulator.uihandler.webserver.msg.user.IUserMsg;
 
 /**
@@ -33,13 +35,15 @@ import eu.learnpad.simulator.uihandler.webserver.msg.user.IUserMsg;
 public class SessionFinished implements IUserMsg {
 
 	public String sessionid;
+	public Map<String, String> tasknames;
+	public Map<String, Integer> taskscores;
 
-	/**
-	 * @param processid
-	 */
-	public SessionFinished(String sessionid) {
+	public SessionFinished(String sessionid, Map<String, String> tasknames,
+			Map<String, Integer> taskscores) {
 		super();
 		this.sessionid = sessionid;
+		this.tasknames = tasknames;
+		this.taskscores = taskscores;
 	}
 
 	/*

--- a/lp-simulation-environment/simulator/src/main/resources/static/TaskReceiver.js
+++ b/lp-simulation-environment/simulator/src/main/resources/static/TaskReceiver.js
@@ -140,7 +140,19 @@ function taskReceiver(address, user, integratedMode) {
         case 'SESSION_FINISHED':
             var containerDiv = $('#processmain' + msg.sessionid);
             var processFinished = document.createElement('p');
-            processFinished.innerHTML = '<h4>Congratulations, you successfully completed the simulation</h4>'
+            var result = '<h4>Congratulations, you successfully completed the simulation</h4>';
+            result += '<p>Score Summary:</p>';
+            result += '<table class="detailed-score table table-striped table-condensed">';
+            result += '<tr><th>Task</th><th>Score</th></tr>';
+            // add task scores
+            for(var aTask in msg.tasknames) {
+                result += '<tr><td>' + msg.tasknames[aTask] + '</td><td>' +
+                    msg.taskscores[aTask] +'</td></tr>';
+            }
+            result += '</table>';
+
+            processFinished.innerHTML = result;
+
             containerDiv.append(processFinished);
 
             // remove process diagram

--- a/lp-simulation-environment/simulator/src/main/resources/ui.html
+++ b/lp-simulation-environment/simulator/src/main/resources/ui.html
@@ -102,6 +102,14 @@
          #tasks {
              padding-top: 10px;
          }
+
+         table.detailed-score th:nth-child(2){
+             text-align: right;
+         }
+         table.detailed-score td:nth-child(2){
+             text-align: right;
+         }
+
         </style>
 
     </head>


### PR DESCRIPTION
The events defined in the Sim Rest API now implement serializable. This
allows for modules to manipulate and pass them among each others.
This is notably required for the Glimpse probes used in the mon
submodule.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/learnpad/learnpad/267)
<!-- Reviewable:end -->
