### PR TITLE
[me] Return Verification Process ID when pushModel

### DIFF
--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/me/rest/ImportModelSet.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/me/rest/ImportModelSet.java
@@ -29,6 +29,7 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
 import eu.learnpad.exception.LpRestException;
+import eu.learnpad.mv.rest.data.VerificationId;
 
 public interface ImportModelSet {
 	// "/learnpad/me/importmodelset/{modelsetid}?type={adoxx,md,lpzip}"
@@ -36,7 +37,7 @@ public interface ImportModelSet {
 	@PUT
 	@Path("/importmodelset/{modelsetid}")
 	@Consumes(MediaType.APPLICATION_OCTET_STREAM)
-	void putModelSet(@PathParam("modelsetid") String modelSetId,
+	VerificationId putModelSet(@PathParam("modelsetid") String modelSetId,
 			@QueryParam("type") String type, InputStream modelSetFile)
 			throws LpRestException;
 }

--- a/lp-core-platform/lp-cp-xwiki-implementation/src/main/java/eu/learnpad/core/impl/me/XwikiController.java
+++ b/lp-core-platform/lp-cp-xwiki-implementation/src/main/java/eu/learnpad/core/impl/me/XwikiController.java
@@ -95,7 +95,7 @@ public class XwikiController extends Controller implements XWikiRestComponent, I
 	}
 
 	@Override
-	public void putModelSet(String modelSetId, String type, InputStream modelSetFile)
+	public VerificationId putModelSet(String modelSetId, String type, InputStream modelSetFile)
 			throws LpRestException {
 		if (XWikiRestUtils.isPage(RestResource.CORE_REPOSITORY_WIKI,
 				RestResource.CORE_REPOSITORY_SPACE, modelSetId) == false) {
@@ -106,7 +106,7 @@ public class XwikiController extends Controller implements XWikiRestComponent, I
 		XWikiRestUtils.putAttachment(RestResource.CORE_REPOSITORY_WIKI,
 				RestResource.CORE_REPOSITORY_SPACE, modelSetId, attachmentName,
 				modelSetFile);
-		this.mv.startVerification(modelSetId, "ALL");
+		return this.mv.startVerification(modelSetId, "ALL");
 	}
 
 	@Override

--- a/lp-core-platform/lp-cp-xwiki-implementation/src/main/java/eu/learnpad/core/impl/me/XwikiCoreFacadeRestResource.java
+++ b/lp-core-platform/lp-cp-xwiki-implementation/src/main/java/eu/learnpad/core/impl/me/XwikiCoreFacadeRestResource.java
@@ -55,10 +55,10 @@ public class XwikiCoreFacadeRestResource extends RestResource implements CoreFac
 	}
 	
 	@Override
-	public void putModelSet(String modelSetId, String type, InputStream modelSetFile)
+	public VerificationId putModelSet(String modelSetId, String type, InputStream modelSetFile)
 			throws LpRestException {
 		// TODO Auto-generated method stub
-
+	    return null;
 	}
 
 	@Override


### PR DESCRIPTION
Considering step 20. and 24. from [Slice A](http://wiki.learnpad.eu/LearnPAdWiki/bin/view/WP10/Slice+A) of the scenario, the simplest is to return the Verification Process ID to ME when pushing a new model.  After that, he can get the verification results trough the existing API with this ID.
@gulyx, does it seems OK to you?

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/learnpad/learnpad/268)
<!-- Reviewable:end -->
