### PR TITLE
[sim] Use local glimpse server

### DIFF
--- a/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/monitoring/activiti/ProbeEventReceiver.java
+++ b/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/monitoring/activiti/ProbeEventReceiver.java
@@ -4,6 +4,7 @@
 package eu.learnpad.simulator.monitoring.activiti;
 
 import java.util.ArrayList;
+import java.util.Scanner;
 
 import javax.jms.JMSException;
 import javax.naming.NamingException;
@@ -60,6 +61,16 @@ import eu.learnpad.simulator.monitoring.event.impl.TaskStartSimEvent;
 public class ProbeEventReceiver extends GlimpseAbstractProbe implements
 IProcessEventReceiver {
 
+	private static final String GLIMPSE_CONF_PATH = "glimpse_server.conf";
+
+	private static String getServerAddress() {
+		Scanner scan = new Scanner(ProbeEventReceiver.class.getClassLoader()
+				.getResourceAsStream(GLIMPSE_CONF_PATH));
+		String uiPage = scan.useDelimiter("\\Z").next();
+		scan.close();
+		return uiPage;
+	}
+
 	private final IProcessManager manager;
 
 	/**
@@ -68,7 +79,7 @@ IProcessEventReceiver {
 	public ProbeEventReceiver(IProcessManager manager) {
 		super(Manager.createProbeSettingsPropertiesObject(
 				"org.apache.activemq.jndi.ActiveMQInitialContextFactory",
-				"tcp://atlantis.isti.cnr.it:61616", "system", "manager",
+				ProbeEventReceiver.getServerAddress(), "system", "manager",
 				"TopicCF", "jms.probeTopic", false, "probeName", "probeTopic"));
 
 		this.manager = manager;

--- a/lp-simulation-environment/simulator/src/main/resources/glimpse_server.conf
+++ b/lp-simulation-environment/simulator/src/main/resources/glimpse_server.conf
@@ -1,0 +1,1 @@
+tcp://localhost:61616


### PR DESCRIPTION
Replace the old remote glimpse server with a configuration file that
specifies the address to use. By default this file contains the address
of the local glimpse server created by the monitoring component.

Fixes PR #303

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/learnpad/learnpad/309)
<!-- Reviewable:end -->
