### PR TITLE
[sim][mon] Correct start script

### DIFF
--- a/lp-simulation-environment/scripts/start
+++ b/lp-simulation-environment/scripts/start
@@ -1,4 +1,3 @@
 #!/usr/bin/env bash
 cd $( dirname "${BASH_SOURCE[0]}")/..
-simulator/out/start > simulator.log 2>&1
-monitoring/out/start > monitor.log 2>&1
+monitoring/out/start > monitor.log 2>&1 && simulator/out/start > simulator.log 2>&1


### PR DESCRIPTION
The simulator now has some 'soft' dependencies to the monitoring
component. Change the start script to launch the simulator only after
the monitoring component has started successfully.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/learnpad/learnpad/313)
<!-- Reviewable:end -->
