### PR TITLE
[sim] Add properties file handling

### DIFF
--- a/lp-simulation-environment/README.md
+++ b/lp-simulation-environment/README.md
@@ -40,7 +40,7 @@ As indicated on the command-line, the demo should then be available at :
 
 # Configuration
 The main configurations are given or impacts on the following (possibly not complete) list of files:
- * lp-simulation-environment/simulator/src/main/resources/glimpse_server.conf
+ * lp-simulation-environment/simulator/out/simulator.properties (optional file, may not exist)
  * lp-simulation-environment/monitoring/configFiles/environmentFile
  * lp-simulation-environment/monitoring/systemSettings
  * lp-simulation-environment/monitoring/out/systemSettings (only once the system is built)

--- a/lp-simulation-environment/simulator/README.md
+++ b/lp-simulation-environment/simulator/README.md
@@ -33,7 +33,18 @@ As indicated on the command-line, the demo should then be available at [http://l
         ./out/stop
 
 # Configuration
-There is no possible configuration at the moment.
+The simulator allows to override some configuration using an optional properties file. This properties file allows to override some default properties values:
+
+- the IP used by the simulator
+- the address of the glimpse server
+
+This properties file must named `simulator.properties` and placed in the folder from which the simulator is started (typically the ./out subfolder if launching the simulator with the start script).
+
+To override the address user by the simulator, put the following inside the file:
+`address=<address>`
+
+To override the glimpse server, put the following inside the file:
+`glimpse_server=tcp://<address>`
 
 # Interfaces
 

--- a/lp-simulation-environment/simulator/pom.xml
+++ b/lp-simulation-environment/simulator/pom.xml
@@ -307,6 +307,7 @@
 						<exclude>main/resources/license/**</exclude>
 						<exclude>main/resources/validation_db.json</exclude>
 						<exclude>main/resources/assembly.xml</exclude>
+						<exclude>main/resources/**.properties</exclude>
 					</excludes>
 					<licenseMerges>
 						<licenseMerge>

--- a/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/monitoring/activiti/ProbeEventReceiver.java
+++ b/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/monitoring/activiti/ProbeEventReceiver.java
@@ -4,7 +4,6 @@
 package eu.learnpad.simulator.monitoring.activiti;
 
 import java.util.ArrayList;
-import java.util.Scanner;
 
 import javax.jms.JMSException;
 import javax.naming.NamingException;
@@ -29,6 +28,7 @@ import eu.learnpad.simulator.monitoring.event.impl.SimulationEndSimEvent;
 import eu.learnpad.simulator.monitoring.event.impl.SimulationStartSimEvent;
 import eu.learnpad.simulator.monitoring.event.impl.TaskEndSimEvent;
 import eu.learnpad.simulator.monitoring.event.impl.TaskStartSimEvent;
+import eu.learnpad.simulator.utils.SimulatorProperties;
 
 /*
  * #%L
@@ -59,17 +59,7 @@ import eu.learnpad.simulator.monitoring.event.impl.TaskStartSimEvent;
  *
  */
 public class ProbeEventReceiver extends GlimpseAbstractProbe implements
-IProcessEventReceiver {
-
-	private static final String GLIMPSE_CONF_PATH = "glimpse_server.conf";
-
-	private static String getServerAddress() {
-		Scanner scan = new Scanner(ProbeEventReceiver.class.getClassLoader()
-				.getResourceAsStream(GLIMPSE_CONF_PATH));
-		String uiPage = scan.useDelimiter("\\Z").next();
-		scan.close();
-		return uiPage;
-	}
+		IProcessEventReceiver {
 
 	private final IProcessManager manager;
 
@@ -79,8 +69,10 @@ IProcessEventReceiver {
 	public ProbeEventReceiver(IProcessManager manager) {
 		super(Manager.createProbeSettingsPropertiesObject(
 				"org.apache.activemq.jndi.ActiveMQInitialContextFactory",
-				ProbeEventReceiver.getServerAddress(), "system", "manager",
-				"TopicCF", "jms.probeTopic", false, "probeName", "probeTopic"));
+				SimulatorProperties.props
+						.getProperty(SimulatorProperties.PROP_GLIMPSE_SERVER),
+				"system", "manager", "TopicCF", "jms.probeTopic", false,
+				"probeName", "probeTopic"));
 
 		this.manager = manager;
 	}

--- a/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/utils/SimulatorProperties.java
+++ b/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/utils/SimulatorProperties.java
@@ -1,0 +1,74 @@
+package eu.learnpad.simulator.utils;
+
+/*
+ * #%L
+ * LearnPAd Simulator
+ * %%
+ * Copyright (C) 2014 - 2016 Linagora
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+/**
+ * This class provides a singleton for handling simulator properties
+ *
+ * @author Tom Jorquera - Linagora
+ *
+ */
+public class SimulatorProperties {
+
+	private final static String PROPS_FILE_NAME = "simulator.properties";
+	private final static String OPTIONAL_PROPS_PATH = "./" + PROPS_FILE_NAME;
+
+	public final static Properties props = new Properties();
+
+	public final static String PROP_ADDRESS = "address";
+	public final static String PROP_GLIMPSE_SERVER = "glimpse_server";
+
+	static {
+
+		// load default properties
+		try {
+
+			InputStream defaultProps = SimulatorProperties.class
+					.getClassLoader().getResourceAsStream(PROPS_FILE_NAME);
+			props.load(defaultProps);
+			defaultProps.close();
+		} catch (IOException e1) {
+			e1.printStackTrace();
+			throw new RuntimeException("Could not find default properties file");
+		}
+
+		// try to load optional properties file
+
+		File f = new File(OPTIONAL_PROPS_PATH);
+		if (f.exists() && !f.isDirectory()) {
+			try {
+				FileInputStream file = new FileInputStream(OPTIONAL_PROPS_PATH);
+				props.load(file);
+				file.close();
+			} catch (IOException e) {
+				e.printStackTrace();
+			}
+		}
+
+	}
+}

--- a/lp-simulation-environment/simulator/src/main/resources/glimpse_server.conf
+++ b/lp-simulation-environment/simulator/src/main/resources/glimpse_server.conf
@@ -1,1 +1,0 @@
-tcp://localhost:61616

--- a/lp-simulation-environment/simulator/src/main/resources/simulator.properties
+++ b/lp-simulation-environment/simulator/src/main/resources/simulator.properties
@@ -1,0 +1,1 @@
+glimpse_server=tcp://localhost:61616


### PR DESCRIPTION
This PR introduces additional mechanisms to support an optional properties file.
This properties file allows to override some default properties values:
- the IP used by the simulator
- the address of the glimpse server

This properties file must named `simulator.properties` and placed in the folder from which the simulator is started (typically the ./out subfolder if launching the simulator with the start script).

To override the address user by the simulator, put the following inside the file:
`address=<address>`

To override the glimpse server, put the following inside the file:
`glimpse_server=tcp://<address>`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/learnpad/learnpad/318)
<!-- Reviewable:end -->
