### PR TITLE
[sim] Rework of input data objects

### DIFF
--- a/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/datastructures/document/LearnPadDocument.java
+++ b/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/datastructures/document/LearnPadDocument.java
@@ -21,7 +21,7 @@ package eu.learnpad.simulator.datastructures.document;
  * #L%
  */
 
-import java.util.Collection;
+import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -42,10 +42,10 @@ public class LearnPadDocument {
 	@JsonProperty("desc")
 	public final String desc;
 	@JsonProperty("fields")
-	public final Collection<LearnPadDocumentField> fields;
+	public final Map<LearnPadDocumentField, Object> fields;
 
 	public LearnPadDocument(String id, String name, String desc,
-			Collection<LearnPadDocumentField> fields) {
+			Map<LearnPadDocumentField, Object> fields) {
 		super();
 		this.id = id;
 		this.name = name;

--- a/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/datastructures/document/LearnPadDocumentField.java
+++ b/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/datastructures/document/LearnPadDocumentField.java
@@ -1,5 +1,7 @@
 package eu.learnpad.simulator.datastructures.document;
 
+import java.util.Map;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /*
@@ -31,24 +33,27 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public class LearnPadDocumentField {
 
 	@JsonProperty("id")
-	String id;
+	public String id;
 	@JsonProperty("name")
-	String name;
+	public String name;
 	@JsonProperty("type")
-	String type;
-	@JsonProperty("desc")
-	String desc;
-	@JsonProperty("value")
-	String value;
+	public String type;
+	@JsonProperty("required")
+	public boolean required;
+	@JsonProperty("category")
+	public String category;
+	@JsonProperty("enumValues")
+	public Map<String, String> enumValues;
 
 	public LearnPadDocumentField(String id, String name, String type,
-			String desc, String value) {
+			boolean required, String category, Map<String, String> enumValues) {
 		super();
 		this.id = id;
 		this.name = name;
 		this.type = type;
-		this.desc = desc;
-		this.value = value;
+		this.required = required;
+		this.category = category;
+		this.enumValues = enumValues;
 	}
 
 }

--- a/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/processmanager/activiti/processdispatcher/ActivitiProcessDispatcher.java
+++ b/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/processmanager/activiti/processdispatcher/ActivitiProcessDispatcher.java
@@ -27,6 +27,7 @@ package eu.learnpad.simulator.processmanager.activiti.processdispatcher;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -58,6 +59,7 @@ import eu.learnpad.simulator.processmanager.ITaskRouter;
 import eu.learnpad.simulator.processmanager.ITaskValidator;
 import eu.learnpad.simulator.processmanager.activiti.ActivitiProcessManager;
 import eu.learnpad.simulator.processmanager.activiti.workarounds.msg.MessageInfoData;
+import eu.learnpad.simulator.uihandler.formhandler.dataobject2jsonform.DataObjectToJsonFormFormHandler;
 import eu.learnpad.simulator.utils.BPMNExplorer;
 
 /**
@@ -123,16 +125,15 @@ public class ActivitiProcessDispatcher extends AbstractProcessDispatcher {
 
 			for (String dataInput : dataInputs) {
 
-				Collection<LearnPadDocumentField> fields = new ArrayList<LearnPadDocumentField>();
-
-				for (String element : explorer.getDataObjectContent(dataInput)) {
-					fields.add(new LearnPadDocumentField(element, element,
-							"string", "", processWithVars.getProcessVariables()
-							.get(element).toString()));
+				Map<LearnPadDocumentField, Object> fieldValues = new HashMap<LearnPadDocumentField, Object>();
+				for (LearnPadDocumentField field : DataObjectToJsonFormFormHandler
+						.dataObjectToFields(dataInput, explorer)) {
+					fieldValues.put(field, processWithVars
+							.getProcessVariables().get(field.id));
 				}
 
 				documents.add(new LearnPadDocument(dataInput, explorer
-						.getDataObjectName(dataInput), "", fields));
+						.getDataObjectName(dataInput), "", fieldValues));
 			}
 		}
 

--- a/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/uihandler/formhandler/AbstractFormHandler.java
+++ b/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/uihandler/formhandler/AbstractFormHandler.java
@@ -35,6 +35,7 @@ import java.util.Set;
 import org.activiti.engine.impl.util.json.JSONArray;
 import org.activiti.engine.impl.util.json.JSONObject;
 
+import eu.learnpad.simulator.datastructures.document.LearnPadDocumentField;
 import eu.learnpad.simulator.uihandler.IFormHandler;
 
 /**
@@ -44,41 +45,16 @@ import eu.learnpad.simulator.uihandler.IFormHandler;
  */
 public abstract class AbstractFormHandler implements IFormHandler {
 
-	public static final class FormField {
-
-		final String id;
-		final String title;
-		final String type;
-		final boolean required;
-
-		final String category;
-
-		// for type 'enum'
-		final Map<String, String> enumValues;
-
-		public FormField(String id, String title, String type,
-				boolean required, String category,
-				Map<String, String> enumValues) {
-			super();
-			this.id = id;
-			this.title = title;
-			this.type = type;
-			this.required = required;
-			this.category = category;
-			this.enumValues = enumValues;
-		}
-
-	}
-
 	// these properties are used to prefix special form properties used to map
 	// roles to users. Hopefully no process will use properties with these
 	// keys....
 	protected static final String SINGLE_USER_KEY_PREFIX = "#_learnpad_route_singlerole_#";
 	protected static final String GROUP_USER_KEY_PREFIX = "#_learnpad_route_grouprole_#";
 
-	public abstract List<FormField> getStartFormData(String processId);
+	public abstract List<LearnPadDocumentField> getStartFormData(
+			String processId);
 
-	public abstract List<FormField> getTaskFormFields(String taskId);
+	public abstract List<LearnPadDocumentField> getTaskFormFields(String taskId);
 
 	/*
 	 * (non-Javadoc)
@@ -218,14 +194,14 @@ public abstract class AbstractFormHandler implements IFormHandler {
 		return res.toString();
 	}
 
-	private String generateForm(List<FormField> fields) {
+	private String generateForm(List<LearnPadDocumentField> fields) {
 
 		String schema = "\"schema\": { ";
 		String form = "\"form\": [ ";
 
-		Map<String, List<FormField>> fieldSets = new LinkedHashMap<String, List<FormField>>();
+		Map<String, List<LearnPadDocumentField>> fieldSets = new LinkedHashMap<String, List<LearnPadDocumentField>>();
 
-		for (FormField field : fields) {
+		for (LearnPadDocumentField field : fields) {
 
 			schema += "\"" + field.id + "\": {";
 			schema += getTitle(field) + ", ";
@@ -237,7 +213,8 @@ public abstract class AbstractFormHandler implements IFormHandler {
 				form += ",";
 			} else {
 				if (!fieldSets.containsKey(field.category)) {
-					fieldSets.put(field.category, new ArrayList<FormField>());
+					fieldSets.put(field.category,
+							new ArrayList<LearnPadDocumentField>());
 				}
 				fieldSets.get(field.category).add(field);
 			}
@@ -249,11 +226,12 @@ public abstract class AbstractFormHandler implements IFormHandler {
 		schema += " }";
 
 		// add field sets to form
-		for (Entry<String, List<FormField>> fieldSet : fieldSets.entrySet()) {
+		for (Entry<String, List<LearnPadDocumentField>> fieldSet : fieldSets
+				.entrySet()) {
 			form += "{\"type\": \"fieldset\"," + "\"title\": \""
 					+ fieldSet.getKey() + "\"," + "\"expandable\": true,"
 					+ "\"items\": [";
-			for (FormField field : fieldSet.getValue()) {
+			for (LearnPadDocumentField field : fieldSet.getValue()) {
 				form += getForm(field) + ",";
 			}
 			// remove last comma
@@ -270,7 +248,7 @@ public abstract class AbstractFormHandler implements IFormHandler {
 		return res;
 	}
 
-	private static String getType(FormField field) {
+	private static String getType(LearnPadDocumentField field) {
 		String res = "\"type\": ";
 
 		String type = field.type;
@@ -305,19 +283,19 @@ public abstract class AbstractFormHandler implements IFormHandler {
 		return res;
 	}
 
-	private static String getTitle(FormField field) {
+	private static String getTitle(LearnPadDocumentField field) {
 		if (field.type.equals("boolean")) {
 			return "\"title\": \"\"";
 		} else {
-			return "\"title\": \"" + field.title + "\"";
+			return "\"title\": \"" + field.name + "\"";
 		}
 	}
 
-	private static String getRequired(FormField field) {
+	private static String getRequired(LearnPadDocumentField field) {
 		return "\"required\":" + field.required;
 	}
 
-	private static String getForm(FormField field) {
+	private static String getForm(LearnPadDocumentField field) {
 		String res = "";
 
 		String type = field.type;
@@ -349,7 +327,7 @@ public abstract class AbstractFormHandler implements IFormHandler {
 
 		} else if (type.equals("boolean")) {
 			res += "{ \"key\": \"" + field.id + "\"";
-			res += ",\"inlinetitle\": \"" + field.title + "\"";
+			res += ",\"inlinetitle\": \"" + field.name + "\"";
 			res += "}";
 		} else if (type.equals("textarea")) {
 			res += "{ \"key\": \"" + field.id + "\"";

--- a/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/uihandler/formhandler/activiti2jsonform/ActivitiToJsonFormFormHandler.java
+++ b/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/uihandler/formhandler/activiti2jsonform/ActivitiToJsonFormFormHandler.java
@@ -33,6 +33,7 @@ import org.activiti.engine.form.FormData;
 import org.activiti.engine.form.FormProperty;
 import org.activiti.engine.form.StartFormData;
 
+import eu.learnpad.simulator.datastructures.document.LearnPadDocumentField;
 import eu.learnpad.simulator.uihandler.formhandler.AbstractFormHandler;
 
 /**
@@ -60,8 +61,8 @@ public class ActivitiToJsonFormFormHandler extends AbstractFormHandler {
 	 * @param props
 	 * @return a list of form fields
 	 */
-	private List<FormField> propertyToField(List<FormProperty> props) {
-		List<FormField> res = new ArrayList<FormField>();
+	private List<LearnPadDocumentField> propertyToField(List<FormProperty> props) {
+		List<LearnPadDocumentField> res = new ArrayList<LearnPadDocumentField>();
 		for (FormProperty prop : props) {
 
 			String type = prop.getType().getName();
@@ -73,21 +74,21 @@ public class ActivitiToJsonFormFormHandler extends AbstractFormHandler {
 			Map<String, String> enumValues = type.equals("enum") ? (Map<String, String>) prop
 					.getType().getInformation("values") : null;
 
-			res.add(new FormField(prop.getId(), title, type, prop.isRequired(),
-							"", enumValues));
+					res.add(new LearnPadDocumentField(prop.getId(), title, type, prop
+					.isRequired(), "", enumValues));
 		}
 
 		return res;
 	}
 
 	@Override
-	public List<FormField> getStartFormData(String processId) {
+	public List<LearnPadDocumentField> getStartFormData(String processId) {
 		StartFormData data = activitiFormService.getStartFormData(processId);
 		return propertyToField(data.getFormProperties());
 	}
 
 	@Override
-	public List<FormField> getTaskFormFields(String taskId) {
+	public List<LearnPadDocumentField> getTaskFormFields(String taskId) {
 		FormData data = activitiFormService.getTaskFormData(taskId);
 		return propertyToField(data.getFormProperties());
 	}

--- a/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/uihandler/formhandler/multi2jsonform/Multi2JsonFormFormHandler.java
+++ b/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/uihandler/formhandler/multi2jsonform/Multi2JsonFormFormHandler.java
@@ -28,6 +28,7 @@ import java.util.List;
 import org.activiti.engine.FormService;
 import org.activiti.engine.TaskService;
 
+import eu.learnpad.simulator.datastructures.document.LearnPadDocumentField;
 import eu.learnpad.simulator.uihandler.formhandler.AbstractFormHandler;
 import eu.learnpad.simulator.uihandler.formhandler.activiti2jsonform.ActivitiToJsonFormFormHandler;
 import eu.learnpad.simulator.uihandler.formhandler.dataobject2jsonform.DataObjectToJsonFormFormHandler;
@@ -72,8 +73,8 @@ public class Multi2JsonFormFormHandler extends AbstractFormHandler {
 	}
 
 	@Override
-	public List<FormField> getStartFormData(String processId) {
-		List<FormField> res = new ArrayList<AbstractFormHandler.FormField>();
+	public List<LearnPadDocumentField> getStartFormData(String processId) {
+		List<LearnPadDocumentField> res = new ArrayList<LearnPadDocumentField>();
 		for (AbstractFormHandler handler : handlers) {
 			res.addAll(handler.getStartFormData(processId));
 		}
@@ -81,8 +82,8 @@ public class Multi2JsonFormFormHandler extends AbstractFormHandler {
 	}
 
 	@Override
-	public List<FormField> getTaskFormFields(String taskId) {
-		List<FormField> res = new ArrayList<AbstractFormHandler.FormField>();
+	public List<LearnPadDocumentField> getTaskFormFields(String taskId) {
+		List<LearnPadDocumentField> res = new ArrayList<LearnPadDocumentField>();
 		for (AbstractFormHandler handler : handlers) {
 			res.addAll(handler.getTaskFormFields(taskId));
 		}


### PR DESCRIPTION
The current design of input data objects was incorrect and did not
really work. This commit introduces a rewrite that change the way
document fields are handled and unify it with the FormHandler FormFields
(which are consequently removed).
This mean that the fields are parsed in an uniform way, but cause a lot
of small type rewrites.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/learnpad/learnpad/326)
<!-- Reviewable:end -->
