### PR TITLE
Rework of the Sim REST Event API

### DIFF
--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/ProcessEndEvent.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/ProcessEndEvent.java
@@ -40,12 +40,7 @@ public class ProcessEndEvent extends AbstractEvent {
 	/**
 	 * Unique ID of the process instance
 	 */
-	public String processid;
-
-	/**
-	 * ID used to identify the process in the BP definition
-	 */
-	public String processdefinitionid;
+	public String processartifactid;
 
 	public ProcessEndEvent() {
 		super();
@@ -53,17 +48,14 @@ public class ProcessEndEvent extends AbstractEvent {
 
 	public ProcessEndEvent(Long timestamp, String simulationsessionid,
 			List<String> involvedusers, String modelsetid,
-			Map<String, Object> simulationSessionData, String processid,
-			String processdefinitionid) {
+			Map<String, Object> simulationSessionData, String processartifactid) {
 		super(EventType.PROCESS_END, timestamp, simulationsessionid,
 				involvedusers, modelsetid, simulationSessionData);
-		this.processid = processid;
-		this.processdefinitionid = processdefinitionid;
+		this.processartifactid = processartifactid;
 	}
 
 	@Override
 	public String toString() {
-		return super.toString() + " processid=" + processid
-				+ " processdefinitionid=" + processdefinitionid;
+		return super.toString() + " processartifactid=" + processartifactid;
 	}
 }

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/ProcessStartEvent.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/ProcessStartEvent.java
@@ -38,14 +38,9 @@ public class ProcessStartEvent extends AbstractEvent {
 	private static final long serialVersionUID = -4855894406498460958L;
 
 	/**
-	 * Unique ID of the process instance
-	 */
-	public String processid;
-
-	/**
 	 * ID used to identify the process in the BP definition
 	 */
-	public String processdefinitionid;
+	public String processartifactid;
 
 	public ProcessStartEvent() {
 		super();
@@ -53,17 +48,14 @@ public class ProcessStartEvent extends AbstractEvent {
 
 	public ProcessStartEvent(Long timestamp, String simulationsessionid,
 			List<String> involvedusers, String modelsetid,
-			Map<String, Object> simulationSessionData, String processid,
-			String processdefinitionid) {
+			Map<String, Object> simulationSessionData, String processartifactid) {
 		super(EventType.PROCESS_START, timestamp, simulationsessionid,
 				involvedusers, modelsetid, simulationSessionData);
-		this.processid = processid;
-		this.processdefinitionid = processdefinitionid;
+		this.processartifactid = processartifactid;
 	}
 
 	@Override
 	public String toString() {
-		return super.toString() + " processid=" + processid
-				+ " processdefinitionid=" + processdefinitionid;
+		return super.toString() + " processdefinitionid=" + processartifactid;
 	}
 }

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/SessionScoreUpdateEvent.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/SessionScoreUpdateEvent.java
@@ -38,9 +38,9 @@ public class SessionScoreUpdateEvent extends AbstractEvent {
 	private static final long serialVersionUID = -8719161124674249926L;
 
 	/**
-	 * Unique ID of the process instance
+	 * Unique ID of the process artifact definition
 	 */
-	public String processid;
+	public String processartifactid;
 
 	/**
 	 * The LearnPAd user those score is updated
@@ -58,18 +58,18 @@ public class SessionScoreUpdateEvent extends AbstractEvent {
 
 	public SessionScoreUpdateEvent(Long timestamp, String simulationsessionid,
 			List<String> involvedusers, String modelsetid,
-			Map<String, Object> simulationSessionData, String processid,
-			String user, Long sessionScore) {
+			Map<String, Object> simulationSessionData,
+			String processartifactid, String user, Long sessionScore) {
 		super(EventType.SESSION_SCORE_UPDATE, timestamp, simulationsessionid,
 				involvedusers, modelsetid, simulationSessionData);
-		this.processid = processid;
+		this.processartifactid = processartifactid;
 		this.sessionscore = sessionScore;
 		this.user = user;
 	}
 
 	@Override
 	public String toString() {
-		return super.toString() + " processid=" + processid + " user=" + user
-				+ " sessionscore=" + sessionscore;
+		return super.toString() + " processartifactid=" + processartifactid
+				+ " user=" + user + " sessionscore=" + sessionscore;
 	}
 }

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/TaskEndEvent.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/TaskEndEvent.java
@@ -38,19 +38,14 @@ public class TaskEndEvent extends AbstractEvent {
 	private static final long serialVersionUID = -5328814254042585792L;
 
 	/**
-	 * Unique ID of the process instance
+	 * Unique ID of the process artifact
 	 */
-	public String processid;
-
-	/**
-	 * Unique ID of the task instance
-	 */
-	public String taskid;
+	public String processartifactid;
 
 	/**
 	 * ID used to identify the task in the BP definition
 	 */
-	public String taskdefid;
+	public String taskartifactid;
 
 	/**
 	 * The LearnPAd users that have been assigned to this task
@@ -66,14 +61,14 @@ public class TaskEndEvent extends AbstractEvent {
 
 	public TaskEndEvent(Long timestamp, String simulationsessionid,
 			List<String> involvedusers, String modelsetid,
-			Map<String, Object> simulationSessionData, String processid,
-			String taskid, String taskdefid, List<String> assignedusers,
-			String completingUser, Map<String, Object> submittedData) {
+			Map<String, Object> simulationSessionData,
+			String processartifactid, String taskartifactid,
+			List<String> assignedusers, String completingUser,
+			Map<String, Object> submittedData) {
 		super(EventType.TASK_END, timestamp, simulationsessionid,
 				involvedusers, modelsetid, simulationSessionData);
-		this.processid = processid;
-		this.taskid = taskid;
-		this.taskdefid = taskdefid;
+		this.processartifactid = processartifactid;
+		this.taskartifactid = taskartifactid;
 		this.assignedusers = assignedusers;
 		this.completingUser = completingUser;
 		this.submittedData = submittedData;
@@ -81,8 +76,8 @@ public class TaskEndEvent extends AbstractEvent {
 
 	@Override
 	public String toString() {
-		return super.toString() + " processid=" + processid + " taskid="
-				+ taskid + " taskdefid=" + taskdefid + " assignedusers="
+		return super.toString() + " processartifactid=" + processartifactid
+				+ " taskartifactid=" + taskartifactid + " assignedusers="
 				+ assignedusers + " completingUser=" + completingUser
 				+ " submittedData=" + submittedData;
 	}

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/TaskFailedEvent.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/TaskFailedEvent.java
@@ -38,19 +38,14 @@ public class TaskFailedEvent extends AbstractEvent {
 	private static final long serialVersionUID = 8801597168699684284L;
 
 	/**
-	 * Unique ID of the process instance
+	 * Unique ID of the process artifact
 	 */
-	public String processid;
-
-	/**
-	 * Unique ID of the task instance
-	 */
-	public String taskid;
+	public String processartifactid;
 
 	/**
 	 * ID used to identify the task in the BP definition
 	 */
-	public String taskdefid;
+	public String taskartifactid;
 
 	/**
 	 * The LearnPAd users that have been assigned to this task
@@ -67,14 +62,14 @@ public class TaskFailedEvent extends AbstractEvent {
 
 	public TaskFailedEvent(Long timestamp, String simulationsessionid,
 			List<String> involvedusers, String modelsetid,
-			Map<String, Object> simulationSessionData, String processid,
-			String taskid, String taskdefid, List<String> assignedusers,
-			String completingUser, Map<String, Object> submittedData) {
+			Map<String, Object> simulationSessionData,
+			String processartifactid, String taskartifactid,
+			List<String> assignedusers, String completingUser,
+			Map<String, Object> submittedData) {
 		super(EventType.TASK_FAILED, timestamp, simulationsessionid,
 				involvedusers, modelsetid, simulationSessionData);
-		this.processid = processid;
-		this.taskid = taskid;
-		this.taskdefid = taskdefid;
+		this.processartifactid = processartifactid;
+		this.taskartifactid = taskartifactid;
 		this.assignedusers = assignedusers;
 		this.completingUser = completingUser;
 		this.submittedData = submittedData;
@@ -82,8 +77,8 @@ public class TaskFailedEvent extends AbstractEvent {
 
 	@Override
 	public String toString() {
-		return super.toString() + " processid=" + processid + " taskid="
-				+ taskid + " taskdefid=" + taskdefid + " assignedusers="
+		return super.toString() + " processartifactid=" + processartifactid
+				+ " taskartifactid=" + taskartifactid + " assignedusers="
 				+ assignedusers + " completingUser=" + completingUser
 				+ " submittedData=" + submittedData;
 	}

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/TaskStartEvent.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/TaskStartEvent.java
@@ -38,19 +38,14 @@ public class TaskStartEvent extends AbstractEvent {
 	private static final long serialVersionUID = 6565005567809009748L;
 
 	/**
-	 * Unique ID of the process instance
+	 * Unique ID of the process artifact
 	 */
-	public String processid;
-
-	/**
-	 * Unique ID of the task instance
-	 */
-	public String taskid;
+	public String processartifactid;
 
 	/**
 	 * ID used to identify the task in the BP definition
 	 */
-	public String taskdefid;
+	public String taskartifactid;
 
 	/**
 	 * The LearnPAd users that have been assigned to this task
@@ -63,20 +58,20 @@ public class TaskStartEvent extends AbstractEvent {
 
 	public TaskStartEvent(Long timestamp, String simulationsessionid,
 			List<String> involvedusers, String modelsetid,
-			Map<String, Object> simulationSessionData, String processid,
-			String taskid, String taskdefid, List<String> assignedusers) {
+			Map<String, Object> simulationSessionData,
+			String processartifactid, String taskartifactid,
+			List<String> assignedusers) {
 		super(EventType.TASK_START, timestamp, simulationsessionid,
 				involvedusers, modelsetid, simulationSessionData);
-		this.processid = processid;
-		this.taskid = taskid;
-		this.taskdefid = taskdefid;
+		this.processartifactid = processartifactid;
+		this.taskartifactid = taskartifactid;
 		this.assignedusers = assignedusers;
 	}
 
 	@Override
 	public String toString() {
-		return super.toString() + " processid=" + processid + " taskid="
-				+ taskid + " taskdefid=" + taskdefid + " assignedusers="
+		return super.toString() + " processartifactid=" + processartifactid
+				+ " taskartifactid=" + taskartifactid + " assignedusers="
 				+ assignedusers;
 	}
 

--- a/lp-core-platform/lp-cp-xwiki-implementation/src/main/java/eu/learnpad/core/impl/sim/XwikiController.java
+++ b/lp-core-platform/lp-cp-xwiki-implementation/src/main/java/eu/learnpad/core/impl/sim/XwikiController.java
@@ -121,7 +121,7 @@ public class XwikiController extends Controller implements XWikiRestComponent, I
 
 	@Override
 	public void receiveProcessStartEvent(ProcessStartEvent event) throws LpRestException{
-		String modelId = event.processid;
+		String modelId = event.processartifactid;
 		String action = "started";		
 		String modelSetId = event.modelsetid;		
 		String simulationId = event.simulationsessionid;
@@ -136,7 +136,7 @@ public class XwikiController extends Controller implements XWikiRestComponent, I
 
 	@Override
 	public void receiveProcessEndEvent(ProcessEndEvent event)  throws LpRestException{
-		String modelId = event.processid;
+		String modelId = event.processartifactid;
 		String action = "stopped";		
 		String modelSetId = event.modelsetid;		
 		String simulationId = event.simulationsessionid;
@@ -154,7 +154,7 @@ public class XwikiController extends Controller implements XWikiRestComponent, I
 	@Override
 	public void receiveTaskStartEvent(TaskStartEvent event) throws LpRestException {
 		String modelSetId = event.modelsetid;
-		String artifactId = event.taskdefid; 
+		String artifactId = event.taskartifactid;
 		String simulationId = event.simulationsessionid;
 
 // It seems not useful for the moment, this notification
@@ -165,8 +165,8 @@ public class XwikiController extends Controller implements XWikiRestComponent, I
 
 	@Override
 	public void receiveTaskEndEvent(TaskEndEvent event) throws LpRestException {
-		String modelId = event.processid;
-		String artifactId = event.taskdefid;
+		String modelId = event.processartifactid;
+		String artifactId = event.taskartifactid;
 		String modelSetId = event.modelsetid;
 		
 		SimulationData data = new SimulationData();

--- a/lp-simulation-environment/monitoring/src/main/java/eu/learnpad/simulator/mon/manager/RestNotifier.java
+++ b/lp-simulation-environment/monitoring/src/main/java/eu/learnpad/simulator/mon/manager/RestNotifier.java
@@ -73,8 +73,8 @@ public class RestNotifier extends Thread {
 		}
 	}
 		
-	public static void notifyProcessStart(Long processTimeStamp, List<String> involvedUsers, String sessionID, String modelSetID, Map<String, Object> simulationSessionData, String processID, String processDefinitionID) {
-		ProcessStartEvent event = new ProcessStartEvent(processTimeStamp, sessionID, involvedUsers, modelSetID, simulationSessionData, processID, processDefinitionID);
+	public static void notifyProcessStart(Long processTimeStamp, List<String> involvedUsers, String sessionID, String modelSetID, Map<String, Object> simulationSessionData, String processArtifactId) {
+		ProcessStartEvent event = new ProcessStartEvent(processTimeStamp, sessionID, involvedUsers, modelSetID, simulationSessionData, processArtifactId);
 		try {
 			RestNotifier.getCoreFacade().receiveProcessStartEvent(event);
 			DebugMessages.println(TimeStamp.getCurrentTime(), RestNotifier.class.getSimpleName(), "ProcessStartEvent sent");
@@ -92,8 +92,8 @@ public class RestNotifier extends Thread {
 		}
 	}
 	
-	public static void notifyProcessEnd(Long processTimeStamp, List<String> involvedUsers, String sessionID, String modelSetID, Map<String, Object> simulationSessionData, String processID, String processDefinitionID) {
-		ProcessEndEvent event = new ProcessEndEvent(processTimeStamp, sessionID, involvedUsers, modelSetID, simulationSessionData, processID, processDefinitionID);
+	public static void notifyProcessEnd(Long processTimeStamp, List<String> involvedUsers, String sessionID, String modelSetID, Map<String, Object> simulationSessionData, String processArtifactId) {
+		ProcessEndEvent event = new ProcessEndEvent(processTimeStamp, sessionID, involvedUsers, modelSetID, simulationSessionData, processArtifactId);
 		try {
 			RestNotifier.getCoreFacade().receiveProcessEndEvent(event);
 			DebugMessages.println(TimeStamp.getCurrentTime(), RestNotifier.class.getSimpleName(), "ProcessStopEvent sent");
@@ -111,8 +111,8 @@ public class RestNotifier extends Thread {
 		}
 	}
 	
-	public static void notifyTaskStart(Long processTimeStamp, String sessionID, List<String> involvedUsers, String modelSetID, Map<String, Object> simulationSessionData, String processID, String taskID, String taskDefinitionID, List<String> assignedUsers) {
-		TaskStartEvent event = new TaskStartEvent(processTimeStamp, sessionID, involvedUsers, modelSetID, simulationSessionData, processID, taskID, taskDefinitionID, assignedUsers);
+	public static void notifyTaskStart(Long processTimeStamp, String sessionID, List<String> involvedUsers, String modelSetID, Map<String, Object> simulationSessionData, String processArtifactId, String taskArtifactId, List<String> assignedUsers) {
+		TaskStartEvent event = new TaskStartEvent(processTimeStamp, sessionID, involvedUsers, modelSetID, simulationSessionData, processArtifactId, taskArtifactId, assignedUsers);
 		try {
 			RestNotifier.getCoreFacade().receiveTaskStartEvent(event);
 			DebugMessages.println(TimeStamp.getCurrentTime(), RestNotifier.class.getSimpleName(), "TaskStartEvent sent");
@@ -139,8 +139,8 @@ public class RestNotifier extends Thread {
 		}
 	}
 	
-	public static void notifyTaskEnd(Long processTimeStamp, String sessionID, List<String> involvedUsers, String modelSetID, Map<String, Object> simulationSessionData, String processID, String taskID, String taskDefinitionID, List<String> assignedUsers, String completingUserID, Map<String,Object> submittedData) {
-		TaskEndEvent event = new TaskEndEvent(processTimeStamp, sessionID, involvedUsers, modelSetID, simulationSessionData, processID, taskID, taskDefinitionID, assignedUsers, completingUserID, submittedData);
+	public static void notifyTaskEnd(Long processTimeStamp, String sessionID, List<String> involvedUsers, String modelSetID, Map<String, Object> simulationSessionData, String processArtifactId, String taskArtifactId, List<String> assignedUsers, String completingUserID, Map<String,Object> submittedData) {
+		TaskEndEvent event = new TaskEndEvent(processTimeStamp, sessionID, involvedUsers, modelSetID, simulationSessionData, processArtifactId, taskArtifactId, assignedUsers, completingUserID, submittedData);
 		try {
 			RestNotifier.getCoreFacade().receiveTaskEndEvent(event);
 			DebugMessages.println(TimeStamp.getCurrentTime(), RestNotifier.class.getSimpleName(), "TaskEndEvent sent");

--- a/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/IProcessEventReceiver.java
+++ b/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/IProcessEventReceiver.java
@@ -30,6 +30,7 @@ import eu.learnpad.simulator.monitoring.event.impl.SessionScoreUpdateSimEvent;
 import eu.learnpad.simulator.monitoring.event.impl.SimulationEndSimEvent;
 import eu.learnpad.simulator.monitoring.event.impl.SimulationStartSimEvent;
 import eu.learnpad.simulator.monitoring.event.impl.TaskEndSimEvent;
+import eu.learnpad.simulator.monitoring.event.impl.TaskFailedSimEvent;
 import eu.learnpad.simulator.monitoring.event.impl.TaskStartSimEvent;
 
 /**
@@ -56,6 +57,8 @@ public interface IProcessEventReceiver {
 	public void receiveTaskStartEvent(TaskStartSimEvent event);
 
 	public void receiveTaskEndEvent(TaskEndSimEvent event);
+
+	public void receiveTaskFailedEvent(TaskFailedSimEvent event);
 
 	public void receiveSessionScoreUpdateEvent(SessionScoreUpdateSimEvent event);
 

--- a/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/monitoring/EventDispatcherImpl.java
+++ b/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/monitoring/EventDispatcherImpl.java
@@ -31,6 +31,7 @@ import eu.learnpad.simulator.monitoring.event.impl.SessionScoreUpdateSimEvent;
 import eu.learnpad.simulator.monitoring.event.impl.SimulationEndSimEvent;
 import eu.learnpad.simulator.monitoring.event.impl.SimulationStartSimEvent;
 import eu.learnpad.simulator.monitoring.event.impl.TaskEndSimEvent;
+import eu.learnpad.simulator.monitoring.event.impl.TaskFailedSimEvent;
 import eu.learnpad.simulator.monitoring.event.impl.TaskStartSimEvent;
 
 /**
@@ -77,6 +78,13 @@ public class EventDispatcherImpl implements IEventDispatcher {
 	public void receiveTaskEndEvent(TaskEndSimEvent event) {
 		for (IProcessEventReceiver receiver : receivers) {
 			receiver.receiveTaskEndEvent(event);
+		}
+	}
+
+	@Override
+	public void receiveTaskFailedEvent(TaskFailedSimEvent event) {
+		for (IProcessEventReceiver receiver : receivers) {
+			receiver.receiveTaskFailedEvent(event);
 		}
 	}
 

--- a/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/monitoring/activiti/ProbeEventReceiver.java
+++ b/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/monitoring/activiti/ProbeEventReceiver.java
@@ -172,7 +172,6 @@ public class ProbeEventReceiver extends GlimpseAbstractProbe implements
 						new ArrayList<String>(event.involvedusers),
 						manager.getModelSetId(event.simulationsessionid),
 						manager.getSimulationSessionParametersData(event.simulationsessionid),
-						event.processInstance.processartifactid,
 						event.processInstance.processartifactkey));
 
 		send(monitoringEvent);
@@ -194,7 +193,6 @@ public class ProbeEventReceiver extends GlimpseAbstractProbe implements
 						new ArrayList<String>(event.involvedusers),
 						manager.getModelSetId(event.simulationsessionid),
 						manager.getSimulationSessionParametersData(event.simulationsessionid),
-						event.processInstance.processartifactid,
 						event.processInstance.processartifactkey));
 		send(monitoringEvent);
 
@@ -215,8 +213,9 @@ public class ProbeEventReceiver extends GlimpseAbstractProbe implements
 						new ArrayList<String>(event.involvedusers),
 						manager.getModelSetId(event.simulationsessionid),
 						manager.getSimulationSessionParametersData(event.simulationsessionid),
-						event.task.processId, event.task.id, event.task.key,
-						new ArrayList<String>(event.involvedusers)));
+						manager.getProcessInstanceInfos(event.task.processId).processartifactkey,
+						event.task.key, new ArrayList<String>(
+								event.involvedusers)));
 
 		send(monitoringEvent);
 
@@ -237,9 +236,10 @@ public class ProbeEventReceiver extends GlimpseAbstractProbe implements
 						new ArrayList<String>(event.involvedusers),
 						manager.getModelSetId(event.simulationsessionid),
 						manager.getSimulationSessionParametersData(event.simulationsessionid),
-						event.task.processId, event.task.id, event.task.key,
-						new ArrayList<String>(event.involvedusers),
-						event.completingUser, event.submittedData));
+						manager.getProcessInstanceInfos(event.task.processId).processartifactkey,
+						event.task.key, new ArrayList<String>(
+								event.involvedusers), event.completingUser,
+						event.submittedData));
 
 		send(monitoringEvent);
 
@@ -260,7 +260,8 @@ public class ProbeEventReceiver extends GlimpseAbstractProbe implements
 						new ArrayList<String>(event.involvedusers),
 						manager.getModelSetId(event.simulationsessionid),
 						manager.getSimulationSessionParametersData(event.simulationsessionid),
-						event.processid, event.user, event.sessionscore));
+						manager.getProcessInstanceInfos(event.processid).processartifactkey,
+						event.user, event.sessionscore));
 
 		send(monitoringEvent);
 

--- a/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/monitoring/activiti/ProbeEventReceiver.java
+++ b/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/monitoring/activiti/ProbeEventReceiver.java
@@ -14,6 +14,7 @@ import eu.learnpad.sim.rest.event.impl.SessionScoreUpdateEvent;
 import eu.learnpad.sim.rest.event.impl.SimulationEndEvent;
 import eu.learnpad.sim.rest.event.impl.SimulationStartEvent;
 import eu.learnpad.sim.rest.event.impl.TaskEndEvent;
+import eu.learnpad.sim.rest.event.impl.TaskFailedEvent;
 import eu.learnpad.sim.rest.event.impl.TaskStartEvent;
 import eu.learnpad.simulator.IProcessEventReceiver;
 import eu.learnpad.simulator.IProcessManager;
@@ -27,6 +28,7 @@ import eu.learnpad.simulator.monitoring.event.impl.SessionScoreUpdateSimEvent;
 import eu.learnpad.simulator.monitoring.event.impl.SimulationEndSimEvent;
 import eu.learnpad.simulator.monitoring.event.impl.SimulationStartSimEvent;
 import eu.learnpad.simulator.monitoring.event.impl.TaskEndSimEvent;
+import eu.learnpad.simulator.monitoring.event.impl.TaskFailedSimEvent;
 import eu.learnpad.simulator.monitoring.event.impl.TaskStartSimEvent;
 import eu.learnpad.simulator.utils.SimulatorProperties;
 
@@ -240,6 +242,30 @@ public class ProbeEventReceiver extends GlimpseAbstractProbe implements
 						event.task.key, new ArrayList<String>(
 								event.involvedusers), event.completingUser,
 						event.submittedData));
+
+		send(monitoringEvent);
+
+	}
+
+	@Override
+	public void receiveTaskFailedEvent(TaskFailedSimEvent event) {
+		GlimpseBaseEventBPMN<String> monitoringEvent = new GlimpseBaseEventBPMN<String>(
+				"Activity_" + event.timestamp,
+				event.simulationsessionid,
+				event.timestamp,
+				event.getType().toString(),
+				false,
+				event.task.subprocessKey,
+				new TaskFailedEvent(
+						event.timestamp,
+						event.simulationsessionid,
+						new ArrayList<String>(event.involvedusers),
+						manager.getModelSetId(event.simulationsessionid),
+						manager.getSimulationSessionParametersData(event.simulationsessionid),
+						manager.getProcessInstanceInfos(event.task.processId).processartifactkey,
+						event.task.key, new ArrayList<String>(
+								event.involvedusers), event.completingUser,
+								event.submittedData));
 
 		send(monitoringEvent);
 

--- a/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/monitoring/event/impl/SessionScoreUpdateSimEvent.java
+++ b/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/monitoring/event/impl/SessionScoreUpdateSimEvent.java
@@ -73,6 +73,7 @@ public class SessionScoreUpdateSimEvent extends AbstractSimEvent {
 		super(timestamp, simulationsessionid, involvedusers);
 		this.processid = processid;
 		this.sessionscore = sessionScore;
+		this.user = user;
 	}
 
 	@Override

--- a/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/monitoring/event/impl/TaskFailedSimEvent.java
+++ b/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/monitoring/event/impl/TaskFailedSimEvent.java
@@ -17,7 +17,7 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package eu.learnpad.simulator.monitoring.event;
+package eu.learnpad.simulator.monitoring.event.impl;
 
 /*
  * #%L
@@ -40,11 +40,37 @@ package eu.learnpad.simulator.monitoring.event;
  * #L%
  */
 
+import java.util.Collection;
+import java.util.Map;
+
+import eu.learnpad.simulator.datastructures.LearnPadTask;
+import eu.learnpad.simulator.datastructures.LearnPadTaskSubmissionResult;
+import eu.learnpad.simulator.monitoring.event.SimEventType;
+
 /**
  *
  * @author Tom Jorquera - Linagora
  *
  */
-public enum SimEventType {
-	SIMULATION_START, SIMULATION_END, PROCESS_START, PROCESS_END, TASK_START, TASK_END, TASK_FAILED, SESSION_SCORE_UPDATE
+public class TaskFailedSimEvent extends TaskStartSimEvent {
+
+	public final String completingUser;
+	public Map<String, Object> submittedData;
+	public final LearnPadTaskSubmissionResult submissionResult;
+
+	public TaskFailedSimEvent(Long timestamp, String simulationsessionid,
+			Collection<String> involvedusers, LearnPadTask task,
+			String completingUser, Map<String, Object> submittedData,
+			LearnPadTaskSubmissionResult submissionResult) {
+		super(timestamp, simulationsessionid, involvedusers, task);
+		this.completingUser = completingUser;
+		this.submittedData = submittedData;
+		this.submissionResult = submissionResult;
+	}
+
+	@Override
+	public SimEventType getType() {
+		return SimEventType.TASK_FAILED;
+	}
+
 }

--- a/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/processmanager/AbstractProcessDispatcher.java
+++ b/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/processmanager/AbstractProcessDispatcher.java
@@ -35,6 +35,7 @@ import eu.learnpad.simulator.datastructures.LearnPadTaskSubmissionResult;
 import eu.learnpad.simulator.monitoring.event.impl.ProcessEndSimEvent;
 import eu.learnpad.simulator.monitoring.event.impl.SessionScoreUpdateSimEvent;
 import eu.learnpad.simulator.monitoring.event.impl.TaskEndSimEvent;
+import eu.learnpad.simulator.monitoring.event.impl.TaskFailedSimEvent;
 import eu.learnpad.simulator.monitoring.event.impl.TaskStartSimEvent;
 import eu.learnpad.simulator.processmanager.activiti.ActivitiProcessManager;
 import eu.learnpad.simulator.processmanager.gamification.TaskScorer;
@@ -131,8 +132,18 @@ public abstract class AbstractProcessDispatcher implements IProcessDispatcher {
 					// add attempt to user failed count
 					taskScorers.get(task.id).addUserAttemptFail(userId);
 
+					LearnPadTaskSubmissionResult res = LearnPadTaskSubmissionResult
+							.rejected();
+
+					// send failure notification
+					processEventReceiver
+					.receiveTaskFailedEvent(new TaskFailedSimEvent(
+							System.currentTimeMillis(),
+							simulationSessionId, involvedUsers, task,
+									userId, data, res));
+
 					// task result is invalid and must be resubmitted
-					return LearnPadTaskSubmissionResult.rejected();
+					return res;
 				} else {
 
 					int taskScore = 0;

--- a/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/robot/RobotUserEventReceiverWrapper.java
+++ b/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/robot/RobotUserEventReceiverWrapper.java
@@ -40,6 +40,7 @@ import eu.learnpad.simulator.monitoring.event.impl.SessionScoreUpdateSimEvent;
 import eu.learnpad.simulator.monitoring.event.impl.SimulationEndSimEvent;
 import eu.learnpad.simulator.monitoring.event.impl.SimulationStartSimEvent;
 import eu.learnpad.simulator.monitoring.event.impl.TaskEndSimEvent;
+import eu.learnpad.simulator.monitoring.event.impl.TaskFailedSimEvent;
 import eu.learnpad.simulator.monitoring.event.impl.TaskStartSimEvent;
 
 /**
@@ -181,6 +182,11 @@ IProcessEventReceiver, IRobotHandler {
 	@Override
 	public void receiveTaskEndEvent(TaskEndSimEvent event) {
 		eventReceiver.receiveTaskEndEvent(event);
+	}
+
+	@Override
+	public void receiveTaskFailedEvent(TaskFailedSimEvent event) {
+		eventReceiver.receiveTaskFailedEvent(event);
 	}
 
 	@Override

--- a/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/uihandler/webserver/UIHandlerWebImpl.java
+++ b/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/uihandler/webserver/UIHandlerWebImpl.java
@@ -43,6 +43,7 @@ import eu.learnpad.simulator.monitoring.event.impl.SessionScoreUpdateSimEvent;
 import eu.learnpad.simulator.monitoring.event.impl.SimulationEndSimEvent;
 import eu.learnpad.simulator.monitoring.event.impl.SimulationStartSimEvent;
 import eu.learnpad.simulator.monitoring.event.impl.TaskEndSimEvent;
+import eu.learnpad.simulator.monitoring.event.impl.TaskFailedSimEvent;
 import eu.learnpad.simulator.monitoring.event.impl.TaskStartSimEvent;
 import eu.learnpad.simulator.uihandler.IFormHandler;
 
@@ -181,6 +182,11 @@ public class UIHandlerWebImpl implements IUserHandler, IProcessEventReceiver {
 			((UIServlet) usersMap.get(user).getServletInstance())
 					.addTask(event.task.id);
 		}
+	}
+
+	@Override
+	public void receiveTaskFailedEvent(TaskFailedSimEvent event) {
+		// nothing to do
 	}
 
 	@Override

--- a/lp-simulation-environment/simulator/src/test/java/eu/learnpad/simulator/api/rest/corefacade/SimRestAPICoreFacadeTest.java
+++ b/lp-simulation-environment/simulator/src/test/java/eu/learnpad/simulator/api/rest/corefacade/SimRestAPICoreFacadeTest.java
@@ -110,25 +110,25 @@ public class SimRestAPICoreFacadeTest {
 
 			receiverClient.receiveProcessEndEvent(new ProcessEndEvent(System
 					.currentTimeMillis(), "1", Arrays.asList("test"), null,
-					null, "1", "1"));
+					null, "1"));
 
 			receiverClient.receiveProcessStartEvent(new ProcessStartEvent(
 					System.currentTimeMillis(), "1", Arrays.asList("test"),
-					null, null, "1", "1"));
+					null, null, "1"));
 
 			receiverClient.receiveTaskEndEvent(new TaskEndEvent(System
 					.currentTimeMillis(), "1", Arrays.asList("test"), null,
-					null, "1", "1", "1", Arrays.asList("test"), "test",
+					null, "1", "1", Arrays.asList("test"), "test",
 					new HashMap<String, Object>()));
 
 			receiverClient.receiveTaskFailedEvent(new TaskFailedEvent(System
 					.currentTimeMillis(), "1", Arrays.asList("test"), null,
-					null, "1", "1", "1", Arrays.asList("test"), "test",
+					null, "1", "1", Arrays.asList("test"), "test",
 					new HashMap<String, Object>()));
 
 			receiverClient.receiveTaskStartEvent(new TaskStartEvent(System
 					.currentTimeMillis(), "1", Arrays.asList("test"), null,
-					null, "1", "1", "1", Arrays.asList("test")));
+					null, "1", "1", Arrays.asList("test")));
 			receiverClient
 			.receiveSessionScoreUpdateEvent(new SessionScoreUpdateEvent(
 					System.currentTimeMillis(), "1", Arrays


### PR DESCRIPTION
The REST messages contained reference to simulator-specific ID for tasks
and processes. This implied that the other component had to use the sim
REST API to translate these simulator-specific IDs into known ones.
This commit replaces all simulator specific events IDs with shared ones,
and modifies the various implementations accordingly.

This PR also include a bunch of internal simulator improvements/fixes regarding events.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/learnpad/learnpad/327)
<!-- Reviewable:end -->
