### PR TITLE
[sim] SimWebUI shows total score on session end

### DIFF
--- a/lp-simulation-environment/simulator/src/main/resources/static/TaskReceiver.js
+++ b/lp-simulation-environment/simulator/src/main/resources/static/TaskReceiver.js
@@ -140,6 +140,9 @@ function taskReceiver(address, user, integratedMode) {
         case 'SESSION_FINISHED':
             var containerDiv = $('#processmain' + msg.sessionid);
             var processFinished = document.createElement('p');
+
+            var totalScore = 0;
+
             var result = '<h4>Congratulations, you successfully completed the simulation</h4>';
             result += '<p>Score Summary:</p>';
             result += '<table class="detailed-score table table-striped table-condensed">';
@@ -148,7 +151,11 @@ function taskReceiver(address, user, integratedMode) {
             for(var aTask in msg.tasknames) {
                 result += '<tr><td>' + msg.tasknames[aTask] + '</td><td>' +
                     msg.taskscores[aTask] +'</td></tr>';
+
+                totalScore += msg.taskscores[aTask];
             }
+
+            result += '<tr><td><i>Total session score</i></td><td><i>' + totalScore + '</i></td></tr>';
             result += '</table>';
 
             processFinished.innerHTML = result;


### PR DESCRIPTION
The Sim Web Ui now shows the total score under the tasks scores in the
summary table at the end of a simulation session.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/learnpad/learnpad/330)
<!-- Reviewable:end -->
