### PR TITLE
[sim] Fix missing modelsetid in events

### DIFF
--- a/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/IProcessManager.java
+++ b/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/IProcessManager.java
@@ -265,6 +265,13 @@ public interface IProcessManager {
 	public String getModelSetId(String processDefId);
 
 	/**
+	 * @param sessionId
+	 * @return the model set id associated with a session Id, or null if no
+	 *         model set is associated to the session Id
+	 */
+	public String getModelSetIdFromSessionId(String sessionId);
+
+	/**
 	 *
 	 * @param simulationSessionId
 	 * @return the parameters data that have been used to instanciate the

--- a/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/monitoring/activiti/ProbeEventReceiver.java
+++ b/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/monitoring/activiti/ProbeEventReceiver.java
@@ -132,7 +132,7 @@ public class ProbeEventReceiver extends GlimpseAbstractProbe implements
 						event.timestamp,
 						event.simulationsessionid,
 						new ArrayList<String>(event.involvedusers),
-						manager.getModelSetId(event.initialProcessDefinitionKey),
+						manager.getModelSetIdFromSessionId(event.initialProcessDefinitionKey),
 						manager.getSimulationSessionParametersData(event.simulationsessionid)));
 
 		send(monitoringEvent);
@@ -152,7 +152,7 @@ public class ProbeEventReceiver extends GlimpseAbstractProbe implements
 						event.timestamp,
 						event.simulationsessionid,
 						new ArrayList<String>(event.involvedusers),
-						manager.getModelSetId(event.simulationsessionid),
+						manager.getModelSetIdFromSessionId(event.simulationsessionid),
 						manager.getSimulationSessionParametersData(event.simulationsessionid)));
 
 		send(monitoringEvent);
@@ -172,7 +172,7 @@ public class ProbeEventReceiver extends GlimpseAbstractProbe implements
 						event.timestamp,
 						event.simulationsessionid,
 						new ArrayList<String>(event.involvedusers),
-						manager.getModelSetId(event.simulationsessionid),
+						manager.getModelSetIdFromSessionId(event.simulationsessionid),
 						manager.getSimulationSessionParametersData(event.simulationsessionid),
 						event.processInstance.processartifactkey));
 
@@ -193,7 +193,7 @@ public class ProbeEventReceiver extends GlimpseAbstractProbe implements
 						event.timestamp,
 						event.simulationsessionid,
 						new ArrayList<String>(event.involvedusers),
-						manager.getModelSetId(event.simulationsessionid),
+						manager.getModelSetIdFromSessionId(event.simulationsessionid),
 						manager.getSimulationSessionParametersData(event.simulationsessionid),
 						event.processInstance.processartifactkey));
 		send(monitoringEvent);
@@ -213,7 +213,7 @@ public class ProbeEventReceiver extends GlimpseAbstractProbe implements
 						event.timestamp,
 						event.simulationsessionid,
 						new ArrayList<String>(event.involvedusers),
-						manager.getModelSetId(event.simulationsessionid),
+						manager.getModelSetIdFromSessionId(event.simulationsessionid),
 						manager.getSimulationSessionParametersData(event.simulationsessionid),
 						manager.getProcessInstanceInfos(event.task.processId).processartifactkey,
 						event.task.key, new ArrayList<String>(
@@ -236,7 +236,7 @@ public class ProbeEventReceiver extends GlimpseAbstractProbe implements
 						event.timestamp,
 						event.simulationsessionid,
 						new ArrayList<String>(event.involvedusers),
-						manager.getModelSetId(event.simulationsessionid),
+						manager.getModelSetIdFromSessionId(event.simulationsessionid),
 						manager.getSimulationSessionParametersData(event.simulationsessionid),
 						manager.getProcessInstanceInfos(event.task.processId).processartifactkey,
 						event.task.key, new ArrayList<String>(
@@ -260,7 +260,7 @@ public class ProbeEventReceiver extends GlimpseAbstractProbe implements
 						event.timestamp,
 						event.simulationsessionid,
 						new ArrayList<String>(event.involvedusers),
-						manager.getModelSetId(event.simulationsessionid),
+						manager.getModelSetIdFromSessionId(event.simulationsessionid),
 						manager.getSimulationSessionParametersData(event.simulationsessionid),
 						manager.getProcessInstanceInfos(event.task.processId).processartifactkey,
 						event.task.key, new ArrayList<String>(
@@ -284,7 +284,7 @@ public class ProbeEventReceiver extends GlimpseAbstractProbe implements
 						event.timestamp,
 						event.simulationsessionid,
 						new ArrayList<String>(event.involvedusers),
-						manager.getModelSetId(event.simulationsessionid),
+						manager.getModelSetIdFromSessionId(event.simulationsessionid),
 						manager.getSimulationSessionParametersData(event.simulationsessionid),
 						manager.getProcessInstanceInfos(event.processid).processartifactkey,
 						event.user, event.sessionscore));

--- a/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/processmanager/activiti/ActivitiProcessManager.java
+++ b/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/processmanager/activiti/ActivitiProcessManager.java
@@ -114,6 +114,10 @@ public class ActivitiProcessManager implements IProcessManager,
 
 	private final Map<String, Map<String, Map<LearnPadTask, Integer>>> taskScoresByUsersBySession = new HashMap<>();
 
+	private final Map<String, String> processDefToModelSet = new ConcurrentHashMap<String, String>();
+
+	private final Map<String, String> simSessionIdToModelSet = new ConcurrentHashMap<String, String>();
+
 	public ActivitiProcessManager(
 			ProcessEngine processEngine,
 			IProcessEventReceiver.IProcessEventReceiverProvider processEventReceiverProvider,
@@ -345,6 +349,11 @@ public class ActivitiProcessManager implements IProcessManager,
 			// register session parameters data
 			sessionParametersData.put(simSession, parameters);
 
+			if (processDefToModelSet.containsKey(projectDefinitionKey)) {
+				simSessionIdToModelSet.put(simSession,
+						processDefToModelSet.get(projectDefinitionKey));
+			}
+
 			// signal simulation session start
 			// signal process start
 			this.processEventReceiverProvider.processEventReceiver()
@@ -490,6 +499,7 @@ public class ActivitiProcessManager implements IProcessManager,
 			nbProcessesBySession.remove(simSession);
 			usersBySession.remove(simSession);
 			sessionParametersData.remove(simSession);
+			simSessionIdToModelSet.remove(simSession);
 
 			taskScoresByUsersBySession.remove(simSession);
 		}
@@ -641,8 +651,6 @@ public class ActivitiProcessManager implements IProcessManager,
 
 	// // ModelSetId related methods
 
-	private final Map<String, String> processDefToModelSet = new ConcurrentHashMap<String, String>();
-
 	@Override
 	public void setModelSetId(String processDefId, String modelSetId) {
 		processDefToModelSet.put(processDefId, modelSetId);
@@ -651,6 +659,11 @@ public class ActivitiProcessManager implements IProcessManager,
 	@Override
 	public String getModelSetId(String processDefId) {
 		return processDefToModelSet.get(processDefId);
+	}
+
+	@Override
+	public String getModelSetIdFromSessionId(String sessionId) {
+		return simSessionIdToModelSet.get(sessionId);
 	}
 
 	@Override


### PR DESCRIPTION
A bug caused the modelsetid to be missing in events sent to the monitoring subcomponent. This PR fixes the problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/learnpad/learnpad/338)
<!-- Reviewable:end -->
