### PR TITLE
[sim] Clean sim session data passed to glimpse

### DIFF
--- a/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/monitoring/activiti/ProbeEventReceiver.java
+++ b/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/monitoring/activiti/ProbeEventReceiver.java
@@ -4,6 +4,8 @@
 package eu.learnpad.simulator.monitoring.activiti;
 
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
 
 import javax.jms.JMSException;
 import javax.naming.NamingException;
@@ -30,6 +32,7 @@ import eu.learnpad.simulator.monitoring.event.impl.SimulationStartSimEvent;
 import eu.learnpad.simulator.monitoring.event.impl.TaskEndSimEvent;
 import eu.learnpad.simulator.monitoring.event.impl.TaskFailedSimEvent;
 import eu.learnpad.simulator.monitoring.event.impl.TaskStartSimEvent;
+import eu.learnpad.simulator.processmanager.activiti.ActivitiProcessManager;
 import eu.learnpad.simulator.utils.SimulatorProperties;
 
 /*
@@ -194,7 +197,7 @@ public class ProbeEventReceiver extends GlimpseAbstractProbe implements
 						event.simulationsessionid,
 						new ArrayList<String>(event.involvedusers),
 						manager.getModelSetIdFromSessionId(event.simulationsessionid),
-						manager.getSimulationSessionParametersData(event.simulationsessionid),
+						getCleanSessionParameters(event.simulationsessionid),
 						event.processInstance.processartifactkey));
 		send(monitoringEvent);
 
@@ -214,7 +217,7 @@ public class ProbeEventReceiver extends GlimpseAbstractProbe implements
 						event.simulationsessionid,
 						new ArrayList<String>(event.involvedusers),
 						manager.getModelSetIdFromSessionId(event.simulationsessionid),
-						manager.getSimulationSessionParametersData(event.simulationsessionid),
+						getCleanSessionParameters(event.simulationsessionid),
 						manager.getProcessInstanceInfos(event.task.processId).processartifactkey,
 						event.task.key, new ArrayList<String>(
 								event.involvedusers)));
@@ -237,7 +240,7 @@ public class ProbeEventReceiver extends GlimpseAbstractProbe implements
 						event.simulationsessionid,
 						new ArrayList<String>(event.involvedusers),
 						manager.getModelSetIdFromSessionId(event.simulationsessionid),
-						manager.getSimulationSessionParametersData(event.simulationsessionid),
+						getCleanSessionParameters(event.simulationsessionid),
 						manager.getProcessInstanceInfos(event.task.processId).processartifactkey,
 						event.task.key, new ArrayList<String>(
 								event.involvedusers), event.completingUser,
@@ -261,7 +264,7 @@ public class ProbeEventReceiver extends GlimpseAbstractProbe implements
 						event.simulationsessionid,
 						new ArrayList<String>(event.involvedusers),
 						manager.getModelSetIdFromSessionId(event.simulationsessionid),
-						manager.getSimulationSessionParametersData(event.simulationsessionid),
+						getCleanSessionParameters(event.simulationsessionid),
 						manager.getProcessInstanceInfos(event.task.processId).processartifactkey,
 						event.task.key, new ArrayList<String>(
 								event.involvedusers), event.completingUser,
@@ -285,12 +288,26 @@ public class ProbeEventReceiver extends GlimpseAbstractProbe implements
 						event.simulationsessionid,
 						new ArrayList<String>(event.involvedusers),
 						manager.getModelSetIdFromSessionId(event.simulationsessionid),
-						manager.getSimulationSessionParametersData(event.simulationsessionid),
+						getCleanSessionParameters(event.simulationsessionid),
 						manager.getProcessInstanceInfos(event.processid).processartifactkey,
 						event.user, event.sessionscore));
 
 		send(monitoringEvent);
 
+	}
+
+	/**
+	 * Remove useless internal additional data from the parameters associated
+	 * with a sim. session
+	 *
+	 * @param simSessionId
+	 * @return the cleaned map
+	 */
+	private Map<String, Object> getCleanSessionParameters(String simSessionId) {
+		Map<String, Object> res = new HashMap<>(
+				manager.getSimulationSessionParametersData(simSessionId));
+		res.remove(ActivitiProcessManager.SIMULATION_ID_KEY);
+		return res;
 	}
 
 }


### PR DESCRIPTION
When passing sim session data to the glimpse probe, clean some useless
stuff added by the simulator for internal management.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/learnpad/learnpad/376)
<!-- Reviewable:end -->
