### PR TITLE
[sim] remove TODO from y2demo data object

### DIFF
--- a/lp-simulation-environment/simulator/src/main/resources/dataobjects/SCIA_DataObject1
+++ b/lp-simulation-environment/simulator/src/main/resources/dataobjects/SCIA_DataObject1
@@ -1,3 +1,2 @@
 accepted,"Is this application acceptable?",enum,true,"",true,Yes,false,No
-kpis,"TODO: need some KPIs here",string,false,""
 explaination,"Reason of non-acceptation (if rejected)",textarea,false,""


### PR DESCRIPTION
Remove TODO line from one of the Y2 demo data objects. Sadly this was
not fixed in time for the demo.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/learnpad/learnpad/385)
<!-- Reviewable:end -->
