### PR TITLE
[sim] Check sessionStorage errors in WebUI

### DIFF
--- a/lp-simulation-environment/simulator/src/main/resources/static/Task-jsonform.js
+++ b/lp-simulation-environment/simulator/src/main/resources/static/Task-jsonform.js
@@ -42,9 +42,25 @@ function taskFormGenerate(taskid, data, formContainer, formId, callback) {
 }
 
 function saveFormContent(taskid, values) {
-    sessionStorage.setItem(taskid, JSON.stringify(values));
+    try {
+        if (window.sessionStorage) {
+            sessionStorage.setItem(taskid, JSON.stringify(values));
+        }
+    } catch (exception) {
+        // nothing more we can do
+    }
 }
 
 function retrieveFormContent(taskid) {
-    return JSON.parse(sessionStorage.getItem(taskid));
+    try {
+        if (window.sessionStorage) {
+            if (window.sessionStorage && window.sessionStorage.getItem(taskid)) {
+                return JSON.parse(sessionStorage.getItem(taskid));
+            }
+        }
+    } catch (exception) {
+        // do nothing, we will return default value
+    }
+    // default return value in case of null or failure
+    return null;
 }


### PR DESCRIPTION
WebUI now checks if it has access to sessionStorage functionalitites
before trying to use them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/learnpad/learnpad/406)
<!-- Reviewable:end -->
