### PR TITLE
[cw] Introduce CW API to store and fetch session score items

### DIFF
--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/cw/BridgeInterface.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/cw/BridgeInterface.java
@@ -28,8 +28,9 @@ import eu.learnpad.cw.rest.GetResource;
 import eu.learnpad.cw.rest.ModelSetImported;
 import eu.learnpad.cw.rest.ModelVerified;
 import eu.learnpad.cw.rest.NotifyRecommendations;
+import eu.learnpad.cw.rest.ScoreUpdateReceiver;
 
 @Path("/learnpad/cw/bridge")
 public interface BridgeInterface extends GetComments, GetFeedbacks, GetResource, ModelSetImported, ContentVerified,
-		ModelVerified, NotifyRecommendations {
+		ModelVerified, NotifyRecommendations, ScoreUpdateReceiver {
 }

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/cw/rest/ScoreUpdateReceiver.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/cw/rest/ScoreUpdateReceiver.java
@@ -5,9 +5,9 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.QueryParam;
 
+import eu.learnpad.cw.rest.data.ScoreRecord;
 import eu.learnpad.cw.rest.data.ScoreRecordCollection;
 import eu.learnpad.exception.LpRestException;
-import eu.learnpad.sim.rest.event.impl.SessionScoreUpdateEvent;
 
 /**
  *
@@ -18,8 +18,7 @@ public interface ScoreUpdateReceiver {
 
 	@Path("/scores")
 	@POST
-	public void receiveScoreUpdate(SessionScoreUpdateEvent event)
-			throws LpRestException;
+	public void receiveScoreUpdate(ScoreRecord record) throws LpRestException;
 
 	@Path("/scores")
 	@GET

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/cw/rest/ScoreUpdateReceiver.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/cw/rest/ScoreUpdateReceiver.java
@@ -1,0 +1,28 @@
+package eu.learnpad.cw.rest;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.QueryParam;
+
+import eu.learnpad.cw.rest.data.ScoreRecordCollection;
+import eu.learnpad.exception.LpRestException;
+import eu.learnpad.sim.rest.event.impl.SessionScoreUpdateEvent;
+
+/**
+ *
+ * @author Tom Jorquera - Linagora
+ *
+ */
+public interface ScoreUpdateReceiver {
+
+	@Path("/scores")
+	@POST
+	public void receiveScoreUpdate(SessionScoreUpdateEvent event)
+			throws LpRestException;
+
+	@Path("/scores")
+	@GET
+	public ScoreRecordCollection getScores(@QueryParam("user") String user,
+			@QueryParam("process") String process) throws LpRestException;
+}

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/cw/rest/data/ScoreRecord.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/cw/rest/data/ScoreRecord.java
@@ -1,0 +1,37 @@
+package eu.learnpad.cw.rest.data;
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * Utility method to store a score record
+ *
+ * @author Tom Jorquera - Linagora
+ *
+ */
+@XmlRootElement
+public class ScoreRecord {
+	public String userArtifactId;
+	public String processArtifactId;
+	public String sessionId;
+	public long score;
+
+	public ScoreRecord() {
+		super();
+	}
+
+	public ScoreRecord(String userArtifactId, String processArtifactId,
+			String sessionId, long score) {
+		this();
+		this.userArtifactId = userArtifactId;
+		this.processArtifactId = processArtifactId;
+		this.sessionId = sessionId;
+		this.score = score;
+	}
+
+	@Override
+	public String toString() {
+		return "ScoreRecord : { userArtifactId " + userArtifactId
+				+ ", processArtifactId " + processArtifactId + ", sessionId "
+				+ sessionId + ", score " + score + " }";
+	}
+}

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/cw/rest/data/ScoreRecordCollection.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/cw/rest/data/ScoreRecordCollection.java
@@ -1,0 +1,33 @@
+package eu.learnpad.cw.rest.data;
+
+import java.util.Collection;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * Utility method to store a set of {@link eu.learnpad.cw.rest.data.ScoreRecord
+ * ScoreRecords}
+ *
+ * @author Tom Jorquera - Linagora
+ *
+ */
+@XmlRootElement
+public class ScoreRecordCollection {
+	@XmlElement(name = "record")
+	public Collection<ScoreRecord> content;
+
+	public ScoreRecordCollection() {
+		super();
+	}
+
+	public ScoreRecordCollection(Collection<ScoreRecord> content) {
+		this();
+		this.content = content;
+	}
+
+	@Override
+	public String toString() {
+		return content.toString();
+	}
+}

--- a/lp-core-platform/lp-cp-xwiki-implementation/src/main/java/eu/learnpad/core/impl/sim/XwikiController.java
+++ b/lp-core-platform/lp-cp-xwiki-implementation/src/main/java/eu/learnpad/core/impl/sim/XwikiController.java
@@ -36,6 +36,7 @@ import org.xwiki.rest.XWikiRestComponent;
 import eu.learnpad.core.rest.DefaultRestResource;
 import eu.learnpad.core.rest.RestResource;
 import eu.learnpad.core.rest.Utils;
+import eu.learnpad.cw.rest.data.ScoreRecord;
 import eu.learnpad.exception.LpRestException;
 import eu.learnpad.exception.impl.LpRestExceptionXWikiImpl;
 import eu.learnpad.or.rest.data.Recommendations;
@@ -176,8 +177,9 @@ public class XwikiController extends Controller implements XWikiRestComponent, I
 	}
 
 	@Override
-	public void receiveSessionScoreUpdateEvent(SessionScoreUpdateEvent event) {
-		// TODO Auto-generated method stub
+	public void receiveSessionScoreUpdateEvent(SessionScoreUpdateEvent event) throws LpRestException {
+		this.cw.receiveScoreUpdate(new ScoreRecord(event.user, event.processartifactid,
+				event.simulationsessionid, event.sessionscore));
 	}
 
 	@Override


### PR DESCRIPTION
This PR introduces a new API for the CW that allows to store and fetch session score items.

The goal of the API is to allows the CW web interface to fetch information about the scores obtained by the users during simulations sessions, in order to be able to display them into, e.g., a score leaderboard.

This API optionally allows to fetch scores by user, by process or both.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/learnpad/learnpad/424)
<!-- Reviewable:end -->
