### PR TITLE
Cw cp fix user id for recommendations

### DIFF
--- a/lp-collaborative-workspace/lp-cw-component/lp-cw-component-ui/src/main/resources/LPUI/RecommendationPanel.xml
+++ b/lp-collaborative-workspace/lp-cw-component/lp-cw-component-ui/src/main/resources/LPUI/RecommendationPanel.xml
@@ -155,10 +155,13 @@
 #set ($querystring = "modelsetid=${modelsetid}&amp;modelid=${modelid}")
 #set ($simulationURL = $xwiki.getURL($simulationReference, 'view', $querystring))
 #set ($currentUser = $xcontext.user)
-#set ($userid = $xwiki.getDocument($currentUser).getObject('XWiki.XWikiUsers').getProperty('email').value)
+##
+#if ("$!{currentUser}" != "XWiki.superadmin" &amp;&amp; "$!{currentUser}" != "XWiki.Admin")
+    #set ($userid = $currentUser)
 {{html clean=false}}
 &lt;div id="panel-metadata" class="hidden" data-websocketurl="${services.websocket.getURL('recommendation')}" data-modelsetid="$!{modelsetid}" data-modelid="$!{modelid}" data-artifactid="$!{artifactid}" data-userid="$!{userid}"&gt;&lt;/div&gt;
 {{/html}}
+#end
 {{/velocity}}</content>
     </property>
     <property>

--- a/lp-core-platform/lp-cp-xwiki-implementation/src/main/java/eu/learnpad/core/impl/cw/XwikiController.java
+++ b/lp-core-platform/lp-cp-xwiki-implementation/src/main/java/eu/learnpad/core/impl/cw/XwikiController.java
@@ -238,6 +238,7 @@ public class XwikiController extends Controller implements XWikiRestComponent, I
 	}
 	
 	private String convertUserID(String userId) throws LpRestException {
+		
 		String wikiName = DefaultRestResource.CORE_REPOSITORY_WIKI;
 		String username = this.removePrefixes(userId);
 		return utils.getEmailAddress(wikiName, username);

--- a/lp-core-platform/lp-cp-xwiki-implementation/src/main/java/eu/learnpad/core/impl/cw/XwikiController.java
+++ b/lp-core-platform/lp-cp-xwiki-implementation/src/main/java/eu/learnpad/core/impl/cw/XwikiController.java
@@ -155,7 +155,8 @@ public class XwikiController extends Controller implements XWikiRestComponent, I
 	@Override
 	public Recommendations getRecommendations(String modelSetId, String artifactId, String userId)
 			throws LpRestException {
-		Recommendations rec = this.or.askRecommendation(modelSetId, artifactId, userId, null);
+		String userEmail = this.convertUserID(userId);
+		Recommendations rec = this.or.askRecommendation(modelSetId, artifactId, userEmail, null);
 		return rec;
 	}
 
@@ -235,5 +236,12 @@ public class XwikiController extends Controller implements XWikiRestComponent, I
 		String username = userId.replaceFirst("XWiki\\.", "");
 		return username;
 	}
+	
+	private String convertUserID(String userId) throws LpRestException {
+		String wikiName = DefaultRestResource.CORE_REPOSITORY_WIKI;
+		String username = this.removePrefixes(userId);
+		return utils.getEmailAddress(wikiName, username);
+	}
+
 
 }


### PR DESCRIPTION
Modified CW RecsPanel and the CP in CW Controller in order 
to properly deal with userids. In fact, the CP should be the only responsible to 
convert (if needed) the IDs among the components (in this case CW and OR).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/learnpad/learnpad/427)
<!-- Reviewable:end -->
