### PR TITLE
[sim] fix weird index in build scripts

### DIFF
--- a/lp-simulation-environment/monitoring/scripts_build/build
+++ b/lp-simulation-environment/monitoring/scripts_build/build
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-declare -r __BUILD_SCRIPTS_PATH__="$( cd "$( dirname "${BASH_SOURCE[-1]}" )" && pwd )"
+declare -r __BUILD_SCRIPTS_PATH__="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 source ${__BUILD_SCRIPTS_PATH__}/common
 

--- a/lp-simulation-environment/monitoring/scripts_build/install
+++ b/lp-simulation-environment/monitoring/scripts_build/install
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-declare -r __BUILD_SCRIPTS_PATH__="$( cd "$( dirname "${BASH_SOURCE[-1]}" )" && pwd )"
+declare -r __BUILD_SCRIPTS_PATH__="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 source ${__BUILD_SCRIPTS_PATH__}/common
 

--- a/lp-simulation-environment/monitoring/scripts_build/test
+++ b/lp-simulation-environment/monitoring/scripts_build/test
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-declare -r __BUILD_SCRIPTS_PATH__="$( cd "$( dirname "${BASH_SOURCE[-1]}" )" && pwd )"
+declare -r __BUILD_SCRIPTS_PATH__="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 source ${__BUILD_SCRIPTS_PATH__}/common
 

--- a/lp-simulation-environment/simulator/scripts_build/build
+++ b/lp-simulation-environment/simulator/scripts_build/build
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-declare -r __BUILD_SCRIPTS_PATH__="$( cd "$( dirname "${BASH_SOURCE[-1]}" )" && pwd )"
+declare -r __BUILD_SCRIPTS_PATH__="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 source ${__BUILD_SCRIPTS_PATH__}/common
 

--- a/lp-simulation-environment/simulator/scripts_build/install
+++ b/lp-simulation-environment/simulator/scripts_build/install
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-declare -r __BUILD_SCRIPTS_PATH__="$( cd "$( dirname "${BASH_SOURCE[-1]}" )" && pwd )"
+declare -r __BUILD_SCRIPTS_PATH__="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 source ${__BUILD_SCRIPTS_PATH__}/common
 

--- a/lp-simulation-environment/simulator/scripts_build/test
+++ b/lp-simulation-environment/simulator/scripts_build/test
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-declare -r __BUILD_SCRIPTS_PATH__="$( cd "$( dirname "${BASH_SOURCE[-1]}" )" && pwd )"
+declare -r __BUILD_SCRIPTS_PATH__="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 source ${__BUILD_SCRIPTS_PATH__}/common
 


### PR DESCRIPTION
Sim build scripts contained a weird variation of a one-liner to get
current script directory. This may have been the result of a shortcut
gone wrong...

This worked on recent platforms due to the fact that, when BASH_SOURCE
contains only one element, BASH_SOURCE[-1] == BASH_SOURCE[0]. But it
caused failures on systems with older bash where -1 is not a valid
index (looking at you macos).

This commit fixes this issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/learnpad/learnpad/432)
<!-- Reviewable:end -->
