### PR TITLE
Correct SIM API data attributes visibility

### DIFF
--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/data/ProcessInstanceData.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/data/ProcessInstanceData.java
@@ -33,12 +33,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  *
  */
 public class ProcessInstanceData {
-	private String instanceid;
-	private String processartifactid;
-	private String processartifactkey;
-	private Map<String, Object> parameters;
-	private Collection<String> users;
-	private Map<String, Collection<String>> routes;
+	public String instanceid;
+	public String processartifactid;
+	public String processartifactkey;
+	public Map<String, Object> parameters;
+	public Collection<String> users;
+	public Map<String, Collection<String>> routes;
 
 	public ProcessInstanceData() {
 	};


### PR DESCRIPTION
The visibility of the attributes in the ProcessInstanceData class was
incorrectly changed to private. This modification caused breakage in the
implementation of the API, and has been reverted.