### PR TITLE
Cw fix docs live table headers

### DIFF
--- a/lp-collaborative-workspace/lp-cw-component/lp-cw-component-ui/src/main/resources/LPCode/Translations.xml
+++ b/lp-collaborative-workspace/lp-cw-component/lp-cw-component-ui/src/main/resources/LPCode/Translations.xml
@@ -157,7 +157,9 @@ lpcode.livetable.model.id=ID
 lpcode.livetable.model.name=Model name
 lpcode.livetable.model.type=Type
 lpcode.livetable.model.doc.date=Last update
-lpcode.livetable.model._actions=Actions</content>
+lpcode.livetable.model._actions=Actions
+# Docs livetable
+lpcode.livetable.docs.documenttitle=Title</content>
   <object>
     <name>LPCode.Translations</name>
     <number>0</number>

--- a/lp-collaborative-workspace/lp-cw-component/lp-cw-component-ui/src/main/resources/LPDocs/WebHome.xml
+++ b/lp-collaborative-workspace/lp-cw-component/lp-cw-component-ui/src/main/resources/LPDocs/WebHome.xml
@@ -43,14 +43,12 @@
 == ${services.localization.render('LPDocs.WebHome.welcome')} ==
 
 #set($collist = ['doc.title', 'doc.date', 'doc.author'])
+#set($docTitleDisplay=${services.localization.render('lpcode.livetable.docs.documenttitle')})
 #set($colprops = {
- 'doc.title' : { 'type' : 'text' , 'size' : 30, 'link' : 'view' },
+ 'doc.title' : { 'type' : 'text' , 'size' : 30, 'link' : 'view', 'displayName' : "${docTitleDisplay}" },
  'doc.date' : { 'type' : 'date' },
  'doc.author' : { 'type' : 'text', 'link' : 'author' }
 })
-## XWIKI does not support defaut translation for the keyword "title"
-#set($xe.index.doc.title=${services.localization.render('lpcode.livetable.docs.documenttitle')})
-#set($xe.index.doc.title="Zago")
 #set($options = {
  'translationPrefix' : 'xe.index.',
  'rowCount' : 15,

--- a/lp-collaborative-workspace/lp-cw-component/lp-cw-component-ui/src/main/resources/LPDocs/WebHome.xml
+++ b/lp-collaborative-workspace/lp-cw-component/lp-cw-component-ui/src/main/resources/LPDocs/WebHome.xml
@@ -48,6 +48,9 @@
  'doc.date' : { 'type' : 'date' },
  'doc.author' : { 'type' : 'text', 'link' : 'author' }
 })
+## XWIKI does not support defaut translation for the keyword "title"
+#set($xe.index.doc.title=${services.localization.render('lpcode.livetable.docs.documenttitle')})
+#set($xe.index.doc.title="Zago")
 #set($options = {
  'translationPrefix' : 'xe.index.',
  'rowCount' : 15,


### PR DESCRIPTION
this fixes the header of the livetable and enable the right translation as reported by issue #451

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/learnpad/learnpad/466)
<!-- Reviewable:end -->
