### PR TITLE
Issues in the Generation Process (#359)

### DIFF
--- a/lp-model-transformer/src/main/resources/transformation/ado2xwiki.atl
+++ b/lp-model-transformer/src/main/resources/transformation/ado2xwiki.atl
@@ -611,6 +611,21 @@ rule CONNECTORType2Object {
 	}
 }
 
+helper context ADOXX!CONNECTORType def : getDenomination : String =
+	self.aTTRIBUTE->select(i | i.name = 'Denomination' and i.type = 'STRING' )->first().value;
+
+rule CONNECTORTypeSubsequent2Object extends CONNECTORType2Object {
+	from c:ADOXX!CONNECTORType ((c.isInSourceModels > 0) and (c.class='Subsequent'))
+	to lco:XWIKI!Object (
+		property <- Sequence{lco_p1, lco_p2, lco_p3, lco_p4, lco_p5}
+	), 
+	lco_p5:XWIKI!Property (
+		name <- 'denomination',
+		type <- 'String',
+		value <- c.getDenomination
+	)
+}
+
 rule IREFTypeObjRef2Object {
 	from
 		i: ADOXX!IREFType (


### PR DESCRIPTION
Referring to the issues in the Generation Process (#359) with this pull request I have corrected the point number 1: "in the gateway pages the information about the description of the possible alternatives (expressed on the edges) is lost. I would be nice to report it close to each name of the following task. See an example here : http://testbed.learnpad.eu/xwiki/bin/view/LP_ME_ADOXX_MODELSET_28600/mod.30048/obj.30067/".

The correction consists in a new Property that will be processed by XWIKI of name: Denomination with value (yes or no) depending from the processed Gateway.

About issue number 2: "the section "crossing model" of the pages concerning sub-processes is not reporting the link enabling the browsing mode of the sub-process. See an example here : http://testbed.learnpad.eu/xwiki/bin/view/LP_ME_ADOXX_MODELSET_28600/mod.30048/obj.30061/", I have checked both the models and the transformation results. 
The transformation process the link about the subprocess (id: obj.30061, Manage Service Conference) and the results is following reported:

Object:
  className: LPCode.LinkClass
  number: 4
  wiki: xwiki 
  space:LP_ME_ADOXX_MODELSET_28600//spaces//mod.30048//spaces//obj.30061
  pageName: WebHome
  Property:
    name: id
    type: String
    value:
  Property:
    name: targetmodelsetid
    type: String
    value: LP_ME_ADOXX_MODELSET_28600
  Property:
    name: targetmodelid
    type: String
    value:mod.30278
  Property:
    name: targetartifactid
    type: String
    value:
  Property:
    name: type
    type: StaticList
    value:outgoing-weaving

Object:
  className: LPCode.LinkClass
  number: 1
  wiki: xwiki 
  space:LP_ME_ADOXX_MODELSET_28600//spaces//mod.30278
  pageName: WebHome 
  Property:
    name: id
    type: String
    value:
  Property:
    name: targetmodelsetid
    type: String
    value:LP_ME_ADOXX_MODELSET_28600
  Property:
    name: targetmodelid
    type: String
    value:mod.30048
  Property:
    name: targetartifactid
    type: String
    value: obj.30061
  Property:
    name: type
    type: StaticList
    value:incoming-weaving

I kindly ask the XWiki team to let me know what else informations are required in order to resolve the issue, if the problem arise from the transformation.


About issues number 3 and 4 I am working on it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/learnpad/learnpad/467)
<!-- Reviewable:end -->
