### PR TITLE
[sim] fix build script to do global stop on errors

### DIFF
--- a/lp-simulation-environment/build
+++ b/lp-simulation-environment/build
@@ -31,7 +31,7 @@ function component_build() {
         simulator/scripts_build/build
         STATUS=$?
         if [ $STATUS -ne 0 ]; then
-                exit $?
+            exit $STATUS
         fi
     fi
 }
@@ -42,12 +42,12 @@ function component_test() {
     STATUS=$?
     if [ $STATUS -ne 0 ]; then
         # if failed return error
-        exit 1;
+        exit $STATUS;
     else
         simulator/scripts_build/test;
         STATUS=$?
         if [ $STATUS -ne 0 ]; then
-                exit $?
+            exit $STATUS
         fi
     fi
 }


### PR DESCRIPTION
Sim build script contained mistakes causing it not to return an error on
failure. This caused the global script process to continue even when it
should have stopped due to error.

This commit fixes the script to return a correct error value.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/learnpad/learnpad/498)
<!-- Reviewable:end -->
