### PR TITLE
[sim][mon] Add integration for score probe

### DIFF
--- a/lp-simulation-environment/monitoring/src/main/java/eu/learnpad/simulator/mon/consumer/GlimpseAbstractConsumer.java
+++ b/lp-simulation-environment/monitoring/src/main/java/eu/learnpad/simulator/mon/consumer/GlimpseAbstractConsumer.java
@@ -1,0 +1,534 @@
+package eu.learnpad.simulator.mon.consumer;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Properties;
+
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.ObjectMessage;
+import javax.jms.Session;
+import javax.jms.TextMessage;
+import javax.jms.Topic;
+import javax.jms.TopicConnection;
+import javax.jms.TopicConnectionFactory;
+import javax.jms.TopicPublisher;
+import javax.jms.TopicSession;
+import javax.jms.TopicSubscriber;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+
+import org.apache.commons.net.ntp.TimeStamp;
+import org.apache.xmlbeans.XmlException;
+
+import eu.learnpad.simulator.mon.exceptions.IncorrectRuleFormatException;
+import eu.learnpad.simulator.mon.utils.DebugMessages;
+import eu.learnpad.simulator.mon.utils.Manager;
+import it.cnr.isti.labse.glimpse.xml.complexEventRule.ComplexEventRuleActionListDocument;
+
+/**
+ *
+ * This class represent a generic implementation of the interface
+ * {@link GlimpseConsumer}.<br />
+ * It provides for extension, the abstract method:
+ * {@link #messageReceived(Message)}<br />
+ * <br />
+ *
+ * @author Antonello Calabr&ograve;
+ * @version 3.2
+ */
+public abstract class GlimpseAbstractConsumer implements GlimpseConsumer {
+
+	protected static TopicConnection connection;
+	protected static boolean firstMessage = true;
+	protected static InitialContext initContext;
+	protected Properties settings;
+
+	/**
+	 * This method setup the connection
+	 *
+	 * @param settings,
+	 *         the settings properties for the connection to the Monitoring
+	 *         infrastructure. The Properties object may also be created using the
+	 *         method
+	 *         {@link Manager#createConsumerSettingsPropertiesObject(String, String, String, String, String, String, boolean, String)}
+	 */
+	protected void init(Properties settings) {
+		try {
+			this.settings = settings;
+			initContext = this.initConnection(settings, true);
+			connection = this.createConnection(initContext, settings, true);
+			TopicSubscriber tSub = this.createSubscriber(connection, initContext, "serviceTopic", true);
+			tSub.setMessageListener(this);
+		} catch (NamingException e) {
+			e.printStackTrace();
+		} catch (JMSException e) {
+			e.printStackTrace();
+		}
+	}
+
+	/**
+	 *
+	 * This constructor allow to create a {@link GlimpseAbstractConsumer}
+	 * object<br />
+	 * providing the {@link #settings} properties and a {@link String} object that
+	 * will be<br />
+	 * automatically converted to a {@link ComplexEventRuleActionListDocument}
+	 * object.<br />
+	 *
+	 * @param settings
+	 *         can be generated automatically using
+	 *         {@link Manager#createConsumerSettingsPropertiesObject(String, String, String, String, String, String, boolean, String)}.
+	 * @param plainTextRule
+	 *         a plain text rule is a String containing the Drools<br />
+	 *         (or other cep engine implemented) rule that can be generated
+	 *         structured<br />
+	 *         using the {@link ComplexEventRuleActionListDocument} classes.<br />
+	 *         For a rule example see the exampleRule.xml file.
+	 */
+
+	public GlimpseAbstractConsumer(Properties settings, String plainTextRule, String usersInvolvedID, String sessionID,
+			String bpmnID) {
+		init(settings);
+		try {
+			this.sendTextMessageWithLearnersList(connection, initContext, "serviceTopic", plainTextRule, usersInvolvedID,
+					sessionID, bpmnID, true);
+		} catch (JMSException e) {
+			e.printStackTrace();
+		} catch (NamingException e) {
+			e.printStackTrace();
+		}
+	}
+
+	/**
+	 *
+	 * This constructor allow to create a {@link GlimpseAbstractConsumer}
+	 * object<br />
+	 * providing the {@link #settings} properties and a
+	 * {@link ComplexEventRuleActionListDocument} object.
+	 *
+	 * @param settings
+	 *         can be generated automatically using
+	 *         {@link Manager#createConsumerSettingsPropertiesObject(String, String, String, String, String, String, boolean, String)}.
+	 * @param complexEventRuleXML
+	 *         a {@link ComplexEventRuleActionListDocument} object<br />
+	 *         that contains the set of rule that will be loaded on the CEP
+	 *         knowledge base for the evaluation. The
+	 *         {@link ComplexEventRuleActionListDocument} object, can be generated
+	 *         from a string, using the method
+	 */
+	public GlimpseAbstractConsumer(Properties settings, ComplexEventRuleActionListDocument complexEventRuleXML) {
+
+		try {
+			init(settings);
+			this.sendActionListMessage(connection, initContext, "serviceTopic", complexEventRuleXML, true);
+		} catch (NamingException e) {
+			e.printStackTrace();
+		} catch (JMSException e) {
+			e.printStackTrace();
+		}
+	}
+
+	public GlimpseAbstractConsumer(Properties settings, String messagePayload, List<String> learnersInvolved,
+			String sessionID, String bpmnID) {
+		try {
+			init(settings);
+			this.sendTextMessageWithLearnersListAsArray(connection, initContext, "serviceTopic", messagePayload,
+					learnersInvolved, sessionID, bpmnID, true);
+		} catch (NamingException e) {
+			e.printStackTrace();
+		} catch (JMSException e) {
+			e.printStackTrace();
+		}
+	}
+
+	private void sendTextMessageWithLearnersListAsArray(TopicConnection connection, InitialContext initContext,
+			String serviceTopic, String messagePayload, List<String> learnersInvolved, String sessionID, String bpmnID,
+			boolean debug) throws NamingException, JMSException {
+
+		if (debug) {
+			DebugMessages.print(TimeStamp.getCurrentTime(), this.getClass().getSimpleName(), "Creating Session ");
+		}
+		TopicSession publishSession = connection.createTopicSession(false, Session.AUTO_ACKNOWLEDGE);
+		if (debug) {
+			DebugMessages.ok();
+			DebugMessages.print(TimeStamp.getCurrentTime(), this.getClass().getSimpleName(), "Looking up for channel ");
+		}
+		Topic connectionTopic = (Topic) initContext.lookup(serviceTopic);
+		if (debug) {
+			DebugMessages.ok();
+			DebugMessages.print(TimeStamp.getCurrentTime(), this.getClass().getSimpleName(), "Creating Publisher ");
+		}
+		TopicPublisher tPub = publishSession.createPublisher(connectionTopic);
+		if (debug) {
+			DebugMessages.ok();
+			DebugMessages.print(TimeStamp.getCurrentTime(), this.getClass().getSimpleName(), "Creating Message ");
+		}
+		TextMessage sendMessage = publishSession.createTextMessage();
+		sendMessage.setObjectProperty("USERSINVOLVEDID", learnersInvolved);
+		sendMessage.setStringProperty("SESSIONID", sessionID);
+		sendMessage.setStringProperty("BPMNID", bpmnID);
+		sendMessage.setStringProperty("SENDER", settings.getProperty("consumerName"));
+		sendMessage.setStringProperty("DESTINATION", "monitor");
+		sendMessage.setText(messagePayload);
+		if (debug) {
+			DebugMessages.ok();
+			DebugMessages.print(TimeStamp.getCurrentTime(), this.getClass().getSimpleName(), "Publishing message  ");
+		}
+		tPub.publish(sendMessage);
+		if (debug) {
+			DebugMessages.ok();
+			DebugMessages.line();
+		}
+
+	}
+
+	/*
+	 * (non-Javadoc)
+	 *
+	 * @see javax.jms.MessageListener#onMessage(javax.jms.Message)
+	 */
+	@Override
+	public void onMessage(Message arg0) {
+		try {
+			if (firstMessage) {
+				TextMessage msg = (TextMessage) arg0;
+				TopicSubscriber newTopic;
+				try {
+					System.out.println("unused = " + this.getAnswerTopicFromTextMessage(msg));
+					newTopic = this.connectToTheResponseChannel(connection, "scoresUpdateResponses", true);
+					newTopic.setMessageListener(this);
+				} catch (IncorrectRuleFormatException e) {
+					System.out.println("IncorrectRuleFromatException raised: INVALID RULE");
+				}
+				firstMessage = false;
+			}
+		} catch (JMSException e) {
+			e.printStackTrace();
+		}
+	}
+
+	/**
+	 * This method can be used when extending this abstract class to<br />
+	 * modify the management of received messages.
+	 *
+	 * @param arg0
+	 *         the received Message
+	 * @throws JMSException
+	 */
+	public abstract void messageReceived(Message arg0) throws JMSException;
+
+	/**
+	 * This method setup the connection parameters using the {@link Properties}
+	 * object {@link #settings}
+	 *
+	 * @param settings
+	 *         the parameter to setup the connection to the Enterprise Service Bus
+	 * @param debug
+	 *         the debug value
+	 * @return it provides an {@link InitialContext} object that will be used<br />
+	 *         during the Consumer <-> Monitoring interaction.
+	 * @throws NamingException
+	 */
+	protected InitialContext initConnection(Properties settings, boolean debug) throws NamingException {
+		if (debug)
+			DebugMessages.print(TimeStamp.getCurrentTime(), this.getClass().getSimpleName(),
+					"Creating InitialContext with settings ");
+		InitialContext initConn = new InitialContext(settings);
+		if (debug) {
+			DebugMessages.ok();
+			DebugMessages.line();
+		}
+		return initConn;
+	}
+
+	/**
+	 * This method setup a {@link TopicConnection} object.
+	 *
+	 * @param initConn
+	 *         the InitialContext object generated using the method
+	 *         {@link GlimpseAbstractConsumer#initConnection(Properties, boolean)}.
+	 * @param settings
+	 *         can be generated automatically using
+	 *         {@link GlimpseAbstractConsumer#createSettingsPropertiesObject(String, String, String, String, String, String, boolean, String)};
+	 * @param debug
+	 * @return a TopicConnection object.
+	 * @throws NamingException
+	 * @throws JMSException
+	 */
+	protected TopicConnection createConnection(InitialContext initConn, Properties settings, boolean debug)
+			throws NamingException, JMSException {
+		if (debug)
+			DebugMessages.print(TimeStamp.getCurrentTime(), this.getClass().getSimpleName(),
+					"Creating ConnectionFactory with settings ");
+		TopicConnectionFactory connFact = (TopicConnectionFactory) initConn
+				.lookup(settings.getProperty("connectionFactoryNames"));
+		if (debug) {
+			DebugMessages.ok();
+			DebugMessages.print(TimeStamp.getCurrentTime(), this.getClass().getSimpleName(), "Creating TopicConnection ");
+		}
+		TopicConnection connection = connFact.createTopicConnection();
+		if (debug) {
+			DebugMessages.ok();
+			DebugMessages.line();
+		}
+		return connection;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 *
+	 * @see
+	 * it.cnr.isti.labse.glimpse.api.consumer.GlimpseConsumer#sendActionListMessage
+	 * (javax.jms.TopicConnection, javax.naming.InitialContext, java.lang.String,
+	 * it.cnr.isti.labse.glimpse.xml.complexEventRule.
+	 * ComplexEventRuleActionListDocument, boolean)
+	 */
+	@Override
+	public void sendActionListMessage(TopicConnection connection, InitialContext initContext, String serviceChannel,
+			ComplexEventRuleActionListDocument actionList, boolean debug) throws JMSException, NamingException {
+		if (debug) {
+			DebugMessages.print(TimeStamp.getCurrentTime(), this.getClass().getSimpleName(), "Creating Session ");
+		}
+		TopicSession publishSession = connection.createTopicSession(false, Session.AUTO_ACKNOWLEDGE);
+		if (debug) {
+			DebugMessages.ok();
+			DebugMessages.print(TimeStamp.getCurrentTime(), this.getClass().getSimpleName(), "Looking up for channel ");
+		}
+		Topic connectionTopic = (Topic) initContext.lookup(serviceChannel);
+		if (debug) {
+			DebugMessages.ok();
+			DebugMessages.print(TimeStamp.getCurrentTime(), this.getClass().getSimpleName(), "Creating Publisher ");
+		}
+		TopicPublisher tPub = publishSession.createPublisher(connectionTopic);
+		if (debug) {
+			DebugMessages.ok();
+			DebugMessages.print(TimeStamp.getCurrentTime(), this.getClass().getSimpleName(), "Creating Message ");
+		}
+		ObjectMessage sendMessage = publishSession.createObjectMessage();
+		sendMessage.setStringProperty("SENDER", settings.getProperty("consumerName"));
+		sendMessage.setStringProperty("DESTINATION", "monitor");
+		sendMessage.setObject((Serializable) actionList);
+		if (debug) {
+			DebugMessages.ok();
+			DebugMessages.print(TimeStamp.getCurrentTime(), this.getClass().getSimpleName(), "Publishing message  ");
+		}
+		tPub.publish(sendMessage);
+		if (debug) {
+			DebugMessages.ok();
+			DebugMessages.line();
+		}
+	}
+
+	@Override
+	public void sendTextMessage(TopicConnection connection, InitialContext initContext, String serviceChannel,
+			String textToSend, boolean debug) throws JMSException, NamingException {
+		if (debug) {
+			DebugMessages.print(TimeStamp.getCurrentTime(), this.getClass().getSimpleName(), "Creating Session ");
+		}
+		TopicSession publishSession = connection.createTopicSession(false, Session.AUTO_ACKNOWLEDGE);
+		if (debug) {
+			DebugMessages.ok();
+			DebugMessages.print(TimeStamp.getCurrentTime(), this.getClass().getSimpleName(), "Looking up for channel ");
+		}
+		Topic connectionTopic = (Topic) initContext.lookup(serviceChannel);
+		if (debug) {
+			DebugMessages.ok();
+			DebugMessages.print(TimeStamp.getCurrentTime(), this.getClass().getSimpleName(), "Creating Publisher ");
+		}
+		TopicPublisher tPub = publishSession.createPublisher(connectionTopic);
+		if (debug) {
+			DebugMessages.ok();
+			DebugMessages.print(TimeStamp.getCurrentTime(), this.getClass().getSimpleName(), "Creating Message ");
+		}
+		TextMessage sendMessage = publishSession.createTextMessage();
+		sendMessage.setStringProperty("SENDER", settings.getProperty("consumerName"));
+		sendMessage.setStringProperty("DESTINATION", "monitor");
+		sendMessage.setText(textToSend);
+		if (debug) {
+			DebugMessages.ok();
+			DebugMessages.print(TimeStamp.getCurrentTime(), this.getClass().getSimpleName(), "Publishing message  ");
+		}
+		tPub.publish(sendMessage);
+		if (debug) {
+			DebugMessages.ok();
+			DebugMessages.line();
+		}
+	}
+
+	public void sendTextMessageWithLearnersList(TopicConnection connection, InitialContext initContext,
+			String serviceChannel, String textToSend, String usersInvolvedID, String sessionID, String bpmnID, boolean debug)
+			throws JMSException, NamingException {
+		if (debug) {
+			DebugMessages.print(TimeStamp.getCurrentTime(), this.getClass().getSimpleName(), "Creating Session ");
+		}
+		TopicSession publishSession = connection.createTopicSession(false, Session.AUTO_ACKNOWLEDGE);
+		if (debug) {
+			DebugMessages.ok();
+			DebugMessages.print(TimeStamp.getCurrentTime(), this.getClass().getSimpleName(), "Looking up for channel ");
+		}
+		Topic connectionTopic = (Topic) initContext.lookup(serviceChannel);
+		if (debug) {
+			DebugMessages.ok();
+			DebugMessages.print(TimeStamp.getCurrentTime(), this.getClass().getSimpleName(), "Creating Publisher ");
+		}
+		TopicPublisher tPub = publishSession.createPublisher(connectionTopic);
+		if (debug) {
+			DebugMessages.ok();
+			DebugMessages.print(TimeStamp.getCurrentTime(), this.getClass().getSimpleName(), "Creating Message ");
+		}
+		TextMessage sendMessage = publishSession.createTextMessage();
+		sendMessage.setStringProperty("USERSINVOLVEDID", usersInvolvedID);
+		sendMessage.setStringProperty("SESSIONID", sessionID);
+		sendMessage.setStringProperty("BPMNID", bpmnID);
+		sendMessage.setStringProperty("SENDER", settings.getProperty("consumerName"));
+		sendMessage.setStringProperty("DESTINATION", "monitor");
+		sendMessage.setText(textToSend);
+		if (debug) {
+			DebugMessages.ok();
+			DebugMessages.print(TimeStamp.getCurrentTime(), this.getClass().getSimpleName(), "Publishing message  ");
+		}
+		tPub.publish(sendMessage);
+		if (debug) {
+			DebugMessages.ok();
+			DebugMessages.line();
+		}
+	}
+
+	/**
+	 * This method creates a subscriber object to send the evaluation request to
+	 * the monitoring engine.
+	 *
+	 * @param connection
+	 *         the {@link TopicConnection} created using
+	 *         {@link GlimpseAbstractConsumer#createConnection(InitialContext, Properties, boolean)}
+	 *         method
+	 * @param initContext
+	 *         the {@link InitialContext}
+	 * @param serviceChannel
+	 *         the channel where to send the request
+	 * @param debug
+	 * @return a {@link TopicSubscriber} object
+	 * @throws JMSException
+	 * @throws NamingException
+	 */
+	protected TopicSubscriber createSubscriber(TopicConnection connection, InitialContext initContext,
+			String serviceChannel, boolean debug) throws JMSException, NamingException {
+		if (debug) {
+			DebugMessages.print(TimeStamp.getCurrentTime(), this.getClass().getSimpleName(), "Creating Session ");
+		}
+		TopicSession subscribeSession = connection.createTopicSession(false, Session.AUTO_ACKNOWLEDGE);
+		if (debug) {
+			DebugMessages.ok();
+			DebugMessages.print(TimeStamp.getCurrentTime(), this.getClass().getSimpleName(), "Connecting to channel ");
+		}
+		Topic connectionTopic = (Topic) initContext.lookup(serviceChannel);
+		if (debug) {
+			DebugMessages.ok();
+			DebugMessages.print(TimeStamp.getCurrentTime(), this.getClass().getSimpleName(), "Create subscriber ");
+		}
+		TopicSubscriber tSub = subscribeSession.createSubscriber(connectionTopic,
+				"DESTINATION = '" + settings.getProperty("consumerName") + "'", true);
+		if (debug) {
+			DebugMessages.ok();
+			DebugMessages.print(TimeStamp.getCurrentTime(), this.getClass().getSimpleName(), "Starting connection ");
+		}
+		connection.start();
+		if (debug) {
+			DebugMessages.ok();
+			DebugMessages.line();
+		}
+		return tSub;
+	}
+
+	/**
+	 * This method aid to generate a {@link ComplexEventRuleActionListDocument}
+	 * from an XML String
+	 *
+	 * @param xmlRule
+	 *         the XML string containing the rule to send
+	 * @param debug
+	 * @return a {@link ComplexEventRuleActionListDocument} object
+	 * @throws XmlException
+	 * @throws JMSException
+	 */
+	protected ComplexEventRuleActionListDocument createComplexEventRuleActionDocumentFromXMLString(String xmlRule,
+			boolean debug) throws JMSException, XmlException {
+		if (debug)
+			DebugMessages.print(TimeStamp.getCurrentTime(), this.getClass().getSimpleName(),
+					"Creating ComplexEventRuleActionListDocument with provided XML ");
+		ComplexEventRuleActionListDocument theDocument = ComplexEventRuleActionListDocument.Factory.parse(xmlRule);
+		if (debug) {
+			DebugMessages.ok();
+			DebugMessages.line();
+		}
+		return theDocument;
+	}
+
+	/**
+	 *
+	 * This method connect the Consumer to the response channel where the results
+	 * of the<br />
+	 * requested evaluation to the monitoring infrastructure will be sent on.
+	 *
+	 * @param connection
+	 *         the connection object currently used
+	 * @param responseChannel
+	 *         the channel where to connect to.<br />
+	 *         The monitoring will provides this parameter after sending the
+	 *         evaluation request.
+	 * @param debug
+	 * @return a {@link TopicSubscriber} object
+	 * @throws JMSException
+	 */
+	protected TopicSubscriber connectToTheResponseChannel(TopicConnection connection, String responseChannel,
+			boolean debug) throws JMSException {
+		if (debug) {
+			DebugMessages.ok();
+			DebugMessages.print(TimeStamp.getCurrentTime(), this.getClass().getSimpleName(), "Creating Session ");
+		}
+		TopicSession subscribeSession = connection.createTopicSession(false, Session.AUTO_ACKNOWLEDGE);
+		if (debug) {
+			DebugMessages.ok();
+			DebugMessages.print(TimeStamp.getCurrentTime(), this.getClass().getSimpleName(), "Connecting to channel ");
+		}
+		Topic connectionTopic = subscribeSession.createTopic(responseChannel);
+		if (debug) {
+			DebugMessages.ok();
+			DebugMessages.print(TimeStamp.getCurrentTime(), this.getClass().getSimpleName(), "Create subscriber ");
+		}
+		TopicSubscriber tSub = subscribeSession.createSubscriber(connectionTopic, null, true);
+		tSub.setMessageListener(this);
+		if (debug) {
+			DebugMessages.ok();
+			DebugMessages.print(TimeStamp.getCurrentTime(), this.getClass().getSimpleName(), "Starting connection ");
+		}
+		connection.start();
+		if (debug) {
+			DebugMessages.ok();
+			DebugMessages.println(TimeStamp.getCurrentTime(), this.getClass().getSimpleName(),
+					"Successfully connected to the responseChannel " + responseChannel);
+			DebugMessages.line();
+		}
+		return tSub;
+	}
+
+	/**
+	 * @param msg
+	 *         the first TextMessage received from the monitoring
+	 *         infrastructure,<br />
+	 *         in response to the submitted evaluation request.
+	 * @return a string to be used with the method
+	 *         {@link GlimpseAbstractConsumer#connectToTheResponseChannel(TopicConnection, String, boolean)}
+	 *         method<br />
+	 *         to connect on the response channel
+	 * @throws JMSException
+	 * @throws IncorrectRuleFormatException
+	 */
+	protected String getAnswerTopicFromTextMessage(TextMessage msg) throws JMSException, IncorrectRuleFormatException {
+		if (msg.getText().substring(0, 14).compareTo("AnswerTopic ==") == 0)
+			return msg.getText().substring(15, msg.getText().length());
+		else
+			throw (new IncorrectRuleFormatException(null));
+	}
+}

--- a/lp-simulation-environment/monitoring/src/main/java/eu/learnpad/simulator/mon/consumer/GlimpseConsumer.java
+++ b/lp-simulation-environment/monitoring/src/main/java/eu/learnpad/simulator/mon/consumer/GlimpseConsumer.java
@@ -1,0 +1,96 @@
+package eu.learnpad.simulator.mon.consumer;
+
+import javax.jms.JMSException;
+import javax.jms.MessageListener;
+import javax.jms.TopicConnection;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+
+import it.cnr.isti.labse.glimpse.xml.complexEventRule.ComplexEventRuleActionListDocument;
+
+/**
+ * Implementing this interface to create a communication with the monitoring
+ * Enabler.<br />
+ * <br />
+ * It is possible to use a generic implementation of the consumer using or
+ * extending the class {@link GlimpseAbstractConsumer}
+ *
+ * However, implementing this interface the behaviour of the consumer must
+ * respect the following actions:<br />
+ * <br />
+ *
+ * Send a TextMessage that contains the Xml generated following the
+ * ComplexEventRequest schema<br />
+ * <br />
+ *
+ * The message must be sent on the jms://serviceTopic channel.<br />
+ * The consumer must listen for the response of the monitoring infrastructure
+ * that will send a jms TextMessage containing the response channel where to
+ * connect to listen for the evaluation results.<br />
+ * The text contained into the TextMessage sent from the monitoring
+ * infrastructure<br />
+ * is "AnswerTopic ==<em>TOPICNAMEWHERETOCONNECTTO</em>"<br />
+ * <br />
+ *
+ * To create in a simple way the XML that define the request, you can use the
+ * class ComplexEventRuleActionListDocument.<br />
+ * Possible XML actions are: Insert Delete Start Stop Restart.<br />
+ * <br />
+ * The payload (the field RuleBody of the ComplexEventRuleType object) of <br />
+ * a well-structured ComplexEventRule message, actually, must contains a Drools
+ * rule.<br />
+ * For more details about Drools Rule, see the exampleRule.xml.<br />
+ * 
+ * ************************************************************************<br
+ * />
+ * *******An usage example is available here
+ * {@link MyGlimpseConsumer}********<br />
+ * ************************************************************************<br
+ * />
+ * <br />
+ *
+ * @author Antonello Calabr&ograve;
+ * @version 3.2
+ *
+ */
+public interface GlimpseConsumer extends MessageListener {
+
+	/**
+	 * Send a ActionList of rules to the monitoring infrastructure requesting an
+	 * evaluation.<br />
+	 * If the request is accepted, the monitoring will answer with a
+	 * responseChannel where to connect<br />
+	 * The actionList parameter is a list of action to provide to the
+	 * Monitoring<br />
+	 * To create it, you can use ComplexEventRuleActionListDocument class.
+	 *
+	 * @param connection
+	 * @param initContext
+	 * @param serviceChannel
+	 * @param actionList
+	 * @param debug
+	 *         debug value
+	 * @throws JMSException
+	 * @throws NamingException
+	 */
+	void sendActionListMessage(TopicConnection connection, InitialContext initContext, String serviceChannel,
+			ComplexEventRuleActionListDocument actionList, boolean debug) throws JMSException, NamingException;
+
+	/**
+	 * Send a textMessage to the monitoring infrastructure,<br />
+	 * examples of setting up connection and behaviour of<br />
+	 * a generic {@link GlimpseConsumer} are defined in <br />
+	 * the {@link GlimpseAbstractConsumer} class.
+	 *
+	 * @param connection
+	 * @param initContext
+	 * @param serviceChannel
+	 * @param textToSend
+	 * @param debug
+	 *         debug value
+	 * @throws JMSException
+	 * @throws NamingException
+	 */
+	void sendTextMessage(TopicConnection connection, InitialContext initContext, String serviceChannel, String textToSend,
+			boolean debug) throws JMSException, NamingException;
+}

--- a/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/monitoring/activiti/scoreprobe/ScoreProbeConsumer.java
+++ b/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/monitoring/activiti/scoreprobe/ScoreProbeConsumer.java
@@ -1,0 +1,119 @@
+package eu.learnpad.simulator.monitoring.activiti.scoreprobe;
+
+/*
+ * #%L
+ * LearnPAd Simulator
+ * %%
+ * Copyright (C) 2014 - 2016 Linagora
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Properties;
+
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.ObjectMessage;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import eu.learnpad.sim.rest.event.ScoreType;
+import eu.learnpad.simulator.mon.consumer.GlimpseAbstractConsumer;
+import eu.learnpad.simulator.mon.utils.Manager;
+import eu.learnpad.simulator.utils.SimulatorProperties;
+import it.cnr.isti.labse.glimpse.xml.complexEventException.ComplexEventException;
+
+/**
+ *
+ * This class instantiates a probe to the monitoring component in order to both
+ * send the BPMN file and to receive and propagate score events related to a
+ * specific session.
+ *
+ * Note: This class is instantiated using the static {@link create} method
+ *
+ * @author Tom Jorquera - Linagora
+ *
+ */
+public class ScoreProbeConsumer extends GlimpseAbstractConsumer {
+
+	private static final String USER_ID_PROPERTY = "USERID";
+
+	private final IProbeScoresReceiver scoreReceiver;
+	private final String sessionId;
+
+	private final Logger logger = LoggerFactory.getLogger(ScoreProbeConsumer.class);
+
+	private ScoreProbeConsumer(IProbeScoresReceiver scoreReceiver, Properties settings, String plainTextRule,
+			List<String> usersInvolvedId, String sessionId, String bpmnId) {
+		super(settings, plainTextRule, usersInvolvedId, sessionId, bpmnId);
+		this.scoreReceiver = scoreReceiver;
+		this.sessionId = sessionId;
+	}
+
+	@Override
+	public void messageReceived(Message arg0) throws JMSException {
+		try {
+			ObjectMessage responseFromMonitoring = (ObjectMessage) arg0;
+			if (responseFromMonitoring.getObject() instanceof ComplexEventException) {
+				ComplexEventException exceptionReceived = (ComplexEventException) responseFromMonitoring.getObject();
+				logger.error("Receive exception from probe: {}",
+						exceptionReceived.getMessage());
+				logger.error("Stack trace:\n{}", exceptionReceived.getStackTrace());
+			} else if (responseFromMonitoring.getObject() instanceof Map) {
+
+					@SuppressWarnings("unchecked")
+					Map<ScoreType, Float> theScores = (Map<ScoreType, Float>)responseFromMonitoring.getObject();
+
+					String userId = responseFromMonitoring.getStringProperty(USER_ID_PROPERTY);
+
+					// propagate
+					for (Entry<ScoreType, Float> score : theScores.entrySet()) {
+						scoreReceiver.receiveScore(sessionId, userId, score.getKey(), score.getValue());
+					}
+
+				} else {
+					logger.debug("Received unexpected message from probe: {}", responseFromMonitoring);
+				}
+		} catch (ClassCastException asd) {
+			asd.printStackTrace();
+		}
+	}
+
+	/**
+	 *
+	 * @param scoreReceiver
+	 * @param sessionId
+	 * @param bpmnId
+	 * @param bpmnFile
+	 * @param involvedUsers
+	 * @return a new score probe consumer
+	 */
+	public static ScoreProbeConsumer create(IProbeScoresReceiver scoreReceiver, String sessionId, String bpmnId,
+			String bpmnFile,
+			List<String> involvedUsers) {
+
+		Properties settings = Manager.createConsumerSettingsPropertiesObject(
+				"org.apache.activemq.jndi.ActiveMQInitialContextFactory",
+				SimulatorProperties.props.getProperty(SimulatorProperties.PROP_GLIMPSE_SERVER), "system", "manager", "TopicCF",
+				"jms.serviceTopic", false, "SimulationComponent");
+
+		return new ScoreProbeConsumer(scoreReceiver, settings, bpmnFile, involvedUsers, sessionId, bpmnId);
+	}
+
+}

--- a/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/processmanager/activiti/ActivitiProcessManager.java
+++ b/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/processmanager/activiti/ActivitiProcessManager.java
@@ -643,7 +643,7 @@ public class ActivitiProcessManager implements IProcessManager,
 	}
 
 	@Override
-	public void receiveScore(String sessionId, String userId, ScoreType type, Float value) {
+	public synchronized void receiveScore(String sessionId, String userId, ScoreType type, Float value) {
 
 		if (!probeScoreByTypeByUsersBySession.containsKey(sessionId)) {
 			probeScoreByTypeByUsersBySession.put(sessionId, new HashMap<String, Map<ScoreType, Float>>());

--- a/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/processmanager/activiti/ActivitiProcessManager.java
+++ b/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/processmanager/activiti/ActivitiProcessManager.java
@@ -61,6 +61,7 @@ import org.activiti.engine.repository.ProcessDefinition;
 import org.activiti.engine.runtime.ProcessInstance;
 import org.activiti.image.ProcessDiagramGenerator;
 import org.activiti.image.impl.DefaultProcessDiagramGenerator;
+import org.slf4j.LoggerFactory;
 import org.xml.sax.SAXException;
 
 import eu.learnpad.sim.rest.data.ProcessInstanceData;
@@ -71,6 +72,7 @@ import eu.learnpad.simulator.datastructures.LearnPadTask;
 import eu.learnpad.simulator.datastructures.LearnPadTaskGameInfos;
 import eu.learnpad.simulator.datastructures.LearnPadTaskSubmissionResult;
 import eu.learnpad.simulator.monitoring.activiti.scoreprobe.IProbeScoresReceiver;
+import eu.learnpad.simulator.monitoring.activiti.scoreprobe.ScoreProbeConsumer;
 import eu.learnpad.simulator.monitoring.event.impl.ProcessStartSimEvent;
 import eu.learnpad.simulator.monitoring.event.impl.SimulationEndSimEvent;
 import eu.learnpad.simulator.monitoring.event.impl.SimulationStartSimEvent;
@@ -120,6 +122,7 @@ public class ActivitiProcessManager implements IProcessManager,
 	private final Map<String, Map<String, Map<ScoreType, Float>>> probeScoreByTypeByUsersBySession = new HashMap<>();
 
 	private final Map<String, String> simSessionIdToModelSet = new ConcurrentHashMap<String, String>();
+	private final Map<String, ScoreProbeConsumer> scoreProbeConsumerBySession = new HashMap<>();
 
 	public ActivitiProcessManager(
 			ProcessEngine processEngine,
@@ -396,6 +399,23 @@ public class ActivitiProcessManager implements IProcessManager,
 						(String) parameters.get(SIMULATION_ID_KEY),
 						users, data));
 
+		try (java.util.Scanner s = new java.util.Scanner(repositoryService.getProcessModel(repositoryService
+				.createProcessDefinitionQuery().processDefinitionKey(projectDefinitionKey).singleResult().getId()))) {
+			String bpmnFile =  s.useDelimiter("\\A").hasNext() ? s.next() : "";
+
+			// create score probe
+			try {
+				scoreProbeConsumerBySession.put(simSession,
+						ScoreProbeConsumer.create(this, simSession, projectDefinitionKey, bpmnFile, new ArrayList<>(users)));
+			} catch (NullPointerException e) {
+				// probably cannot connect to mon
+				LoggerFactory.getLogger(ActivitiProcessManager.class)
+						.error("Failed to create score probe for process {}. Is monitoring component accessible?", process.getId());
+				e.printStackTrace();
+			}
+
+		}
+
 		return process.getId();
 	}
 
@@ -507,6 +527,7 @@ public class ActivitiProcessManager implements IProcessManager,
 			taskScoresByUsersBySession.remove(simSession);
 
 			probeScoreByTypeByUsersBySession.remove(simSession);
+			scoreProbeConsumerBySession.remove(simSession);
 
 		}
 


### PR DESCRIPTION
This PR adds integration between sim and mon for score and bpmn probes.
From now, when a new session is created on the sim, it is associated with a score probe that both send the bpmn file  to the mon and receive scores events from the mon regarding the session.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/learnpad/learnpad/530)
<!-- Reviewable:end -->
