### PR TITLE
[sim][mon] Add integration for score probe

### DIFF
--- a/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/processmanager/activiti/ActivitiProcessManager.java
+++ b/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/processmanager/activiti/ActivitiProcessManager.java
@@ -118,10 +118,10 @@ public class ActivitiProcessManager implements IProcessManager,
 
 	private final Map<String, Map<String, Map<LearnPadTask, Integer>>> taskScoresByUsersBySession = new HashMap<>();
 
-	private final Map<String, String> processDefToModelSet = new ConcurrentHashMap<String, String>();
+	private final Map<String, String> processDefToModelSet = new ConcurrentHashMap<>();
 	private final Map<String, Map<String, Map<ScoreType, Float>>> probeScoreByTypeByUsersBySession = new HashMap<>();
 
-	private final Map<String, String> simSessionIdToModelSet = new ConcurrentHashMap<String, String>();
+	private final Map<String, String> simSessionIdToModelSet = new ConcurrentHashMap<>();
 	private final Map<String, ScoreProbeConsumer> scoreProbeConsumerBySession = new HashMap<>();
 
 	public ActivitiProcessManager(
@@ -169,7 +169,7 @@ public class ActivitiProcessManager implements IProcessManager,
 
 	@Override
 	public Collection<String> addProjectDefinitions(InputStream resource) {
-		Set<String> res = new HashSet<String>();
+		Set<String> res = new HashSet<>();
 
 		try {
 			// Activiti message workaround
@@ -204,7 +204,7 @@ public class ActivitiProcessManager implements IProcessManager,
 	 * @see activitipoc.IProcessManager#getAvailableProcessDefintion()
 	 */
 	public Collection<String> getAvailableProcessDefintion() {
-		Set<String> res = new HashSet<String>();
+		Set<String> res = new HashSet<>();
 
 		List<ProcessDefinition> processes = repositoryService
 				.createProcessDefinitionQuery().list();
@@ -302,7 +302,7 @@ public class ActivitiProcessManager implements IProcessManager,
 	 */
 	public Collection<String> getProcessDefinitionGroupRoles(
 			String processDefinitionId) {
-		Set<String> result = new HashSet<String>();
+		Set<String> result = new HashSet<>();
 
 		// open the BPMN model of the process
 		BpmnModel model = repositoryService.getBpmnModel(processDefinitionId);
@@ -425,7 +425,7 @@ public class ActivitiProcessManager implements IProcessManager,
 	 * @see activitipoc.IProcessManager#getCurrentProcessInstances()
 	 */
 	public Collection<String> getCurrentProcessInstances() {
-		Set<String> res = new HashSet<String>();
+		Set<String> res = new HashSet<>();
 
 		List<ProcessInstance> processes = runtimeService
 				.createProcessInstanceQuery().list();
@@ -542,7 +542,7 @@ public class ActivitiProcessManager implements IProcessManager,
 			String sessionId, String userId) {
 
 		if (taskScoresByUsersBySession.get(sessionId) == null) {
-			return new HashMap<LearnPadTask, Integer>();
+			return new HashMap<>();
 		} else {
 			return taskScoresByUsersBySession.get(sessionId).get(userId);
 		}
@@ -614,7 +614,7 @@ public class ActivitiProcessManager implements IProcessManager,
 				// TODO:this is not very efficient :( Possible to do it directly
 				// with a
 				// query?
-				List<String> res = new ArrayList<String>();
+				List<String> res = new ArrayList<>();
 				for (String activityId : runtimeService
 						.getActiveActivityIds(processInstanceId)) {
 					if (this.historyService

--- a/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/uihandler/webserver/UIHandlerWebImpl.java
+++ b/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/uihandler/webserver/UIHandlerWebImpl.java
@@ -130,7 +130,7 @@ public class UIHandlerWebImpl implements IUserHandler, IProcessEventReceiver {
 	 * @see activitipoc.IUIHandler#getUsers()
 	 */
 	public List<String> getUsers() {
-		return new ArrayList<String>(usersMap.keySet());
+		return new ArrayList<>(usersMap.keySet());
 	}
 
 	@Override

--- a/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/uihandler/webserver/UIServlet.java
+++ b/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/uihandler/webserver/UIServlet.java
@@ -64,9 +64,9 @@ public class UIServlet extends WebSocketServlet {
 
 	private final IProcessManager manager;
 
-	private final Map<String, SimulationStartSimEvent> currentSessions = new HashMap<String, SimulationStartSimEvent>();
-	private final Set<String> currentTasks = new HashSet<String>();
-	private final Set<UISocket> activeSockets = new HashSet<UISocket>();
+	private final Map<String, SimulationStartSimEvent> currentSessions = new HashMap<>();
+	private final Set<String> currentTasks = new HashSet<>();
+	private final Set<UISocket> activeSockets = new HashSet<>();
 
 	private final ObjectMapper mapper = new ObjectMapper();
 
@@ -162,8 +162,8 @@ public class UIServlet extends WebSocketServlet {
 		Map<LearnPadTask, Integer> detailedScore = manager
 				.getDetailedInstanceScore(sessionId, uiid);
 
-		Map<String, String> taskNames = new HashMap<String, String>();
-		Map<String, Integer> taskScores = new HashMap<String, Integer>();
+		Map<String, String> taskNames = new HashMap<>();
+		Map<String, Integer> taskScores = new HashMap<>();
 
 		for (Entry<LearnPadTask, Integer> score : detailedScore.entrySet()) {
 			taskNames.put(score.getKey().id, score.getKey().name);

--- a/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/utils/BPMNExplorer.java
+++ b/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/utils/BPMNExplorer.java
@@ -85,17 +85,17 @@ public class BPMNExplorer {
 					+ processDefinitionKey + " in BPMN model");
 		}
 
-		final Map<String, String> mutTaskIDToSubProcess = new HashMap<String, String>();
+		final Map<String, String> mutTaskIDToSubProcess = new HashMap<>();
 
-		final Map<String, Set<String>> mutTaskIDToDataInputs = new HashMap<String, Set<String>>();
-		final Map<String, Set<String>> mutTaskIDToDataOutputs = new HashMap<String, Set<String>>();
+		final Map<String, Set<String>> mutTaskIDToDataInputs = new HashMap<>();
+		final Map<String, Set<String>> mutTaskIDToDataOutputs = new HashMap<>();
 
-		final Set<String> mutDataObjects = new HashSet<String>();
-		final Set<String> mutNotStandaloneDataObjects = new HashSet<String>();
+		final Set<String> mutDataObjects = new HashSet<>();
+		final Set<String> mutNotStandaloneDataObjects = new HashSet<>();
 
-		final Map<String, String> mutDataObjectsIdtoName = new HashMap<String, String>();
+		final Map<String, String> mutDataObjectsIdtoName = new HashMap<>();
 
-		final Map<String, List<String>> mutDataObjectContent = new HashMap<String, List<String>>();
+		final Map<String, List<String>> mutDataObjectContent = new HashMap<>();
 
 		// parse the BPMN file and extract useful infos
 		initializeWithElements(null, process.getFlowElements(),
@@ -108,7 +108,7 @@ public class BPMNExplorer {
 
 			try {
 
-				List<String> elements = new ArrayList<String>();
+				List<String> elements = new ArrayList<>();
 
 				try (BufferedReader br = new BufferedReader(
 						new InputStreamReader(this

--- a/lp-simulation-environment/simulator/src/test/java/eu/learnpad/simulator/uihandler/webserver/UIHandlerWebImplTest.java
+++ b/lp-simulation-environment/simulator/src/test/java/eu/learnpad/simulator/uihandler/webserver/UIHandlerWebImplTest.java
@@ -74,9 +74,9 @@ public class UIHandlerWebImplTest {
 	public void webserverInit() {
 		webserver = mock(WebServer.class);
 
-		taskAddByUI = new HashMap<String, List<String>>();
-		taskRemoveByUI = new HashMap<String, List<String>>();
-		sessionCompletionByUI = new HashMap<String, List<String>>();
+		taskAddByUI = new HashMap<>();
+		taskRemoveByUI = new HashMap<>();
+		sessionCompletionByUI = new HashMap<>();
 
 		// Ok this is a little over the top...
 		//
@@ -227,7 +227,7 @@ public class UIHandlerWebImplTest {
 		List<String> tasks = Arrays.asList("task1", "task2", "task3", "task4",
 				"task5");
 
-		Map<String, List<String>> tasksToUsers = new HashMap<String, List<String>>();
+		Map<String, List<String>> tasksToUsers = new HashMap<>();
 		tasksToUsers.put("task1", Arrays.asList("user1"));
 		tasksToUsers.put("task2", Arrays.asList("user1", "user2"));
 		tasksToUsers.put("task3", Arrays.asList("user1", "user2", "user3"));


### PR DESCRIPTION
This PR adds integration between sim and mon for score and bpmn probes.
From now, when a new session is created on the sim, it is associated with a score probe that both send the bpmn file  to the mon and receive scores events from the mon regarding the session.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/learnpad/learnpad/531)
<!-- Reviewable:end -->
