### PR TITLE
[mon] Updated rules generation and ScoreUpdateEvent

### DIFF
--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/ScoreUpdateEvent.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/ScoreUpdateEvent.java
@@ -22,8 +22,6 @@ package eu.learnpad.sim.rest.event.impl;
 import java.util.List;
 import java.util.Map;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
 import eu.learnpad.sim.rest.event.AbstractEvent;
 import eu.learnpad.sim.rest.event.EventType;
 import eu.learnpad.sim.rest.event.ScoreType;
@@ -51,32 +49,42 @@ public class ScoreUpdateEvent extends AbstractEvent {
 	 * The new session score of the user
 	 */
 	
-	public ObjectNode updatedScore;
-
+	private ScoreType scoreUpdateType;
+	private Float scoreUpdateValue;
 
 	public ScoreUpdateEvent() {
 		super();
 	}
 
 	public ScoreUpdateEvent(Long timestamp, String simulationsessionid, List<String> involvedusers, String modelsetid,
-			Map<String, Object> simulationSessionData, String processartifactid, String user, ScoreType scoreUpdateName, Float scoreUpdateValue) {
+			Map<String, Object> simulationSessionData, String processartifactid, String user, ScoreType scoreUpdateType, Float scoreUpdateValue) {
 		super(EventType.SCORE_UPDATE, timestamp, simulationsessionid, involvedusers, modelsetid, simulationSessionData);
+		this.scoreUpdateType = scoreUpdateType;
+		this.scoreUpdateValue = scoreUpdateValue;
+		
 		this.processartifactid = processartifactid;
-		this.updatedScore.put(scoreUpdateName.toString(), scoreUpdateValue);
 		this.user = user;
 	}
-
-	public ObjectNode getUpdatedScore() {
-		return updatedScore;
+	
+	public ScoreType getScoreUpdateType() {
+		return scoreUpdateType;
 	}
 
-	public void setUpdatedScore(ObjectNode updatedScore) {
-		this.updatedScore = updatedScore;
+	public void setScoreUpdateType(ScoreType scoreUpdateType) {
+		this.scoreUpdateType = scoreUpdateType;
+	}
+
+	public Float getScoreUpdateValue() {
+		return scoreUpdateValue;
+	}
+
+	public void setScoreUpdateValue(Float scoreUpdateValue) {
+		this.scoreUpdateValue = scoreUpdateValue;
 	}
 	
 	@Override
 	public String toString() {
 		return super.toString() + " processartifactid=" + processartifactid + " user=" + user + " updatedScore="
-				+ updatedScore.toString();
+				+ scoreUpdateValue.toString();
 	}
 }

--- a/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/ScoreUpdateEvent.java
+++ b/lp-core-platform/lp-cp-apis/src/main/java/eu/learnpad/sim/rest/event/impl/ScoreUpdateEvent.java
@@ -49,8 +49,8 @@ public class ScoreUpdateEvent extends AbstractEvent {
 	 * The new session score of the user
 	 */
 	
-	private ScoreType scoreUpdateType;
-	private Float scoreUpdateValue;
+	public ScoreType scoreUpdateType;
+	public Float scoreUpdateValue;
 
 	public ScoreUpdateEvent() {
 		super();

--- a/lp-simulation-environment/monitoring/configFiles/startupRule.drl
+++ b/lp-simulation-environment/monitoring/configFiles/startupRule.drl
@@ -12,6 +12,7 @@ import eu.learnpad.sim.rest.event.impl.ScoreUpdateEvent;
 import eu.learnpad.sim.rest.event.EventType;
 import eu.learnpad.simulator.mon.manager.ResponseDispatcher; 
 import eu.learnpad.simulator.mon.manager.RestNotifier; 
+import eu.learnpad.simulator.mon.rules.ScoreTemporaryStorage;
         
 declare GlimpseBaseEventBPMN
     @role( event )
@@ -168,3 +169,24 @@ then
 	RestNotifier.notifySessionScoreUpdateDemo($aEvent.getTimeStamp(), (SessionScoreUpdateEvent)$aEvent.getEvent()); 
 	retract($aEvent);		 	
 end   
+
+rule "Save in tempStructure the SessioScoreUpdate value" 
+no-loop true 
+
+salience 20 
+
+dialect "java" 
+
+when 
+ 	$aEvent : GlimpseBaseEventBPMN(
+		this.isConsumed == false,
+		this.isException == false,
+		this.getEventName == EventType.SESSION_SCORE_UPDATE.toString());  
+then		
+	$aEvent.setConsumed(true); 
+	update($aEvent); 
+	ScoreTemporaryStorage.setTemporaryLearnerSessionScore(
+									(String)((SessionScoreUpdateEvent)$aEvent.getEvent()).user.toString(), 
+									(Long)((SessionScoreUpdateEvent)$aEvent.getEvent()).sessionscore);
+	retract($aEvent);		 	
+end  

--- a/lp-simulation-environment/monitoring/configFiles/startupRule.drl
+++ b/lp-simulation-environment/monitoring/configFiles/startupRule.drl
@@ -12,7 +12,7 @@ import eu.learnpad.sim.rest.event.impl.ScoreUpdateEvent;
 import eu.learnpad.sim.rest.event.EventType;
 import eu.learnpad.simulator.mon.manager.ResponseDispatcher; 
 import eu.learnpad.simulator.mon.manager.RestNotifier; 
-import eu.learnpad.simulator.mon.rules.ScoreTemporaryStorage;
+import eu.learnpad.simulator.mon.storage.ScoreTemporaryStorage;
         
 declare GlimpseBaseEventBPMN
     @role( event )
@@ -188,5 +188,6 @@ then
 	ScoreTemporaryStorage.setTemporaryLearnerSessionScore(
 									(String)((SessionScoreUpdateEvent)$aEvent.getEvent()).user.toString(), 
 									(Long)((SessionScoreUpdateEvent)$aEvent.getEvent()).sessionscore);
+	ScoreTemporaryStorage.setLastScoreUpdateEventSeen((SessionScoreUpdateEvent)$aEvent.getEvent());
 	retract($aEvent);		 	
 end  

--- a/lp-simulation-environment/monitoring/src/main/java/eu/learnpad/simulator/mon/configFiles/startupRule.drl
+++ b/lp-simulation-environment/monitoring/src/main/java/eu/learnpad/simulator/mon/configFiles/startupRule.drl
@@ -12,6 +12,7 @@ import eu.learnpad.sim.rest.event.impl.ScoreUpdateEvent;
 import eu.learnpad.sim.rest.event.EventType;
 import eu.learnpad.simulator.mon.manager.ResponseDispatcher; 
 import eu.learnpad.simulator.mon.manager.RestNotifier; 
+import eu.learnpad.simulator.mon.rules.ScoreTemporaryStorage;
         
 declare GlimpseBaseEventBPMN
     @role( event )
@@ -168,3 +169,24 @@ then
 	RestNotifier.notifySessionScoreUpdateDemo($aEvent.getTimeStamp(), (SessionScoreUpdateEvent)$aEvent.getEvent()); 
 	retract($aEvent);		 	
 end   
+
+rule "Save in tempStructure the SessioScoreUpdate value" 
+no-loop true 
+
+salience 20 
+
+dialect "java" 
+
+when 
+ 	$aEvent : GlimpseBaseEventBPMN(
+		this.isConsumed == false,
+		this.isException == false,
+		this.getEventName == EventType.SESSION_SCORE_UPDATE.toString());  
+then		
+	$aEvent.setConsumed(true); 
+	update($aEvent); 
+	ScoreTemporaryStorage.setTemporaryLearnerSessionScore(
+									(String)((SessionScoreUpdateEvent)$aEvent.getEvent()).user.toString(), 
+									(Long)((SessionScoreUpdateEvent)$aEvent.getEvent()).sessionscore);
+	retract($aEvent);		 	
+end  

--- a/lp-simulation-environment/monitoring/src/main/java/eu/learnpad/simulator/mon/configFiles/startupRule.drl
+++ b/lp-simulation-environment/monitoring/src/main/java/eu/learnpad/simulator/mon/configFiles/startupRule.drl
@@ -12,7 +12,7 @@ import eu.learnpad.sim.rest.event.impl.ScoreUpdateEvent;
 import eu.learnpad.sim.rest.event.EventType;
 import eu.learnpad.simulator.mon.manager.ResponseDispatcher; 
 import eu.learnpad.simulator.mon.manager.RestNotifier; 
-import eu.learnpad.simulator.mon.rules.ScoreTemporaryStorage;
+import eu.learnpad.simulator.mon.storage.ScoreTemporaryStorage;
         
 declare GlimpseBaseEventBPMN
     @role( event )
@@ -188,5 +188,6 @@ then
 	ScoreTemporaryStorage.setTemporaryLearnerSessionScore(
 									(String)((SessionScoreUpdateEvent)$aEvent.getEvent()).user.toString(), 
 									(Long)((SessionScoreUpdateEvent)$aEvent.getEvent()).sessionscore);
+	ScoreTemporaryStorage.setLastScoreUpdateEventSeen((SessionScoreUpdateEvent)$aEvent.getEvent());
 	retract($aEvent);		 	
-end  
+end    

--- a/lp-simulation-environment/monitoring/src/main/java/eu/learnpad/simulator/mon/coverage/Activity.java
+++ b/lp-simulation-environment/monitoring/src/main/java/eu/learnpad/simulator/mon/coverage/Activity.java
@@ -9,14 +9,25 @@ public class Activity implements Serializable {
 	
 	private String name;
 	private String path_id;
+	private String taskArtifactID;
 	private HashMap<String, Float> expectedKpi; 
 	private float weight;
+
 	
-	public Activity(String name, String path_id ,HashMap<String, Float> expectedKpi, float weight) {
+	public Activity(String name, String path_id , String taskArtifactID, HashMap<String, Float> expectedKpi, float weight) {
 		this.name = name;
 		this.path_id = path_id;
+		this.taskArtifactID = taskArtifactID;
 		this.expectedKpi = expectedKpi;
 		this.weight = weight;
+	}
+
+	public String getTaskArtifactID() {
+		return taskArtifactID;
+	}
+
+	public void setTaskArtifactID(String taskArtifactID) {
+		this.taskArtifactID = taskArtifactID;
 	}
 
 	public String getName() {

--- a/lp-simulation-environment/monitoring/src/main/java/eu/learnpad/simulator/mon/impl/LearnerAssessmentManagerImpl.java
+++ b/lp-simulation-environment/monitoring/src/main/java/eu/learnpad/simulator/mon/impl/LearnerAssessmentManagerImpl.java
@@ -35,6 +35,7 @@ import eu.learnpad.simulator.mon.manager.RestNotifier;
 import eu.learnpad.simulator.mon.rules.generator.RulesPerPath;
 import eu.learnpad.simulator.mon.storage.DBController;
 import eu.learnpad.simulator.mon.storage.H2Controller;
+import eu.learnpad.simulator.mon.storage.ScoreTemporaryStorage;
 import eu.learnpad.simulator.mon.utils.ComputeLearnerScore;
 import eu.learnpad.simulator.mon.utils.DebugMessages;
 import it.cnr.isti.labse.glimpse.xml.complexEventRule.ComplexEventRuleActionListDocument;
@@ -100,12 +101,6 @@ public class LearnerAssessmentManagerImpl extends LearnerAssessmentManager {
 				Vector<Path> theGeneratedPath = crossRulesGenerator.generatePathsRules(
 																	crossRulesGenerator.generateAllPaths(theUnfoldedBPMN, newBpmn.getId()));
 				
-				
-				
-				//rules for other kpi calculation
-//				ComplexEventRuleActionListDocument rulesForKPI = 
-//						KpiRulesGenerator.generateAll(usersInvolved, sessionID, bpmnID, theUnfoldedBPMN);
-				
 				theGeneratedPath = setAllAbsoluteSessionScores(theGeneratedPath);
 				
 				this.rulesLists = crossRulesGenerator.instantiateRulesSetForUsersInvolved(
@@ -143,10 +138,109 @@ public class LearnerAssessmentManagerImpl extends LearnerAssessmentManager {
 		
 	}
 
-	
-public void computeAndSaveScores(List<String> learnersID, String user, String idBPMN, String idPath, SessionScoreUpdateEvent sessionScore) {
+	@Override
+	public void computeAndPropagateScores(List<String> learnersID, String idPath, String idBPMN) {
 		
 		int pathsCardinality = databaseController.getBPMNPathsCardinality(idBPMN);
+		Date now = new Date();
+		
+		for(int i = 0; i<learnersID.size(); i++) {
+			databaseController.setLearnerSessionScore(
+					learnersID.get(i), idPath, idBPMN, 
+					ScoreTemporaryStorage.getTemporaryLearnerSessionScore(learnersID.get(i)),
+					new java.sql.Date(now.getTime()));
+			
+			float learnerBPScore = ComputeLearnerScore.learnerBP(
+					databaseController.getMaxSessionScores(learnersID.get(i), idBPMN));
+			
+			Vector<Path> pathsExecutedByLearner = databaseController.getPathsExecutedByLearner(learnersID.get(i), idBPMN); 
+			
+			//compute relativeBPScore
+			float learnerRelativeBPScore = ComputeLearnerScore.learnerRelativeBP(pathsExecutedByLearner);
+
+			//compute coverage percentage
+			float learnerCoverage = ComputeLearnerScore.BPCoverage(
+					pathsExecutedByLearner,pathsCardinality);
+
+			databaseController.updateBpmnLearnerScores(learnersID.get(i), idBPMN, learnerBPScore, learnerRelativeBPScore, learnerCoverage);
+			
+			//compute globalScore
+			float learnerGlobalScore = ComputeLearnerScore.learnerGlobal(
+					databaseController.getLearnerBPMNScores(learnersID.get(i)));
+		
+			//compute relativeGlobalScore
+			float learnerRelativeGlobalScore = ComputeLearnerScore.learnerRelativeGlobal(
+					databaseController.getLearnerRelativeBPScores(learnersID.get(i)));
+			
+			
+			//compute absoluteGlobalScore
+			float learnerAbsoluteGlobalScore = ComputeLearnerScore.learnerAbsoluteGlobal(
+					databaseController.getBPMNAbsoluteScoresExecutedByLearner(learnersID.get(i)));
+			
+			databaseController.updateLearnerScores(
+					learnersID.get(i), learnerGlobalScore, learnerRelativeGlobalScore, learnerAbsoluteGlobalScore);
+
+			HashMap<ScoreType, Float> scoresToShow = new HashMap<ScoreType, Float>();
+			
+			scoresToShow.put(ScoreType.ABSOLUTE_BP_SCORE, absoluteBPScore);
+			scoresToShow.put(ScoreType.ABSOLUTE_GLOBAL_SCORE, learnerAbsoluteGlobalScore);
+			scoresToShow.put(ScoreType.ABSOLUTE_SESSION_SCORE, absoluteSessionScore);
+			scoresToShow.put(ScoreType.BP_COVERAGE, learnerCoverage);
+			scoresToShow.put(ScoreType.BP_SCORE, learnerBPScore);
+			scoresToShow.put(ScoreType.GLOBAL_SCORE, learnerGlobalScore);
+			scoresToShow.put(ScoreType.RELATIVE_BP_SCORE, learnerRelativeBPScore);
+			scoresToShow.put(ScoreType.RELATIVE_GLOBAL_SCORE, learnerRelativeGlobalScore);
+			scoresToShow.put(ScoreType.SESSION_SCORE, ScoreTemporaryStorage.getTemporaryLearnerSessionScore(learnersID.get(i)).floatValue());
+			
+			sendScoresToSim(scoresToShow,learnersID.get(i));
+			
+			sendScoreUpdateEventToCP(
+					generateScoreEvent(
+							ScoreType.ABSOLUTE_BP_SCORE, absoluteBPScore, ScoreTemporaryStorage.getLastScoreUpdateEventSeen(), learnersID.get(i)));
+			
+			sendScoreUpdateEventToCP(
+					generateScoreEvent(
+							ScoreType.ABSOLUTE_GLOBAL_SCORE, learnerAbsoluteGlobalScore, ScoreTemporaryStorage.getLastScoreUpdateEventSeen(), learnersID.get(i)));
+			
+			sendScoreUpdateEventToCP(
+					generateScoreEvent(
+							ScoreType.ABSOLUTE_SESSION_SCORE, absoluteSessionScore, ScoreTemporaryStorage.getLastScoreUpdateEventSeen(), learnersID.get(i)));
+			
+			sendScoreUpdateEventToCP(
+					generateScoreEvent(
+							ScoreType.BP_COVERAGE, learnerCoverage, ScoreTemporaryStorage.getLastScoreUpdateEventSeen(), learnersID.get(i)));
+			
+			sendScoreUpdateEventToCP(
+					generateScoreEvent(
+							ScoreType.BP_SCORE, learnerBPScore, ScoreTemporaryStorage.getLastScoreUpdateEventSeen(), learnersID.get(i)));
+			
+			sendScoreUpdateEventToCP(
+					generateScoreEvent(
+							ScoreType.GLOBAL_SCORE, learnerGlobalScore, ScoreTemporaryStorage.getLastScoreUpdateEventSeen(), learnersID.get(i)));
+			
+			sendScoreUpdateEventToCP(
+					generateScoreEvent(
+							ScoreType.RELATIVE_BP_SCORE, learnerRelativeBPScore, ScoreTemporaryStorage.getLastScoreUpdateEventSeen(), learnersID.get(i)));
+			
+			sendScoreUpdateEventToCP(
+					generateScoreEvent(
+							ScoreType.RELATIVE_GLOBAL_SCORE, learnerRelativeGlobalScore, ScoreTemporaryStorage.getLastScoreUpdateEventSeen(), learnersID.get(i)));
+			
+			sendScoreUpdateEventToCP(
+					generateScoreEvent(
+							ScoreType.SESSION_SCORE, 
+							ScoreTemporaryStorage.getTemporaryLearnerSessionScore(learnersID.get(i)).floatValue(), 
+							ScoreTemporaryStorage.getLastScoreUpdateEventSeen(), learnersID.get(i)));
+			
+		}
+		
+		
+	}
+	
+	public void computeAndSaveScores(List<String> learnersID, String user, String idBPMN, String idPath, SessionScoreUpdateEvent sessionScore) {
+		
+		int pathsCardinality = databaseController.getBPMNPathsCardinality(idBPMN);
+		
 		
 //		for(int i = 0; i<learnersID.size(); i++) {
 //			
@@ -257,6 +351,9 @@ public void computeAndSaveScores(List<String> learnersID, String user, String id
 			e.printStackTrace();
 		}
 	}
+
+
+	
 	
 	public static void main(String[] args)
 	{
@@ -290,4 +387,5 @@ public void computeAndSaveScores(List<String> learnersID, String user, String id
 	 		test.computeAndSaveScores(ciccio, "ciccio", "a23748293649", "a23748293649-1",up);
 	 		
 	 }
+
 }

--- a/lp-simulation-environment/monitoring/src/main/java/eu/learnpad/simulator/mon/impl/LearnerAssessmentManagerImpl.java
+++ b/lp-simulation-environment/monitoring/src/main/java/eu/learnpad/simulator/mon/impl/LearnerAssessmentManagerImpl.java
@@ -95,10 +95,12 @@ public class LearnerAssessmentManagerImpl extends LearnerAssessmentManager {
 				Vector<Activity[]> theUnfoldedBPMN = bpmnExplorer.getUnfoldedBPMN(theBPMN);
 				
 				Bpmn newBpmn = new Bpmn(bpmnID,now,0, 0, theUnfoldedBPMN.size());
-				
+
 				//rules for coverage
 				Vector<Path> theGeneratedPath = crossRulesGenerator.generatePathsRules(
 																	crossRulesGenerator.generateAllPaths(theUnfoldedBPMN, newBpmn.getId()));
+				
+				
 				
 				//rules for other kpi calculation
 //				ComplexEventRuleActionListDocument rulesForKPI = 

--- a/lp-simulation-environment/monitoring/src/main/java/eu/learnpad/simulator/mon/impl/PathExplorerImpl.java
+++ b/lp-simulation-environment/monitoring/src/main/java/eu/learnpad/simulator/mon/impl/PathExplorerImpl.java
@@ -27,16 +27,15 @@ public class PathExplorerImpl implements PathExplorer {
 		kpiExample.put("kpiThree", 0.3f);
 		kpiExample.put("kpiFour", 0.4f);
 		
-		Activity serviceConfInv = new Activity("Service Conference Invitation","Service Conference Invitation",kpiExample, 2.0f);
-		
-		Activity putStamps = new Activity("Putting Stamps on the received documentation", "Putting Stamps on the received documentation",kpiExample, 2.0f);
-		Activity checkProvided = new Activity("Check Provided Documentation","Check Provided Documentation",kpiExample, 2.0f);
-		Activity takeADecision = new Activity("Take a decision","Take a decision",kpiExample, 2.0f);
-		Activity provideOp = new Activity("Provide Opinion","Provide Opinion",kpiExample, 2.0f);
-		Activity receivedOpinion = new Activity("Received Opinion Evaluation","Received Opinion Evaluation",kpiExample, 2.0f);
-		Activity provideAuthUnder = new Activity("Provide Authorization Under Condition","Provide Authorization Under Condition",kpiExample, 2.0f);
-		Activity provideAuth = new Activity("Provide Authorization","Provide Authorization",kpiExample, 2.0f);
-		Activity provideFinal = new Activity("Provide Final Report","Provide Final Report",kpiExample, 2.0f);
+		Activity serviceConfInv = new Activity("Service Conference Invitation","Service Conference Invitation", "taskArtifactID1", kpiExample, 2.0f);
+		Activity putStamps = new Activity("Putting Stamps on the received documentation", "Putting Stamps on the received documentation", "taskArtifactID2",kpiExample, 2.0f);
+		Activity checkProvided = new Activity("Check Provided Documentation","Check Provided Documentation","taskArtifactID3", kpiExample, 2.0f);
+		Activity takeADecision = new Activity("Take a decision","Take a decision","taskArtifactID4", kpiExample, 2.0f);	
+		Activity provideOp = new Activity("Provide Opinion","Provide Opinion", "taskArtifactID5",kpiExample, 2.0f);
+		Activity receivedOpinion = new Activity("Received Opinion Evaluation","Received Opinion Evaluation","taskArtifactID6", kpiExample, 2.0f);
+		Activity provideAuthUnder = new Activity("Provide Authorization Under Condition","Provide Authorization Under Condition","taskArtifactID7", kpiExample, 2.0f);
+		Activity provideAuth = new Activity("Provide Authorization","Provide Authorization","taskArtifactID8", kpiExample, 2.0f);
+		Activity provideFinal = new Activity("Provide Final Report","Provide Final Report","taskArtifactID9", kpiExample, 2.0f);
 		
 		lastExploredBPMN.add(new Activity[]
 						{serviceConfInv});

--- a/lp-simulation-environment/monitoring/src/main/java/eu/learnpad/simulator/mon/impl/RulesPerPathGeneratorImpl.java
+++ b/lp-simulation-environment/monitoring/src/main/java/eu/learnpad/simulator/mon/impl/RulesPerPathGeneratorImpl.java
@@ -70,38 +70,56 @@ public class RulesPerPathGeneratorImpl implements RulesPerPath {
 		if (anActivitiesSet.length > 0) {
 			concat = "\t\t\t$0Event : GlimpseBaseEventBPMN("+
 					"this.isConsumed == false, this.getEvent().simulationsessionid == \"##SESSIONIDPLACEHOLDER##\""
-					+", this.getEvent.type == EventType.PROCESS_START.toString()"
+					+", this.getEvent.type == EventType.SIMULATION_START.toString()"
 					+", this.isException == false);\n";
 		}
 		
-			for(int j = 0; j<anActivitiesSet.length; j++) {
-					
-					concat +="\t\t\t$"+((2*j)+1)+"Event : GlimpseBaseEventBPMN(" +
-							"this.isConsumed == false, this.getEvent().simulationsessionid == \"##SESSIONIDPLACEHOLDER##\""
-							+", this.getEvent.type == EventType.SESSION_SCORE_UPDATE.toString()"
-							+", this.getUserID == \"##USERSINVOLVEDSESSIONSCOREIDS##\""
-							+", this.isException == false"
-							+", this after $" + (2*j) + "Event);\n";
-						
-					concat +="\t\t\t$"+((2*j)+2)+"Event : GlimpseBaseEventBPMN(" +
-							"this.isConsumed == false, this.getEvent().simulationsessionid == \"##SESSIONIDPLACEHOLDER##\""
-							+", this.getEvent.type == EventType.TASK_END.toString()"
-							+", this.getTaskEndEvent().completingUser.toString() == \"##USERSINVOLVEDTASKENDIDS##\""
-							+", this.isException == false"
-							+", this.getEventName == \"" + anActivitiesSet[j].getName() +"\""
-							+", this after $" + ((2*j)+1) + "Event);\n";
-			}
+		for(int j = 0; j<anActivitiesSet.length; j++) {				
+			concat +="\t\t\t$"+((j)+1)+"Event : GlimpseBaseEventBPMN(" +
+					"this.isConsumed == false, this.getEvent().simulationsessionid == \"##SESSIONIDPLACEHOLDER##\""
+					+", this.getEvent.type == EventType.TASK_END.toString()"
+					+", this.getTaskEndEvent().completingUser.toString() == \"##USERSINVOLVEDTASKENDIDS##\""
+					+", this.isException == false"
+					+", this.getTaskEndEvent().taskartifactid.toString() == \"" + anActivitiesSet[j].getTaskArtifactID() +"\""
+					+", this after $" + (j) + "Event);\n";
+	}
 
-			concat +="\t\t\t$"+((anActivitiesSet.length*2)+1)+"Event : GlimpseBaseEventBPMN(" +
-				"this.isConsumed == false, this.getEvent().simulationsessionid == \"##SESSIONIDPLACEHOLDER##\""
-				+", this.getEvent.type == EventType.PROCESS_END.toString()"
-				+", this.isException == false"
-				+", this after $" + (anActivitiesSet.length*2) + "Event);\n";
+	concat +="\t\t\t$"+((anActivitiesSet.length)+1)+"Event : GlimpseBaseEventBPMN(" +
+		"this.isConsumed == false, this.getEvent().simulationsessionid == \"##SESSIONIDPLACEHOLDER##\""
+		+", this.getEvent.type == EventType.SIMULATION_END.toString()"
+		+", this.isException == false"
+		+", this after $" + (anActivitiesSet.length) + "Event);\n";
+			
+		
+		
+//			for(int j = 0; j<anActivitiesSet.length; j++) {				
+//					concat +="\t\t\t$"+((2*j)+1)+"Event : GlimpseBaseEventBPMN(" +
+//							"this.isConsumed == false, this.getEvent().simulationsessionid == \"##SESSIONIDPLACEHOLDER##\""
+//							+", this.getEvent.type == EventType.SESSION_SCORE_UPDATE.toString()"
+//							+", this.getUserID == \"##USERSINVOLVEDSESSIONSCOREIDS##\""
+//							+", this.isException == false"
+//							+", this after $" + (2*j) + "Event);\n";
+//						
+//					concat +="\t\t\t$"+((2*j)+2)+"Event : GlimpseBaseEventBPMN(" +
+//							"this.isConsumed == false, this.getEvent().simulationsessionid == \"##SESSIONIDPLACEHOLDER##\""
+//							+", this.getEvent.type == EventType.TASK_END.toString()"
+//							+", this.getTaskEndEvent().completingUser.toString() == \"##USERSINVOLVEDTASKENDIDS##\""
+//							+", this.isException == false"
+//							+", this.getEventName == \"" + anActivitiesSet[j].getName() +"\""
+//							+", this after $" + ((2*j)+1) + "Event);\n";
+//			}
+//
+//			concat +="\t\t\t$"+((anActivitiesSet.length*2)+1)+"Event : GlimpseBaseEventBPMN(" +
+//				"this.isConsumed == false, this.getEvent().simulationsessionid == \"##SESSIONIDPLACEHOLDER##\""
+//				+", this.getEvent.type == EventType.SIMULATION_END.toString()"
+//				+", this.isException == false"
+//				+", this after $" + (anActivitiesSet.length*2) + "Event);\n";
 
 		aInsert.setRuleBody(RuleElements.getHeader(aInsert.getRuleName(),  "java") +
 				RuleElements.getWhenClause() + 
 				concat + 
-				RuleElements.getThenClauseForCoverageWithLearnersScoreUpdateAndProcessStartNotification(anActivitiesSet, idBPMN, idPath) +
+				RuleElements.getThenClausesForSetPathsAsCompletedAndPropagateScoresToPlatformAndOR(anActivitiesSet, idBPMN, idPath) +
+				//RuleElements.getThenClauseForCoverageWithLearnersScoreUpdateAndProcessStartNotification(anActivitiesSet, idBPMN, idPath) +
 				RuleElements.getEnd());
 		return aInsert;
 	}

--- a/lp-simulation-environment/monitoring/src/main/java/eu/learnpad/simulator/mon/impl/startupRuleBackup.drl
+++ b/lp-simulation-environment/monitoring/src/main/java/eu/learnpad/simulator/mon/impl/startupRuleBackup.drl
@@ -1,6 +1,0 @@
-import eu.learnpad.simulator.mon.event.GlimpseBaseEventAbstract;
-
-declare GlimpseBaseEventAbstract
-   @role( event )
-   @timestamp( timeStamp )
-end

--- a/lp-simulation-environment/monitoring/src/main/java/eu/learnpad/simulator/mon/manager/GlimpseManager.java
+++ b/lp-simulation-environment/monitoring/src/main/java/eu/learnpad/simulator/mon/manager/GlimpseManager.java
@@ -51,6 +51,7 @@ import eu.learnpad.simulator.mon.consumer.ConsumerProfile;
 import eu.learnpad.simulator.mon.coverage.Learner;
 import eu.learnpad.simulator.mon.exceptions.IncorrectRuleFormatException;
 import eu.learnpad.simulator.mon.rules.RulesManager;
+import eu.learnpad.simulator.mon.rules.ScoreTemporaryStorage;
 import eu.learnpad.simulator.mon.utils.DebugMessages;
 
 public class GlimpseManager extends Thread implements MessageListener {
@@ -151,8 +152,11 @@ public class GlimpseManager extends Thread implements MessageListener {
 				String bpmnID = msg.getObjectProperty("BPMNID").toString();
 				String sessionID = msg.getObjectProperty("SESSIONID").toString();	
 				
-				Vector<Learner> objectProperty = learnerAssessmentManager.getDBController().getLearners(learnersIDs); 
-				ruleDoc = learnerAssessmentManager.elaborateModel(xmlMessagePayload, objectProperty, sessionID, bpmnID);
+				Vector<Learner> learnersInvolved = learnerAssessmentManager.getDBController().getOrSetLearners(learnersIDs); 
+				
+				ScoreTemporaryStorage sessionScoreBuffer = new ScoreTemporaryStorage(learnersInvolved, sessionID);
+				
+				ruleDoc = learnerAssessmentManager.elaborateModel(xmlMessagePayload, learnersInvolved, sessionID, bpmnID);
 
 			} else {
 				ruleDoc = ComplexEventRuleActionListDocument.Factory.parse(xmlMessagePayload);

--- a/lp-simulation-environment/monitoring/src/main/java/eu/learnpad/simulator/mon/manager/GlimpseManager.java
+++ b/lp-simulation-environment/monitoring/src/main/java/eu/learnpad/simulator/mon/manager/GlimpseManager.java
@@ -51,7 +51,7 @@ import eu.learnpad.simulator.mon.consumer.ConsumerProfile;
 import eu.learnpad.simulator.mon.coverage.Learner;
 import eu.learnpad.simulator.mon.exceptions.IncorrectRuleFormatException;
 import eu.learnpad.simulator.mon.rules.RulesManager;
-import eu.learnpad.simulator.mon.rules.ScoreTemporaryStorage;
+import eu.learnpad.simulator.mon.storage.ScoreTemporaryStorage;
 import eu.learnpad.simulator.mon.utils.DebugMessages;
 
 public class GlimpseManager extends Thread implements MessageListener {

--- a/lp-simulation-environment/monitoring/src/main/java/eu/learnpad/simulator/mon/manager/LearnerAssessmentManager.java
+++ b/lp-simulation-environment/monitoring/src/main/java/eu/learnpad/simulator/mon/manager/LearnerAssessmentManager.java
@@ -24,4 +24,5 @@ public abstract class LearnerAssessmentManager extends Thread {
 	public abstract DBController getDBController();
 	public abstract void computeAndSaveScores(List<String> learnersID, String user, String idBPMN, String idPath, SessionScoreUpdateEvent sessionScore);
 	public abstract Vector<Path> setAllAbsoluteSessionScores(Vector<Path> theGeneratedPath);
+	public abstract void computeAndPropagateScores(List<String> learnersID, String idPath, String idBPMN);
 }

--- a/lp-simulation-environment/monitoring/src/main/java/eu/learnpad/simulator/mon/manager/ResponseDispatcher.java
+++ b/lp-simulation-environment/monitoring/src/main/java/eu/learnpad/simulator/mon/manager/ResponseDispatcher.java
@@ -129,6 +129,13 @@ public class ResponseDispatcher {
 	}	
 
 	
+	public static void setPathCompletedAndPropagateScores(String learnersID, String idPath, String idBPMN)
+	{
+		ResponseDispatcher.lam.computeAndPropagateScores(new ArrayList<String>(Arrays.asList(learnersID.split(","))), idPath, idBPMN);
+	}
+
+	
+	
 	public static void sendResponse(Object object, String enablerName, String answerTopic)
 	{
 		try {

--- a/lp-simulation-environment/monitoring/src/main/java/eu/learnpad/simulator/mon/rules/RuleElements.java
+++ b/lp-simulation-environment/monitoring/src/main/java/eu/learnpad/simulator/mon/rules/RuleElements.java
@@ -48,13 +48,13 @@ public class RuleElements {
 	
 	public static String getThenClauseForCoverageWithLearnersScoreUpdateAndProcessStartNotification(Activity[] theActivitySetToSetConsumed, String idBPMN, String idPath) {
 		String concat = "\n\t\tthen ";
-		for (int i = 0; i<(theActivitySetToSetConsumed.length*2)+2; i++) {
+		for (int i = 0; i<((theActivitySetToSetConsumed.length)+2); i++) {
 			concat = concat + "\n\t\t\t$"+ i
 					+ "Event.setConsumed(true); \n\t\t\tupdate($"+ i +"Event);"
 					+ "\n\t\t\tretract($"+ i +"Event);";					
 		}
 		 concat = concat + "\n\t\t\t" +
-			"ResponseDispatcher.saveAndNotifyLearnersScore(\"##LEARNERSINVOLVEDID##\", $"+ ((theActivitySetToSetConsumed.length*2)-1)+ "Event.getUserID() ,\"" + idBPMN + "\", drools.getRule().getName(), (SessionScoreUpdateEvent)$"+ ((theActivitySetToSetConsumed.length*2)-1)+"Event.getEvent());";
+			"ResponseDispatcher.saveAndNotifyLearnersScore(\"##LEARNERSINVOLVEDID##\", $"+ ((theActivitySetToSetConsumed.length)-1)+ "Event.getUserID() ,\"" + idBPMN + "\", drools.getRule().getName(), (SessionScoreUpdateEvent)$"+ ((theActivitySetToSetConsumed.length)-1)+"Event.getEvent());";
 		return concat;
 	}
 	
@@ -75,6 +75,20 @@ public class RuleElements {
 	
 	public static String getEnd() {
 		return "\n\t\tend\n\n\t";
+	}
+
+	public static String getThenClausesForSetPathsAsCompletedAndPropagateScoresToPlatformAndOR(
+			Activity[] anActivitiesSet, String idBPMN, String idPath) {
+		
+		String concat = "\n\t\tthen ";
+		for (int i = 0; i<((anActivitiesSet.length)+2); i++) {
+			concat = concat + "\n\t\t\t$"+ i
+					+ "Event.setConsumed(true); \n\t\t\tupdate($"+ i +"Event);"
+					+ "\n\t\t\tretract($"+ i +"Event);";					
+		}
+		 concat = concat + "\n\t\t\t" +
+			"ResponseDispatcher.setPathCompletedAndPropagateScores(\"##LEARNERSINVOLVEDID##\",\"" + idPath + "\", \"" + idBPMN + "\");";
+		return concat;
 	}
 	
 }

--- a/lp-simulation-environment/monitoring/src/main/java/eu/learnpad/simulator/mon/rules/ScoreTemporaryStorage.java
+++ b/lp-simulation-environment/monitoring/src/main/java/eu/learnpad/simulator/mon/rules/ScoreTemporaryStorage.java
@@ -1,0 +1,45 @@
+package eu.learnpad.simulator.mon.rules;
+
+import java.util.HashMap;
+import java.util.Vector;
+
+import eu.learnpad.simulator.mon.coverage.Learner;
+
+public class ScoreTemporaryStorage {
+
+	private static HashMap<String, Long> sessionScoreValues;
+	private static String sessionID;
+	
+	public ScoreTemporaryStorage(Vector<Learner> theLearnersInvolvedInSession, String sessionID) {
+		
+		ScoreTemporaryStorage.sessionID = sessionID;
+				
+		sessionScoreValues = new HashMap<String, Long>(theLearnersInvolvedInSession.size());
+		
+		for (int i = 0; i<theLearnersInvolvedInSession.size(); i++) {
+						sessionScoreValues.put(
+									theLearnersInvolvedInSession.get(i).getId(), 
+									0l);
+		}	
+	}
+	
+	public static String getSessionID() {
+		return sessionID;
+	}
+
+	public static void setSessionID(String sessionID) {
+		ScoreTemporaryStorage.sessionID = sessionID;
+	}
+
+	
+	public static void setTemporaryLearnerSessionScore(String learnerID, Long scoreValue) {
+						ScoreTemporaryStorage.sessionScoreValues.replace(
+									learnerID, 
+									ScoreTemporaryStorage.sessionScoreValues.get(learnerID), 
+									scoreValue);
+	}
+	
+	public static Long getTemporaryLearnerSessionScore(String learnerID) {
+		return ScoreTemporaryStorage.sessionScoreValues.get(learnerID);
+	}
+}

--- a/lp-simulation-environment/monitoring/src/main/java/eu/learnpad/simulator/mon/storage/DBController.java
+++ b/lp-simulation-environment/monitoring/src/main/java/eu/learnpad/simulator/mon/storage/DBController.java
@@ -55,7 +55,7 @@ public interface DBController {
 	public Topic getTopic(int theTopicID);
 	public boolean updateTopic(int theTopicId, Topic theTopicToUpdate);
 	
-	public Vector<Learner> getLearners(List<String> learnersIDs);
+	public Vector<Learner> getOrSetLearners(List<String> learnersIDs);
 	
 	public Vector<Path> getPathsExecutedByLearner(String learnerID, String idBPMN);
 	public Vector<Path> savePathsForBPMN(Vector<Path> vector);

--- a/lp-simulation-environment/monitoring/src/main/java/eu/learnpad/simulator/mon/storage/H2Controller.java
+++ b/lp-simulation-environment/monitoring/src/main/java/eu/learnpad/simulator/mon/storage/H2Controller.java
@@ -371,7 +371,7 @@ public class H2Controller implements DBController {
 	}
 
 	@Override
-	public Vector<Learner> getLearners(List<String> learnersIDs) {
+	public Vector<Learner> getOrSetLearners(List<String> learnersIDs) {
 		Vector<Learner> learners = new Vector<Learner>();
 		String query;
 		Learner aLearner;

--- a/lp-simulation-environment/monitoring/src/main/java/eu/learnpad/simulator/mon/storage/MySqlController.java
+++ b/lp-simulation-environment/monitoring/src/main/java/eu/learnpad/simulator/mon/storage/MySqlController.java
@@ -396,7 +396,7 @@ public class MySqlController implements DBController {
 	}
 
 	@Override
-	public Vector<Learner> getLearners(List<String> learnersIDs) {
+	public Vector<Learner> getOrSetLearners(List<String> learnersIDs) {
 		Vector<Learner> learners = new Vector<Learner>();
 		String query;
 		Learner aLearner;

--- a/lp-simulation-environment/monitoring/src/main/java/eu/learnpad/simulator/mon/storage/ScoreTemporaryStorage.java
+++ b/lp-simulation-environment/monitoring/src/main/java/eu/learnpad/simulator/mon/storage/ScoreTemporaryStorage.java
@@ -43,10 +43,9 @@ public class ScoreTemporaryStorage {
 
 	
 	public static void setTemporaryLearnerSessionScore(String learnerID, Long scoreValue) {
+						Long toReplace = ScoreTemporaryStorage.sessionScoreValues.get(learnerID);
 						ScoreTemporaryStorage.sessionScoreValues.replace(
-									learnerID, 
-									ScoreTemporaryStorage.sessionScoreValues.get(learnerID), 
-									scoreValue);
+									learnerID,	toReplace,	scoreValue);
 	}
 	
 	public static Long getTemporaryLearnerSessionScore(String learnerID) {

--- a/lp-simulation-environment/monitoring/src/main/java/eu/learnpad/simulator/mon/storage/ScoreTemporaryStorage.java
+++ b/lp-simulation-environment/monitoring/src/main/java/eu/learnpad/simulator/mon/storage/ScoreTemporaryStorage.java
@@ -43,9 +43,8 @@ public class ScoreTemporaryStorage {
 
 	
 	public static void setTemporaryLearnerSessionScore(String learnerID, Long scoreValue) {
-						Long toReplace = ScoreTemporaryStorage.sessionScoreValues.get(learnerID);
 						ScoreTemporaryStorage.sessionScoreValues.replace(
-									learnerID,	toReplace,	scoreValue);
+									learnerID, scoreValue);
 	}
 	
 	public static Long getTemporaryLearnerSessionScore(String learnerID) {

--- a/lp-simulation-environment/monitoring/src/main/java/eu/learnpad/simulator/mon/storage/ScoreTemporaryStorage.java
+++ b/lp-simulation-environment/monitoring/src/main/java/eu/learnpad/simulator/mon/storage/ScoreTemporaryStorage.java
@@ -1,15 +1,17 @@
-package eu.learnpad.simulator.mon.rules;
+package eu.learnpad.simulator.mon.storage;
 
 import java.util.HashMap;
 import java.util.Vector;
 
+import eu.learnpad.sim.rest.event.impl.SessionScoreUpdateEvent;
 import eu.learnpad.simulator.mon.coverage.Learner;
 
 public class ScoreTemporaryStorage {
 
 	private static HashMap<String, Long> sessionScoreValues;
 	private static String sessionID;
-	
+	private static SessionScoreUpdateEvent lastScoreUpdateEventSeen;
+
 	public ScoreTemporaryStorage(Vector<Learner> theLearnersInvolvedInSession, String sessionID) {
 		
 		ScoreTemporaryStorage.sessionID = sessionID;
@@ -27,6 +29,14 @@ public class ScoreTemporaryStorage {
 		return sessionID;
 	}
 
+	public static SessionScoreUpdateEvent getLastScoreUpdateEventSeen() {
+		return lastScoreUpdateEventSeen;
+	}
+
+	public static void setLastScoreUpdateEventSeen(SessionScoreUpdateEvent lastScoreUpdateEventSeen) {
+		ScoreTemporaryStorage.lastScoreUpdateEventSeen = lastScoreUpdateEventSeen;
+	}
+	
 	public static void setSessionID(String sessionID) {
 		ScoreTemporaryStorage.sessionID = sessionID;
 	}

--- a/lp-simulation-environment/monitoring/src/main/java/eu/learnpad/simulator/mon/storage/ScoreTemporaryStorage.java
+++ b/lp-simulation-environment/monitoring/src/main/java/eu/learnpad/simulator/mon/storage/ScoreTemporaryStorage.java
@@ -43,8 +43,8 @@ public class ScoreTemporaryStorage {
 
 	
 	public static void setTemporaryLearnerSessionScore(String learnerID, Long scoreValue) {
-						ScoreTemporaryStorage.sessionScoreValues.replace(
-									learnerID, scoreValue);
+		
+		ScoreTemporaryStorage.sessionScoreValues.put(learnerID, scoreValue);
 	}
 	
 	public static Long getTemporaryLearnerSessionScore(String learnerID) {


### PR DESCRIPTION
Rules generation fixed according new parameters there are now a generation of rules related to the path completion and one related to the capture of all the sessionscoreupdate.

All the updated session score are stored and used at the end of
simulation (SIMULATION_END) for calculation of kpi and others value that
will be sent to the cp and to the sim.

Activity has been updated taking in account the parameter taskartifactid
that sill be used for matching the events instead of the taskName
parameter.

The updates on the ScoreUpdateEvent should be approved by @tomjorquera
and @semmeneg

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/learnpad/learnpad/533)
<!-- Reviewable:end -->
