### PR TITLE
[sim] UI now support single session display

### DIFF
--- a/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/uihandler/webserver/UIHandlerWebImpl.java
+++ b/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/uihandler/webserver/UIHandlerWebImpl.java
@@ -187,7 +187,7 @@ public class UIHandlerWebImpl implements IUserHandler, IProcessEventReceiver {
 		for (String userId : event.involvedusers) {
 			if (usersMap.containsKey(userId)) {
 				((UIServlet) usersMap.get(userId).getServletInstance())
-						.addTask(event.task.id);
+						.addTask(event.simulationsessionid, event.task.id);
 			}
 		}
 	}

--- a/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/uihandler/webserver/msg/user/send/AddTask.java
+++ b/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/uihandler/webserver/msg/user/send/AddTask.java
@@ -35,8 +35,9 @@ public class AddTask implements IUserMsg {
 	/**
 	 * @param taskid
 	 */
-	public AddTask(String taskid) {
+	public AddTask(String sessionid, String taskid) {
 		super();
+		this.sessionid = sessionid;
 		this.taskid = taskid;
 	}
 
@@ -49,6 +50,7 @@ public class AddTask implements IUserMsg {
 		return TYPE.ADDTASK;
 	}
 
+	public final String sessionid;
 	public final String taskid;
 
 }

--- a/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/uihandler/webserver/msg/user/send/DeleteTask.java
+++ b/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/uihandler/webserver/msg/user/send/DeleteTask.java
@@ -35,8 +35,9 @@ public class DeleteTask implements IUserMsg {
 	/**
 	 * @param taskid
 	 */
-	public DeleteTask(String taskid) {
+	public DeleteTask(String sessionid, String taskid) {
 		super();
+		this.sessionid = sessionid;
 		this.taskid = taskid;
 	}
 
@@ -49,6 +50,7 @@ public class DeleteTask implements IUserMsg {
 		return TYPE.DELTASK;
 	}
 
+	public final String sessionid;
 	public final String taskid;
 
 }

--- a/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/uihandler/webserver/msg/user/send/ProcessFinished.java
+++ b/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/uihandler/webserver/msg/user/send/ProcessFinished.java
@@ -35,8 +35,9 @@ public class ProcessFinished implements IUserMsg {
 	/**
 	 * @param processid
 	 */
-	public ProcessFinished(String processid) {
+	public ProcessFinished(String sessionid, String processid) {
 		super();
+		this.sessionid = sessionid;
 		this.processid = processid;
 	}
 
@@ -49,6 +50,7 @@ public class ProcessFinished implements IUserMsg {
 		return TYPE.FINISHED;
 	}
 
+	public final String sessionid;
 	public final String processid;
 
 }

--- a/lp-simulation-environment/simulator/src/main/resources/static/TaskReceiver.js
+++ b/lp-simulation-environment/simulator/src/main/resources/static/TaskReceiver.js
@@ -39,147 +39,151 @@ function taskReceiver(address, user, integratedMode, sessionid) {
 
     newTaskReceiver._onmessage = function(m) {
         var msg = JSON.parse(m.data);
-        switch (msg.type) {
+        if(sessionid != null && sessionid != msg.sessionid) {
+            // ignore message
+        } else {
+            switch (msg.type) {
 
-        case 'SESSION_STARTED':
+            case 'SESSION_STARTED':
 
-            // create new tab for session
-            $('#taskstable').append(
-                '<li role="presentation"><a data-toggle="tab" href="#processcontainer' +
-                    msg.sessionid + '">' + msg.sessionname +
-                    '</a></li>'
-            );
-            var tasksDiv = $('#tasks');
-            var processDiv = document.createElement('div');
-            processDiv.id = 'processcontainer' + msg.sessionid;
-            processDiv.className = 'tab-pane';
-            tasksDiv.append(processDiv);
+                // create new tab for session
+                $('#taskstable').append(
+                    '<li role="presentation"><a data-toggle="tab" href="#processcontainer' +
+                        msg.sessionid + '">' + msg.sessionname +
+                        '</a></li>'
+                );
+                var tasksDiv = $('#tasks');
+                var processDiv = document.createElement('div');
+                processDiv.id = 'processcontainer' + msg.sessionid;
+                processDiv.className = 'tab-pane';
+                tasksDiv.append(processDiv);
 
-            var processMainDiv = document.createElement('div');
-            processMainDiv.id = 'processmain' + msg.sessionid;
-            processMainDiv.className = 'col-sm-8';
-            processDiv.appendChild(processMainDiv);
+                var processMainDiv = document.createElement('div');
+                processMainDiv.id = 'processmain' + msg.sessionid;
+                processMainDiv.className = 'col-sm-8';
+                processDiv.appendChild(processMainDiv);
 
-            var processSideDiv = document.createElement('div');
-            processSideDiv.id = 'processside' + msg.sessionid;
-            processSideDiv.className = 'col-sm-4';
-            processDiv.appendChild(processSideDiv);
+                var processSideDiv = document.createElement('div');
+                processSideDiv.id = 'processside' + msg.sessionid;
+                processSideDiv.className = 'col-sm-4';
+                processDiv.appendChild(processSideDiv);
 
-            if (!integratedMode) {
-                var processUserInfos = document.createElement('div');
-                processUserInfos.id = 'processuserinfos' +msg.sessionid;
-                processSideDiv.appendChild(processUserInfos);
+                if (!integratedMode) {
+                    var processUserInfos = document.createElement('div');
+                    processUserInfos.id = 'processuserinfos' +msg.sessionid;
+                    processSideDiv.appendChild(processUserInfos);
 
-                users(address, user, msg.involvedusers, processUserInfos.id);
+                    users(address, user, msg.involvedusers, processUserInfos.id);
+                }
+
+                // add session chat container
+                $('#processside' + msg.sessionid).append(
+                    '<div id="sessionchat' + msg.sessionid + '"></div>'
+                );
+                sessionChat('#sessionchat' + msg.sessionid, address, user, msg.sessionid);
+
+                // add gamification panel to side div
+                var scoreHelpText = "Your score is calculated based on how well you perform each task.<p>Each successfully completed task gives you points based of your number of attempts and how long did you take regarding the expected time.<p>Faster completion and less mistakes will award more points.";
+                $('#processside' + msg.sessionid).append(
+                    '<div id="gamification' + msg.sessionid +
+                        '" class="game-panel panel panel-default">' +
+                        '<div class="panel-body">' +
+                        '<div><h4><em id="score' + msg.sessionid +
+                        '"></em> <span style="float:right" class="glyphicon glyphicon-question-sign"' +
+                        ' data-toggle="popover" data-trigger="focus" tabindex="0" ' +
+                        'data-placement="bottom" data-content="' + scoreHelpText +
+                        '"></span></h4></div></div></div>'
+                );
+                // initialize help popover
+                $('#gamification' + msg.sessionid + ' [data-toggle="popover"]').popover({'html': true});
+
+                // this element can cause page height change, so we need to
+                // monitor it
+                heightMon.monitor('#gamification' + msg.sessionid + ' [data-toggle="popover"]');
+                $('#gamification' + msg.sessionid + ' [data-toggle="popover"]').bind(
+                    'transitionend', heightMon.checkForChangeNotification);
+
+                // check if it is the first tab
+                // (in this case we make it open by default)
+                if ($('#taskstable li').length == 1) {
+                    $('#taskstable li a:first').tab('show');
+                }
+
+                // add the process diagram container
+                // We add an image of the initial process of the session,
+                // it will be updated when we receive tasks
+                $('#processmain' + msg.sessionid).append(
+                    '<div class="panel-group diagram" id="accordion' +
+                        msg.sessionid +
+                        '" role="tablist" aria-multiselectable="true">' +
+                        '<div class="panel panel-default">' +
+                        '<div class="panel-heading" role="tab" id="diagramHeading' + msg.sessionid +
+                        '"><h4 class="panel-title">' +
+                        '<a class="collapsed" data-toggle="collapse" data-parent="#accordion' + msg.sessionid +
+                        '" href="#diagramCollapse' + msg.sessionid +
+                        '" aria-expanded="true" aria-controls="diagramCollapse' + msg.sessionid +
+                        '">See Process Diagram' + '</a>' + '</h4>' + '</div>' +
+                        '<div id="diagramCollapse' + msg.sessionid +
+                        '" class="panel-collapse collapse in" role="tabpanel" aria-labelledby="diagramHeading' + msg.sessionid +
+                        '"><div class="panel-body" style="overflow: scroll;width: 100%;">' +
+                        '<img class="diagramImg" src="diagram/process/' + msg.initialprocessdefinitionkey + '"></img>' +
+                        '</div>' +
+                        '</div>' +
+                        '</div>' +
+                        '</div>'
+                );
+
+                // this element can cause page height change, so we need to
+                // monitor it
+                heightMon.monitor('#accordion' + msg.sessionid);
+                document.getElementById('accordion' + msg.sessionid).addEventListener(
+                    "transitionend",
+                    heightMon.checkForChangeNotification);
+                break;
+            case 'SESSION_FINISHED':
+                var containerDiv = $('#processmain' + msg.sessionid);
+                var processFinished = document.createElement('p');
+
+                var totalScore = 0;
+
+                var result = '<h4>Congratulations, you successfully completed the simulation</h4>';
+                result += '<p>Session Score Summary:</p>';
+                result += '<table class="detailed-score table table-striped table-condensed">';
+                result += '<tr><th>Task</th><th>Score</th></tr>';
+                // add task scores
+                for(var aTask in msg.tasknames) {
+                    result += '<tr><td>' + msg.tasknames[aTask] + '</td><td>' +
+                        msg.taskscores[aTask] +'</td></tr>';
+
+                    totalScore += msg.taskscores[aTask];
+                }
+
+                result += '<tr><td><i>Total session score</i></td><td><i>' + totalScore + '</i></td></tr>';
+                result += '</table>';
+
+                processFinished.innerHTML = result;
+
+                containerDiv.append(processFinished);
+
+                // remove process diagram
+                $('#accordion' + msg.sessionid).remove();
+
+                break;
+
+            case 'ADDTASK':
+                var newTask = task(address, msg.taskid, user, integratedMode);
+                newTaskReceiver.activeTasks[msg.taskid] = newTask;
+                newTask.join();
+                break;
+
+            case 'DELTASK':
+                // may be undefined if task was closed from another ui
+                newTaskReceiver.activeTasks[msg.taskid].end();
+                delete newTaskReceiver.activeTasks[msg.taskid];
+                break;
             }
 
-            // add session chat container
-            $('#processside' + msg.sessionid).append(
-                '<div id="sessionchat' + msg.sessionid + '"></div>'
-            );
-            sessionChat('#sessionchat' + msg.sessionid, address, user, msg.sessionid);
-
-            // add gamification panel to side div
-            var scoreHelpText = "Your score is calculated based on how well you perform each task.<p>Each successfully completed task gives you points based of your number of attempts and how long did you take regarding the expected time.<p>Faster completion and less mistakes will award more points.";
-            $('#processside' + msg.sessionid).append(
-                '<div id="gamification' + msg.sessionid +
-                    '" class="game-panel panel panel-default">' +
-                    '<div class="panel-body">' +
-                    '<div><h4><em id="score' + msg.sessionid +
-                    '"></em> <span style="float:right" class="glyphicon glyphicon-question-sign"' +
-                    ' data-toggle="popover" data-trigger="focus" tabindex="0" ' +
-                    'data-placement="bottom" data-content="' + scoreHelpText +
-                    '"></span></h4></div></div></div>'
-            );
-            // initialize help popover
-            $('#gamification' + msg.sessionid + ' [data-toggle="popover"]').popover({'html': true});
-
-            // this element can cause page height change, so we need to
-            // monitor it
-            heightMon.monitor('#gamification' + msg.sessionid + ' [data-toggle="popover"]');
-            $('#gamification' + msg.sessionid + ' [data-toggle="popover"]').bind(
-                'transitionend', heightMon.checkForChangeNotification);
-
-            // check if it is the first tab
-            // (in this case we make it open by default)
-            if ($('#taskstable li').length == 1) {
-                $('#taskstable li a:first').tab('show');
-            }
-
-            // add the process diagram container
-            // We add an image of the initial process of the session,
-            // it will be updated when we receive tasks
-            $('#processmain' + msg.sessionid).append(
-                '<div class="panel-group diagram" id="accordion' +
-                    msg.sessionid +
-                    '" role="tablist" aria-multiselectable="true">' +
-                    '<div class="panel panel-default">' +
-                    '<div class="panel-heading" role="tab" id="diagramHeading' + msg.sessionid +
-                    '"><h4 class="panel-title">' +
-                    '<a class="collapsed" data-toggle="collapse" data-parent="#accordion' + msg.sessionid +
-                    '" href="#diagramCollapse' + msg.sessionid +
-                    '" aria-expanded="true" aria-controls="diagramCollapse' + msg.sessionid +
-                    '">See Process Diagram' + '</a>' + '</h4>' + '</div>' +
-                    '<div id="diagramCollapse' + msg.sessionid +
-                    '" class="panel-collapse collapse in" role="tabpanel" aria-labelledby="diagramHeading' + msg.sessionid +
-                    '"><div class="panel-body" style="overflow: scroll;width: 100%;">' +
-                    '<img class="diagramImg" src="diagram/process/' + msg.initialprocessdefinitionkey + '"></img>' +
-                    '</div>' +
-                    '</div>' +
-                    '</div>' +
-                    '</div>'
-            );
-
-            // this element can cause page height change, so we need to
-            // monitor it
-            heightMon.monitor('#accordion' + msg.sessionid);
-            document.getElementById('accordion' + msg.sessionid).addEventListener(
-                "transitionend",
-                heightMon.checkForChangeNotification);
-            break;
-        case 'SESSION_FINISHED':
-            var containerDiv = $('#processmain' + msg.sessionid);
-            var processFinished = document.createElement('p');
-
-            var totalScore = 0;
-
-            var result = '<h4>Congratulations, you successfully completed the simulation</h4>';
-            result += '<p>Session Score Summary:</p>';
-            result += '<table class="detailed-score table table-striped table-condensed">';
-            result += '<tr><th>Task</th><th>Score</th></tr>';
-            // add task scores
-            for(var aTask in msg.tasknames) {
-                result += '<tr><td>' + msg.tasknames[aTask] + '</td><td>' +
-                    msg.taskscores[aTask] +'</td></tr>';
-
-                totalScore += msg.taskscores[aTask];
-            }
-
-            result += '<tr><td><i>Total session score</i></td><td><i>' + totalScore + '</i></td></tr>';
-            result += '</table>';
-
-            processFinished.innerHTML = result;
-
-            containerDiv.append(processFinished);
-
-            // remove process diagram
-            $('#accordion' + msg.sessionid).remove();
-
-            break;
-
-        case 'ADDTASK':
-            var newTask = task(address, msg.taskid, user, integratedMode);
-            newTaskReceiver.activeTasks[msg.taskid] = newTask;
-            newTask.join();
-            break;
-
-        case 'DELTASK':
-            // may be undefined if task was closed from another ui
-            newTaskReceiver.activeTasks[msg.taskid].end();
-            delete newTaskReceiver.activeTasks[msg.taskid];
-            break;
         }
-
         // some events can cause height change
         heightMon.checkForChangeNotification();
     };
@@ -189,7 +193,7 @@ function taskReceiver(address, user, integratedMode, sessionid) {
             function(taskid) {
                 newTaskReceiver.activeTasks[taskid].end();
                 delete newTaskReceiver.activeTasks[taskid];
-        });
+            });
         delete taskReceiver._ws;
         if (newTaskReceiver.finishOnError) {
             alert(

--- a/lp-simulation-environment/simulator/src/main/resources/static/TaskReceiver.js
+++ b/lp-simulation-environment/simulator/src/main/resources/static/TaskReceiver.js
@@ -20,7 +20,7 @@
  */
 'use strict';
 
-function taskReceiver(address, user, integratedMode) {
+function taskReceiver(address, user, integratedMode, sessionid) {
     if (typeof integratedMode == 'undefined') {
         integratedMode = false;
     }

--- a/lp-simulation-environment/simulator/src/main/resources/ui.html
+++ b/lp-simulation-environment/simulator/src/main/resources/ui.html
@@ -259,6 +259,7 @@
                  return decodeURIComponent(name[1]);
          }
          var userid = get("userid");
+         var sessionid = get("simulationid");
 
          var integratedMode = false;
          if(window != parent.window) {
@@ -273,14 +274,14 @@
          }
 
          if(userid != null) {
-             taskReceiver(#serveripaddress#, userid, integratedMode);
+             taskReceiver(#serveripaddress#, userid, integratedMode, sessionid);
              if(!integratedMode) {
                  dummyChat('chatcontainer', #serveripaddress#, userid);
              }
          } else {
              $('#connectBn').click(function(event) {
                  userid = $('#uiid').val();
-                 taskReceiver(#serveripaddress#, userid, integratedMode);
+                 taskReceiver(#serveripaddress#, userid, integratedMode, sessionid);
                  if(!integratedMode) {
                      dummyChat('chatcontainer', #serveripaddress#, userid);
                  }

--- a/lp-simulation-environment/simulator/src/test/java/eu/learnpad/simulator/uihandler/webserver/UIHandlerWebImplTest.java
+++ b/lp-simulation-environment/simulator/src/test/java/eu/learnpad/simulator/uihandler/webserver/UIHandlerWebImplTest.java
@@ -110,11 +110,11 @@ public class UIHandlerWebImplTest {
 							taskAddByUI.put(userKey, new ArrayList<String>());
 						}
 						taskAddByUI.get(userKey).add(
-								invocation.getArgumentAt(0, String.class));
+								invocation.getArgumentAt(1, String.class));
 						return null;
 					}
 
-				}).when(mockServlet).addTask(any(String.class));
+				}).when(mockServlet).addTask(any(String.class), any(String.class));
 
 				// memorize remove task invocations
 				doAnswer(new Answer<Void>() {


### PR DESCRIPTION
The user UI now supports an optional "sessionid" parameter.
If this parameter is specified, the UI will only show tasks and events
related to the given session.

This is used in the CW to display only the current simulation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/learnpad/learnpad/538)
<!-- Reviewable:end -->
