### PR TITLE
[sim] add infobox for multi-users sim url

### DIFF
--- a/lp-simulation-environment/simulator/README.md
+++ b/lp-simulation-environment/simulator/README.md
@@ -37,6 +37,7 @@ The simulator allows to override some configuration using an optional properties
 
 - the IP used by the simulator
 - the address of the glimpse server
+- the address of the LearnPAd platform
 
 This properties file must named `simulator.properties` and placed in the folder from which the simulator is started (typically the ./out subfolder if launching the simulator with the start script).
 
@@ -45,6 +46,9 @@ To override the address user by the simulator, put the following inside the file
 
 To override the glimpse server, put the following inside the file:
 `glimpse_server=tcp://<address>`
+
+To override the LearnPAd platform address, put the following inside the file:
+`platform_address=<address>`
 
 # Interfaces
 

--- a/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/uihandler/webserver/WebServer.java
+++ b/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/uihandler/webserver/WebServer.java
@@ -402,6 +402,8 @@ public class WebServer {
 			// set server ip
 			uiPage = uiPage.replace("#serveripaddress#", "\"" + getIPAddress()
 					+ ":" + port + "\"");
+			uiPage = uiPage.replace("#platformaddress#", "\"" + SimulatorProperties.props
+					.getProperty(SimulatorProperties.PLATFORM_ADDRESS) + "\"");
 
 			response.setContentType("text/html; charset=utf-8");
 			response.setStatus(HttpServletResponse.SC_OK);

--- a/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/utils/SimulatorProperties.java
+++ b/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/utils/SimulatorProperties.java
@@ -42,6 +42,7 @@ public class SimulatorProperties {
 
 	public final static String PROP_ADDRESS = "address";
 	public final static String PROP_GLIMPSE_SERVER = "glimpse_server";
+	public final static String PLATFORM_ADDRESS = "platform_address";
 
 	static {
 

--- a/lp-simulation-environment/simulator/src/main/resources/simulator.properties
+++ b/lp-simulation-environment/simulator/src/main/resources/simulator.properties
@@ -1,1 +1,2 @@
 glimpse_server=tcp://localhost:61616
+platform_address=localhost:8080

--- a/lp-simulation-environment/simulator/src/main/resources/static/TaskReceiver.js
+++ b/lp-simulation-environment/simulator/src/main/resources/static/TaskReceiver.js
@@ -76,6 +76,14 @@ function taskReceiver(address, user, integratedMode, sessionid, platformAddress)
                     users(address, user, msg.involvedusers, processUserInfos.id);
                 }
 
+                // add infobox with links for other users to join
+                var infoLinks = '<div class="alert alert-info" role="alert">' +
+                        'Other participants can join the session using the following link (when logged in):<p>';
+                var url = 'http://' + platformAddress + '/xwiki/bin/view/LPUI/SimulationEnvironment?sessionid=' + msg.sessionid;
+                infoLinks += '<a href="' + url + '">' + url + '</a><p>';
+                infoLinks += '</div>';
+                $('#processmain' + msg.sessionid).append(infoLinks);
+
                 // add session chat container
                 $('#processside' + msg.sessionid).append(
                     '<div id="sessionchat' + msg.sessionid + '"></div>'

--- a/lp-simulation-environment/simulator/src/main/resources/static/TaskReceiver.js
+++ b/lp-simulation-environment/simulator/src/main/resources/static/TaskReceiver.js
@@ -20,7 +20,7 @@
  */
 'use strict';
 
-function taskReceiver(address, user, integratedMode, sessionid) {
+function taskReceiver(address, user, integratedMode, sessionid, platformAddress) {
     if (typeof integratedMode == 'undefined') {
         integratedMode = false;
     }

--- a/lp-simulation-environment/simulator/src/main/resources/ui.html
+++ b/lp-simulation-environment/simulator/src/main/resources/ui.html
@@ -281,7 +281,7 @@
          } else {
              $('#connectBn').click(function(event) {
                  userid = $('#uiid').val();
-                 taskReceiver(#serveripaddress#, userid, integratedMode, sessionid);
+                 taskReceiver(#serveripaddress#, userid, integratedMode, sessionid, #platformaddress#);
                  if(!integratedMode) {
                      dummyChat('chatcontainer', #serveripaddress#, userid);
                  }

--- a/lp-simulation-environment/simulator/src/test/java/eu/learnpad/simulator/uihandler/webserver/WebServerTest.java
+++ b/lp-simulation-environment/simulator/src/test/java/eu/learnpad/simulator/uihandler/webserver/WebServerTest.java
@@ -51,6 +51,7 @@ import org.junit.Test;
 
 import eu.learnpad.simulator.MainTest;
 import eu.learnpad.simulator.Simulator;
+import eu.learnpad.simulator.utils.SimulatorProperties;
 
 /**
  *
@@ -122,6 +123,8 @@ public class WebServerTest {
 				localPageContent = localPageContent.replace(
 						"#serveripaddress#", "\"" + WebServer.getIPAddress()
 						+ ":" + MainTest.PORT + "\"");
+				localPageContent = localPageContent.replace("#platformaddress#",
+						"\"" + SimulatorProperties.props.getProperty(SimulatorProperties.PLATFORM_ADDRESS) + "\"");
 
 				byte[] fetchedFileDigest = checksum(new ByteArrayInputStream(
 						fetchedPageContent.getBytes()),


### PR DESCRIPTION
This PR adds an infobox at the top of a session displaying a link to join the session.
In order to add this feature, the PR introduces a new property in the simulator for setting the address of the platform.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/learnpad/learnpad/539)
<!-- Reviewable:end -->
