### PR TITLE
[sim] Add build option for specific deployments

### DIFF
--- a/lp-simulation-environment/README.md
+++ b/lp-simulation-environment/README.md
@@ -47,6 +47,15 @@ The main configurations are given or impacts on the following (possibly not comp
  * lp-simulation-environment/scripts/start 
  * lp-simulation-environment/out/start (only once the system is built)
 
+## Specific deployment
+
+When building the component, it is possible to pass a "--name" argument to the ./build script, where "name" correspond to subfolder in the `deployment` folder, containing a set of files to be used for a specific deployment.
+    
+For example, if `deployment` contains a `test` folder, the command ./build --test will setup the files in this folder accordingly.
+
+Currently, the following files can be installed via this process:
+ * simulator.properties
+
 ## Note that for this test HTTP protocol should be used.
 
 # Interfaces

--- a/lp-simulation-environment/build
+++ b/lp-simulation-environment/build
@@ -74,8 +74,24 @@ function component_install() {
                 mkdir ${__OUT_PATH__}/monitoring &&
                 cp -r ${__COMPONENT_PATH__}/simulator/out ${__OUT_PATH__}/simulator/out &&
                 cp -r ${__COMPONENT_PATH__}/monitoring/out ${__OUT_PATH__}/monitoring/out
+
+            # check if known deployment is required and setup files
+            if [ -n "$1" -a -d "${__COMPONENT_PATH__}/deployment/$1" ]
+            then
+                cp "${__COMPONENT_PATH__}/deployment/$1/simulator.properties" \
+                   "${__COMPONENT_PATH__}/simulator/"
+            fi
         fi;
     fi
 }
 
-component_build && component_test && component_install
+for i in "$@"
+do
+    case $i in
+        --*)
+        CASE=${i#--}
+        ;;
+    esac
+done
+
+component_build && component_test && component_install $CASE


### PR DESCRIPTION
Add the option to specify a "--name" argument in the ./build script,
where "name" correspond to subfolder in the `deployment` folder,
containing a set of files to be used for a specific deployment.

For example, if `deployment` contains a `test` folder, the command
./build --test will setup the files in this folder accordingly.

Update README accordingly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/learnpad/learnpad/540)
<!-- Reviewable:end -->
