### PR TITLE
[sim] fix deployment file path

### DIFF
--- a/lp-simulation-environment/build
+++ b/lp-simulation-environment/build
@@ -79,7 +79,7 @@ function component_install() {
             if [ -n "$1" -a -d "${__COMPONENT_PATH__}/deployment/$1" ]
             then
                 cp "${__COMPONENT_PATH__}/deployment/$1/simulator.properties" \
-                   "${__COMPONENT_PATH__}/simulator/"
+                   "${__COMPONENT_PATH__}/simulator/out/"
             fi
         fi;
     fi


### PR DESCRIPTION
Previous version of the build script did not put files in the correct
place in case of deployment (damn you eclipse and your convenient load
paths).
This commit changes the build script to use the correct path.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/learnpad/learnpad/543)
<!-- Reviewable:end -->
