### PR TITLE
[sim] Fix undefined CW url in join message

### DIFF
--- a/lp-simulation-environment/simulator/src/main/resources/ui.html
+++ b/lp-simulation-environment/simulator/src/main/resources/ui.html
@@ -274,7 +274,7 @@
          }
 
          if(userid != null) {
-             taskReceiver(#serveripaddress#, userid, integratedMode, sessionid);
+             taskReceiver(#serveripaddress#, userid, integratedMode, sessionid, #platformaddress#);
              if(!integratedMode) {
                  dummyChat('chatcontainer', #serveripaddress#, userid);
              }


### PR DESCRIPTION
Add missing parameter to taskReceiver. This fixes the `undefined`
erroneous URL when displaying "join session" message.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/learnpad/learnpad/547)
<!-- Reviewable:end -->
