### PR TITLE
[sim] fix build script "file exist" error

### DIFF
--- a/lp-simulation-environment/build
+++ b/lp-simulation-environment/build
@@ -70,8 +70,8 @@ function component_install() {
             mkdir -p ${__OUT_PATH__} &&
                 cp "scripts/start" "${__OUT_START_FILE__}" &&
                 cp "scripts/stop" "${__OUT_STOP_FILE__}" &&
-                mkdir ${__OUT_PATH__}/simulator &&
-                mkdir ${__OUT_PATH__}/monitoring &&
+                mkdir -p ${__OUT_PATH__}/simulator &&
+                mkdir -p ${__OUT_PATH__}/monitoring &&
                 cp -r ${__COMPONENT_PATH__}/simulator/out ${__OUT_PATH__}/simulator/out &&
                 cp -r ${__COMPONENT_PATH__}/monitoring/out ${__OUT_PATH__}/monitoring/out
 


### PR DESCRIPTION
Some conditions could cause the build script to fail with a "file
exists" error.
Change build script to avoid failing if folder is already created.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/learnpad/learnpad/550)
<!-- Reviewable:end -->
