### PR TITLE
[sim] fix URL in "join session" message

### DIFF
--- a/lp-simulation-environment/simulator/src/main/resources/static/TaskReceiver.js
+++ b/lp-simulation-environment/simulator/src/main/resources/static/TaskReceiver.js
@@ -79,7 +79,7 @@ function taskReceiver(address, user, integratedMode, sessionid, platformAddress)
                 // add infobox with links for other users to join
                 var infoLinks = '<div class="alert alert-info" role="alert">' +
                         'Other participants can join the session using the following link (when logged in):<p>';
-                var url = 'http://' + platformAddress + '/xwiki/bin/view/LPUI/SimulationEnvironment?sessionid=' + msg.sessionid;
+                var url = 'http://' + platformAddress + '/xwiki/bin/view/LPUI/SimulationEnvironment?simulationid=' + msg.sessionid;
                 infoLinks += '<a href="' + url + '">' + url + '</a><p>';
                 infoLinks += '</div>';
                 $('#processmain' + msg.sessionid).append(infoLinks);


### PR DESCRIPTION
Fix an incorrect parameter in the "join session" message.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/learnpad/learnpad/551)
<!-- Reviewable:end -->
