### PR TITLE
[sim] fix serviceconf default params init

### DIFF
--- a/lp-simulation-environment/simulator/src/main/resources/static/Process.js
+++ b/lp-simulation-environment/simulator/src/main/resources/static/Process.js
@@ -115,6 +115,15 @@ function processReceiver(address) {
             }
 
             // some default values
+            values['off1Choice'] = 'off1Ok';
+            values['off2Choice'] = 'off2Ok';
+
+            values['off1FeedbackOpinionStatus'] = 's5';
+            values['off2FeedbackOpinionStatus'] = 's5';
+
+            values['off1FeedbackMotivation'] = '';
+            values['off2FeedbackMotivation'] = '';
+
             values['off1FeedbackCond1'] = '';
             values['off1FeedbackCond2'] = '';
             values['off1FeedbackCond3'] = '';


### PR DESCRIPTION
Add some missing default values for serviceconf initialization. These
parameters are needed in case one of the two other offices represent a
third-party *not* involved in the process, since in this case a robot
will not provide meaningful value.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/learnpad/learnpad/572)
<!-- Reviewable:end -->
