### PR TITLE
[sim] Replace simple robots with markovbots

### DIFF
--- a/lp-simulation-environment/simulator/pom.xml
+++ b/lp-simulation-environment/simulator/pom.xml
@@ -306,6 +306,7 @@
 						<exclude>main/resources/static/lib/**</exclude>
 						<exclude>main/resources/license/**</exclude>
 						<exclude>main/resources/validation_db.json</exclude>
+						<exclude>main/resources/markov/**.json</exclude>
 						<exclude>main/resources/assembly.xml</exclude>
 						<exclude>main/resources/**.properties</exclude>
 					</excludes>

--- a/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/Simulator.java
+++ b/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/Simulator.java
@@ -22,6 +22,7 @@ package eu.learnpad.simulator;
  */
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Map;
 
 import org.activiti.engine.ProcessEngine;
@@ -36,7 +37,7 @@ import eu.learnpad.simulator.processmanager.activiti.ActivitiProcessManager;
 import eu.learnpad.simulator.robot.IRobotFactory;
 import eu.learnpad.simulator.robot.RobotUserEventReceiver;
 import eu.learnpad.simulator.robot.activiti.ActivitiRobotInputExtractor;
-import eu.learnpad.simulator.robot.activiti.simplerobot.SimpleRobotFactory;
+import eu.learnpad.simulator.robot.activiti.markovrobot.onelevel.OneLevelMarkovBotFactory;
 import eu.learnpad.simulator.uihandler.formhandler.AbstractFormHandler;
 import eu.learnpad.simulator.uihandler.formhandler.multi2jsonform.Multi2JsonFormFormHandler;
 import eu.learnpad.simulator.uihandler.webserver.UIHandlerWebImpl;
@@ -90,9 +91,8 @@ public class Simulator implements IProcessManagerProvider,
 				"tasks", this), new ArrayList<String>(), this, formHandler);
 
 		// handle robots
-		robotFactory = new SimpleRobotFactory(
-				processEngine.getRepositoryService(),
-				processEngine.getTaskService(), formHandler);
+		robotFactory = new OneLevelMarkovBotFactory(processEngine.getTaskService(), processEngine.getRepositoryService(),
+				OneLevelMarkovBotFactory.readTrainingData(Arrays.asList("markov/train.json")), 12345L);
 
 		robotEventReceiver = new RobotUserEventReceiver<>(
 				robotFactory, new ActivitiRobotInputExtractor(

--- a/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/robot/activiti/markovrobot/onelevel/ObservationData.java
+++ b/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/robot/activiti/markovrobot/onelevel/ObservationData.java
@@ -1,0 +1,44 @@
+package eu.learnpad.simulator.robot.activiti.markovrobot.onelevel;
+
+/*
+ * #%L
+ * LearnPAd Simulator
+ * %%
+ * Copyright (C) 2014 - 2016 Linagora
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+import java.util.Map;
+
+public class ObservationData {
+	final String process;
+	final String task;
+	final Map<String, Object> input;
+	final Map<String, Object> output;
+
+	public ObservationData(String process, String task, Map<String, Object> input, Map<String, Object> output) {
+		super();
+		this.process = process;
+		this.task = task;
+		this.input = input;
+		this.output = output;
+	}
+
+	@Override
+	public String toString() {
+		return "{ process: " + process + ", task: " + task + ", " + "input: " + input + ", output: " + output + "}";
+	}
+}

--- a/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/robot/activiti/markovrobot/onelevel/OneLevelMarkovBot.java
+++ b/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/robot/activiti/markovrobot/onelevel/OneLevelMarkovBot.java
@@ -1,0 +1,91 @@
+package eu.learnpad.simulator.robot.activiti.markovrobot.onelevel;
+
+/*
+ * #%L
+ * LearnPAd Simulator
+ * %%
+ * Copyright (C) 2014 - 2016 Linagora
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+import org.activiti.engine.RepositoryService;
+import org.activiti.engine.TaskService;
+import org.activiti.engine.task.Task;
+
+import eu.learnpad.simulator.robot.IRobot;
+
+public class OneLevelMarkovBot implements IRobot<Map<String, Object>, Map<String, Object>> {
+
+	private final TaskService taskService;
+	private final RepositoryService repoService;
+	private final Random rand;
+	private final Collection<ObservationData> observationMemory = new ArrayList<>();
+
+	public OneLevelMarkovBot(TaskService taskService, RepositoryService repoService, long seed,
+			Collection<ObservationData> trainingData) {
+		super();
+		this.taskService = taskService;
+		this.repoService = repoService;
+		this.rand = new Random(seed);
+
+		observationMemory.addAll(trainingData);
+
+	}
+
+	public OneLevelMarkovBot(TaskService taskService, RepositoryService repoService,
+			Collection<ObservationData> trainingData) {
+		this(taskService, repoService, new Random().nextLong(), trainingData);
+	}
+
+	public Map<String, Object> draw(ObservationData context) {
+
+		List<ObservationData> candidates = new ArrayList<>();
+
+		for (ObservationData candidate : observationMemory) {
+			if (candidate.process.equals(context.process) && candidate.task.equals(context.task)
+					&& context.input.entrySet().containsAll(candidate.input.entrySet())) {
+				candidates.add(candidate);
+			}
+		}
+
+		if (candidates.size() == 0) {
+			return new HashMap<>();
+		}
+
+		final int drawnValue = rand.nextInt(candidates.size());
+
+		return candidates.get(drawnValue).output;
+
+	}
+
+	@Override
+	public Map<String, Object> handleTask(String taskId, Map<String, Object> inputData) {
+
+		Task task = taskService.createTaskQuery().taskId(taskId).singleResult();
+		String taskKey = task.getTaskDefinitionKey();
+		String processKey = repoService.createProcessDefinitionQuery().processDefinitionId(task.getProcessDefinitionId())
+				.singleResult().getKey();
+		return draw(new ObservationData(processKey, taskKey, inputData, new HashMap<String, Object>()));
+	}
+
+}

--- a/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/robot/activiti/markovrobot/onelevel/OneLevelMarkovBotFactory.java
+++ b/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/robot/activiti/markovrobot/onelevel/OneLevelMarkovBotFactory.java
@@ -1,0 +1,140 @@
+/**
+ *
+ */
+package eu.learnpad.simulator.robot.activiti.markovrobot.onelevel;
+
+/*
+ * #%L
+ * LearnPAd Simulator
+ * %%
+ * Copyright (C) 2014 - 2015 Linagora
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Random;
+import java.util.Scanner;
+
+import org.activiti.engine.RepositoryService;
+import org.activiti.engine.TaskService;
+import org.activiti.engine.impl.util.json.JSONArray;
+import org.activiti.engine.impl.util.json.JSONObject;
+
+import eu.learnpad.simulator.robot.IRobot;
+import eu.learnpad.simulator.robot.IRobotFactory;
+
+/**
+ * @author Tom Jorquera - Linagora
+ *
+ */
+public class OneLevelMarkovBotFactory implements IRobotFactory<Map<String, Object>, Map<String, Object>> {
+
+	private final TaskService taskService;
+	private final RepositoryService repoService;
+	private final Collection<ObservationData> trainingData;
+	private final Random rand;
+
+	public OneLevelMarkovBotFactory(TaskService taskService, RepositoryService repoService,
+			Collection<ObservationData> trainingData, Long seed) {
+		super();
+		this.taskService = taskService;
+		this.repoService = repoService;
+		this.trainingData = trainingData;
+		this.rand = new Random(seed);
+	}
+
+	public OneLevelMarkovBotFactory(TaskService taskService, RepositoryService repoService,
+			Collection<ObservationData> trainingData) {
+		this(taskService, repoService, trainingData, new Random().nextLong());
+	}
+
+	/*
+	 * (non-Javadoc)
+	 *
+	 * @see eu.learnpad.simulator.robot.IRobotFactory#createRobot()
+	 */
+	@Override
+	public IRobot<Map<String, Object>, Map<String, Object>> createRobot() {
+		return new OneLevelMarkovBot(taskService, repoService, rand.nextLong(), trainingData);
+	}
+
+	@SuppressWarnings("unchecked")
+	public static Collection<ObservationData> readTrainingData(Collection<String> files) {
+		Collection<ObservationData> res = new ArrayList<>();
+
+		for (String file : files) {
+
+			// read JSON data
+			Scanner in = new Scanner(OneLevelMarkovBotFactory.class.getClassLoader().getResourceAsStream(file));
+			String jsonText = "";
+			while (in.hasNextLine()) {
+				jsonText = jsonText + in.nextLine();
+			}
+			in.close();
+			System.out.println(jsonText);
+
+			JSONObject jsonObject = new JSONObject(jsonText);
+
+			// transform to collection of Observation data
+			Iterator<String> processIter = jsonObject.keys();
+
+			while (processIter.hasNext()) {
+				String processKey = processIter.next();
+
+				JSONObject taskObject = jsonObject.getJSONObject(processKey);
+				Iterator<String> taskIter = taskObject.keys();
+
+				while (taskIter.hasNext()) {
+					String taskKey = taskIter.next();
+
+					JSONArray obsArray = taskObject.getJSONArray(taskKey);
+
+					for (int i = 0; i < obsArray.length(); i++) {
+						JSONObject obs = obsArray.getJSONObject(i);
+
+						Map<String, Object> input = new HashMap<>();
+						JSONObject inputJs = obs.getJSONObject("input");
+						Iterator<String> inputIter = inputJs.keys();
+						while (inputIter.hasNext()) {
+							String inputKey = inputIter.next();
+							input.put(inputKey, inputJs.get(inputKey));
+						}
+
+						Map<String, Object> output = new HashMap<>();
+						JSONObject outputJs = obs.getJSONObject("output");
+						Iterator<String> outputIter = outputJs.keys();
+						while (outputIter.hasNext()) {
+							String outputKey = outputIter.next();
+							output.put(outputKey, outputJs.get(outputKey));
+						}
+
+						res.add(new ObservationData(processKey, taskKey, input, output));
+
+					}
+
+				}
+
+			}
+		}
+
+		return res;
+	}
+
+}

--- a/lp-simulation-environment/simulator/src/main/resources/markov/train.json
+++ b/lp-simulation-environment/simulator/src/main/resources/markov/train.json
@@ -1,0 +1,874 @@
+{
+    "mod.21262" : {
+        "usertask1" : [
+            {
+                "input" : {
+                    "case" : "829-2015"
+                },
+                "output" : {
+                    "offEdiuzia" : true,
+                    "offPorto" : true,
+                    "offAmb" : true,
+                    "offAtt" : true,
+                    "offPolizia" : true,
+                    "offTrib" : true,
+                    "offPat" : false,
+                    "offSind" : false,
+                    "offARPAM" : false,
+                    "offServIgiene" : false,
+                    "offDepIgiene" : false,
+                    "offPrev" : false,
+                    "offVVFF" : false,
+                    "offAreaAmb" : false,
+                    "offAreaEco" : false,
+                    "offVal" : false,
+                    "offGest" : false,
+                    "offSoprint" : true,
+                    "offFerrov" : false,
+                    "offANAS" : false,
+                    "offQUEST" : false,
+                    "offPREF" : false,
+                    "offISP" : false,
+                    "offDog" : true,
+                    "offCap" : true
+                }
+            },
+            {
+                "input" : {
+                    "case" : "1118-2015"
+                },
+                "output" : {
+                    "offEdiuzia" : true,
+                    "offPorto" : false,
+                    "offAmb" : true,
+                    "offAtt" : true,
+                    "offPolizia" : false,
+                    "offTrib" : false,
+                    "offPat" : true,
+                    "offSind" : false,
+                    "offARPAM" : false,
+                    "offServIgiene" : false,
+                    "offDepIgiene" : false,
+                    "offPrev" : false,
+                    "offVVFF" : false,
+                    "offAreaAmb" : false,
+                    "offAreaEco" : false,
+                    "offVal" : false,
+                    "offGest" : false,
+                    "offSoprint" : true,
+                    "offFerrov" : false,
+                    "offANAS" : false,
+                    "offQUEST" : false,
+                    "offPREF" : false,
+                    "offISP" : false,
+                    "offDog" : false,
+                    "offCap" : false
+                }
+            }
+        ],
+        "usertask5" : [
+            {
+                "input" : {
+                    "case" : "829-2015",
+                    "off1Role" : "offEdiuzia"
+                },
+                "output" : {
+                    "off1Choice" : "off1Ok"
+                }
+            },
+            {
+                "input" : {
+                    "case" : "829-2015",
+                    "off1Role" : "offPorto"
+                },
+                "output" : {
+                    "off1Choice" : "off1Ok"
+                }
+            },
+            {
+                "input" : {
+                    "case" : "829-2015",
+                    "off1Role" : "offAmb"
+                },
+                "output" : {
+                    "off1Choice" : "off1Ok"
+                }
+            },
+            {
+                "input" : {
+                    "case" : "829-2015",
+                    "off1Role" : "offAtt"
+                },
+                "output" : {
+                    "off1Choice" : "off1Ok"
+                }
+            },
+            {
+                "input" : {
+                    "case" : "829-2015",
+                    "off1Role" : "offPolizia"
+                },
+                "output" : {
+                    "off1Choice" : "off1Ok"
+                }
+            },
+            {
+                "input" : {
+                    "case" : "829-2015",
+                    "off1Role" : "offTrib"
+                },
+                "output" : {
+                    "off1Choice" : "off1Ok"
+                }
+            },
+            {
+                "input" : {
+                    "case" : "829-2015",
+                    "off1Role" : "offSoprint"
+                },
+                "output" : {
+                    "off1Choice" : "off1Ok"
+                }
+            },
+            {
+                "input" : {
+                    "case" : "829-2015",
+                    "off1Role" : "offDog"
+                },
+                "output" : {
+                    "off1Choice" : "off1Ok"
+                }
+            },
+            {
+                "input" : {
+                    "case" : "829-2015",
+                    "off1Role" : "offCap"
+                },
+                "output" : {
+                    "off1Choice" : "off1Ok"
+                }
+            },
+            {
+                "input" : {
+                    "case" : "1118-2015",
+                    "off1Role" : "offEdiuzia"
+                },
+                "output" : {
+                    "off1Choice" : "off1Ok"
+                }
+            },
+            {
+                "input" : {
+                    "case" : "1118-2015",
+                    "off1Role" : "offAmb"
+                },
+                "output" : {
+                    "off1Choice" : "off1Ok"
+                }
+            },
+            {
+                "input" : {
+                    "case" : "1118-2015",
+                    "off1Role" : "offAtt"
+                },
+                "output" : {
+                    "off1Choice" : "off1Ok"
+                }
+            },
+            {
+                "input" : {
+                    "case" : "1118-2015",
+                    "off1Role" : "offPat"
+                },
+                "output" : {
+                    "off1Choice" : "off1Ok"
+                }
+            },
+            {
+                "input" : {
+                    "case" : "1118-2015",
+                    "off1Role" : "offSoprint"
+                },
+                "output" : {
+                    "off1Choice" : "off1Ok"
+                }
+            }
+        ],
+        "usertask4" : [
+            {
+                "input" : {
+                    "case" : "829-2015",
+                    "off2Role" : "offEdiuzia"
+                },
+                "output" : {
+                    "off2Choice" : "off2Ok"
+                }
+            },
+            {
+                "input" : {
+                    "case" : "829-2015",
+                    "off2Role" : "offPorto"
+                },
+                "output" : {
+                    "off2Choice" : "off2Ok"
+                }
+            },
+            {
+                "input" : {
+                    "case" : "829-2015",
+                    "off2Role" : "offAmb"
+                },
+                "output" : {
+                    "off2Choice" : "off2Ok"
+                }
+            },
+            {
+                "input" : {
+                    "case" : "829-2015",
+                    "off2Role" : "offAtt"
+                },
+                "output" : {
+                    "off2Choice" : "off2Ok"
+                }
+            },
+            {
+                "input" : {
+                    "case" : "829-2015",
+                    "off2Role" : "offPolizia"
+                },
+                "output" : {
+                    "off2Choice" : "off2Ok"
+                }
+            },
+            {
+                "input" : {
+                    "case" : "829-2015",
+                    "off2Role" : "offTrib"
+                },
+                "output" : {
+                    "off2Choice" : "off2Ok"
+                }
+            },
+            {
+                "input" : {
+                    "case" : "829-2015",
+                    "off2Role" : "offSoprint"
+                },
+                "output" : {
+                    "off2Choice" : "off2Ok"
+                }
+            },
+            {
+                "input" : {
+                    "case" : "829-2015",
+                    "off2Role" : "offDog"
+                },
+                "output" : {
+                    "off2Choice" : "off2Ok"
+                }
+            },
+            {
+                "input" : {
+                    "case" : "829-2015",
+                    "off2Role" : "offCap"
+                },
+                "output" : {
+                    "off2Choice" : "off2Ok"
+                }
+            },
+            {
+                "input" : {
+                    "case" : "1118-2015",
+                    "off2Role" : "offEdiuzia"
+                },
+                "output" : {
+                    "off2Choice" : "off2Ok"
+                }
+            },
+            {
+                "input" : {
+                    "case" : "1118-2015",
+                    "off2Role" : "offAmb"
+                },
+                "output" : {
+                    "off2Choice" : "off2Ok"
+                }
+            },
+            {
+                "input" : {
+                    "case" : "1118-2015",
+                    "off2Role" : "offAtt"
+                },
+                "output" : {
+                    "off2Choice" : "off2Ok"
+                }
+            },
+            {
+                "input" : {
+                    "case" : "1118-2015",
+                    "off2Role" : "offPat"
+                },
+                "output" : {
+                    "off2Choice" : "off2Ok"
+                }
+            },
+            {
+                "input" : {
+                    "case" : "1118-2015",
+                    "off2Role" : "offSoprint"
+                },
+                "output" : {
+                    "off2Choice" : "off2Ok"
+                }
+            }
+        ],
+        "usertask11" : [
+            {
+                "input" : {
+                    "case" : "829-2015",
+                    "off1Role" : "offEdiuzia"
+                },
+                "output" : {
+                    "off1FeedbackOpinionStatus" : "s2"
+                }
+            },
+            {
+                "input" : {
+                    "case" : "829-2015",
+                    "off1Role" : "offPorto"
+                },
+                "output" : {
+                    "off1FeedbackOpinionStatus" : "s1"
+                }
+            },
+            {
+                "input" : {
+                    "case" : "829-2015",
+                    "off1Role" : "offAmb"
+                },
+                "output" : {
+                    "off1FeedbackOpinionStatus" : "s1"
+                }
+            },
+            {
+                "input" : {
+                    "case" : "829-2015",
+                    "off1Role" : "offAtt"
+                },
+                "output" : {
+                    "off1FeedbackOpinionStatus" : "s1"
+                }
+            },
+            {
+                "input" : {
+                    "case" : "829-2015",
+                    "off1Role" : "offPolizia"
+                },
+                "output" : {
+                    "off1FeedbackOpinionStatus" : "s1"
+                }
+            },
+            {
+                "input" : {
+                    "case" : "829-2015",
+                    "off1Role" : "offTrib"
+                },
+                "output" : {
+                    "off1FeedbackOpinionStatus" : "s2"
+                }
+            },
+            {
+                "input" : {
+                    "case" : "829-2015",
+                    "off1Role" : "offSoprint"
+                },
+                "output" : {
+                    "off1FeedbackOpinionStatus" : "s1"
+                }
+            },
+            {
+                "input" : {
+                    "case" : "829-2015",
+                    "off1Role" : "offDog"
+                },
+                "output" : {
+                    "off1FeedbackOpinionStatus" : "s1"
+                }
+            },
+            {
+                "input" : {
+                    "case" : "829-2015",
+                    "off1Role" : "offCap"
+                },
+                "output" : {
+                    "off1FeedbackOpinionStatus" : "s1"
+                }
+            },
+            {
+                "input" : {
+                    "case" : "1118-2015",
+                    "off1Role" : "offEdiuzia"
+                },
+                "output" : {
+                    "off1FeedbackOpinionStatus" : "s1"
+                }
+            },
+            {
+                "input" : {
+                    "case" : "1118-2015",
+                    "off1Role" : "offAmb"
+                },
+                "output" : {
+                    "off1FeedbackOpinionStatus" : "s1"
+                }
+            },
+            {
+                "input" : {
+                    "case" : "1118-2015",
+                    "off1Role" : "offAtt"
+                },
+                "output" : {
+                    "off1FeedbackOpinionStatus" : "s1"
+                }
+            },
+            {
+                "input" : {
+                    "case" : "1118-2015",
+                    "off1Role" : "offPat"
+                },
+                "output" : {
+                    "off1FeedbackOpinionStatus" : "s1"
+                }
+            },
+            {
+                "input" : {
+                    "case" : "1118-2015",
+                    "off1Role" : "offSoprint"
+                },
+                "output" : {
+                    "off1FeedbackOpinionStatus" : "s1"
+                }
+            }
+        ],
+        "usertask8" : [
+            {
+                "input" : {
+                    "case" : "829-2015",
+                    "off2Role" : "offEdiuzia"
+                },
+                "output" : {
+                    "off2FeedbackOpinionStatus" : "s2"
+                }
+            },
+            {
+                "input" : {
+                    "case" : "829-2015",
+                    "off2Role" : "offPorto"
+                },
+                "output" : {
+                    "off2FeedbackOpinionStatus" : "s1"
+                }
+            },
+            {
+                "input" : {
+                    "case" : "829-2015",
+                    "off2Role" : "offAmb"
+                },
+                "output" : {
+                    "off2FeedbackOpinionStatus" : "s1"
+                }
+            },
+            {
+                "input" : {
+                    "case" : "829-2015",
+                    "off2Role" : "offAtt"
+                },
+                "output" : {
+                    "off2FeedbackOpinionStatus" : "s1"
+                }
+            },
+            {
+                "input" : {
+                    "case" : "829-2015",
+                    "off2Role" : "offPolizia"
+                },
+                "output" : {
+                    "off2FeedbackOpinionStatus" : "s1"
+                }
+            },
+            {
+                "input" : {
+                    "case" : "829-2015",
+                    "off2Role" : "offTrib"
+                },
+                "output" : {
+                    "off2FeedbackOpinionStatus" : "s2"
+                }
+            },
+            {
+                "input" : {
+                    "case" : "829-2015",
+                    "off2Role" : "offSoprint"
+                },
+                "output" : {
+                    "off2FeedbackOpinionStatus" : "s1"
+                }
+            },
+            {
+                "input" : {
+                    "case" : "829-2015",
+                    "off2Role" : "offDog"
+                },
+                "output" : {
+                    "off2FeedbackOpinionStatus" : "s1"
+                }
+            },
+            {
+                "input" : {
+                    "case" : "829-2015",
+                    "off2Role" : "offCap"
+                },
+                "output" : {
+                    "off2FeedbackOpinionStatus" : "s1"
+                }
+            },
+            {
+                "input" : {
+                    "case" : "1118-2015",
+                    "off2Role" : "offEdiuzia"
+                },
+                "output" : {
+                    "off2FeedbackOpinionStatus" : "s1"
+                }
+            },
+            {
+                "input" : {
+                    "case" : "1118-2015",
+                    "off2Role" : "offAmb"
+                },
+                "output" : {
+                    "off2FeedbackOpinionStatus" : "s1"
+                }
+            },
+            {
+                "input" : {
+                    "case" : "1118-2015",
+                    "off2Role" : "offAtt"
+                },
+                "output" : {
+                    "off2FeedbackOpinionStatus" : "s1"
+                }
+            },
+            {
+                "input" : {
+                    "case" : "1118-2015",
+                    "off2Role" : "offPat"
+                },
+                "output" : {
+                    "off2FeedbackOpinionStatus" : "s1"
+                }
+            },
+            {
+                "input" : {
+                    "case" : "1118-2015",
+                    "off2Role" : "offPat"
+                },
+                "output" : {
+                    "off2FeedbackOpinionStatus" : "s5"
+                }
+            },
+            {
+                "input" : {
+                    "case" : "1118-2015",
+                    "off2Role" : "offSoprint"
+                },
+                "output" : {
+                    "off2FeedbackOpinionStatus" : "s1"
+                }
+            },
+            {
+                "input" : {
+                    "case" : "1118-2015",
+                    "off2Role" : "offSoprint"
+                },
+                "output" : {
+                    "off2FeedbackOpinionStatus" : "s5"
+                }
+            }
+        ],
+        "usertask14" :[
+            {
+                "input" : {
+                    "case" : "829-2015",
+                    "off1Role" : "offEdiuzia"
+                },
+                "output" : {
+                    "off1FeedbackMotivation" : "parere favorevole condizionato dello Sportello Unico per l\'Edilizia - ammissibilità dell\'intervento su richiesta di permesso di costruire"
+                }
+            },
+            {
+                "input" : {
+                    "case" : "829-2015",
+                    "off1Role" : "offPorto"
+                },
+                "output" : {
+                    "off1FeedbackMotivation" : "parere positivo scritto e precedentemente depositato in ordine alla modifica del muretto"
+                }
+            },
+            {
+                "input" : {
+                    "case" : "829-2015",
+                    "off1Role" : "offAmb"
+                },
+                "output" : {
+                    "off1FeedbackMotivation" : "parere di compatibilità paesaggistica ai sensi dell\'art. 146 DLgs 42/2004 e smi"
+                }
+            },
+            {
+                "input" : {
+                    "case" : "829-2015",
+                    "off1Role" : "offAtt"
+                },
+                "output" : {
+                    "off1FeedbackMotivation" : "autorizzazione ai sensi dell\'art. 24 Reg. C.N. - parere favorevole in quanto la concessione demaniale rimane inalterata"
+                }
+            },
+            {
+                "input" : {
+                    "case" : "829-2015",
+                    "off1Role" : "offPolizia"
+                },
+                "output" : {
+                    "off1FeedbackMotivation" : "parere di conformità al codice della strada - nulla osta per quanto di competenza"
+                }
+            },
+            {
+                "input" : {
+                    "case" : "829-2015",
+                    "off1Role" : "offTrib"
+                },
+                "output" : {
+                    "off1FeedbackMotivation" : "precedentemente presentato conteggio oneri imposta pubblicitaria con cui si esenta l\'esercizio - avendo superficie < 5 mq - con la prescrizione che al termine dei lavori dovrà essere presentata nuova dichiarazione superfici ai fini della tassa rifiuti "
+                }
+            },
+            {
+                "input" : {
+                    "case" : "829-2015",
+                    "off1Role" : "offSoprint"
+                },
+                "output" : {
+                    "off1FeedbackMotivation" : "parere ai sensi dell\'art. 146 DLgs 42/2004 e smi e art. 14-ter comma 3bis L. 241/1990 - silenzio assenso"
+                }
+            },
+            {
+                "input" : {
+                    "case" : "829-2015",
+                    "off1Role" : "offDog"
+                },
+                "output" : {
+                    "off1FeedbackMotivation" : "autorizzazione doganale ai sensi dell\'art. 19 DLgs 374/1990 precedentemente rilasciata - parere favorevole già espresso: non c\'è bisogno di ulteriori risposte né di intervenire nella conferenza di servizi"
+                }
+            },
+            {
+                "input" : {
+                    "case" : "829-2015",
+                    "off1Role" : "offCap"
+                },
+                "output" : {
+                    "off1FeedbackMotivation" : "informato solo per conoscenza - silenzio assenso"
+                }
+            },
+            {
+                "input" : {
+                    "case" : "1118-2015",
+                    "off1Role" : "offEdiuzia"
+                },
+                "output" : {
+                    "off1FeedbackMotivation" : "rilascio parere favorevole su presentazione SCIA"
+                }
+            },
+            {
+                "input" : {
+                    "case" : "1118-2015",
+                    "off1Role" : "offAmb"
+                },
+                "output" : {
+                    "off1FeedbackMotivation" : "l\'intervento proposto è compatibile a livello paesaggistico ai sensi dell\'art. 146 DLgs 42/2004"
+                }
+            },
+            {
+                "input" : {
+                    "case" : "1118-2015",
+                    "off1Role" : "offAtt"
+                },
+                "output" : {
+                    "off1FeedbackMotivation" : "espletata attività istruttoria - ok sui controlli formali e di merito"
+                }
+            },
+            {
+                "input" : {
+                    "case" : "1118-2015",
+                    "off1Role" : "offPat"
+                },
+                "output" : {
+                    "off1FeedbackMotivation" : "NULLA OSTA quale Ente proprietario dell\'area - parere favorevole ai sensi dell\'art. 6 par. 2 contratto rep 28 27/12/2001 (scadenza 31/12/2019)"
+                }
+            },
+            {
+                "input" : {
+                    "case" : "1118-2015",
+                    "off1Role" : "offSoprint"
+                },
+                "output" : {
+                    "off1FeedbackMotivation" : "parere ai sensi dell\'art. 146 DLgs 42/2004 e smi e art. 14-ter comma 3bis L. 241/1990 - silenzio assenso"
+                }
+            }
+        ],
+        "usertask15" :[
+            {
+                "input" : {
+                    "case" : "829-2015",
+                    "off2Role" : "offEdiuzia"
+                },
+                "output" : {
+                    "off2FeedbackMotivation" : "parere favorevole condizionato dello Sportello Unico per l\'Edilizia - ammissibilità dell\'intervento su richiesta di permesso di costruire"
+                }
+            },
+            {
+                "input" : {
+                    "case" : "829-2015",
+                    "off2Role" : "offPorto"
+                },
+                "output" : {
+                    "off2FeedbackMotivation" : "parere positivo scritto e precedentemente depositato in ordine alla modifica del muretto"
+                }
+            },
+            {
+                "input" : {
+                    "case" : "829-2015",
+                    "off2Role" : "offAmb"
+                },
+                "output" : {
+                    "off2FeedbackMotivation" : "parere di compatibilità paesaggistica ai sensi dell\'art. 146 DLgs 42/2004 e smi"
+                }
+            },
+            {
+                "input" : {
+                    "case" : "829-2015",
+                    "off2Role" : "offAtt"
+                },
+                "output" : {
+                    "off2FeedbackMotivation" : "autorizzazione ai sensi dell\'art. 24 Reg. C.N. - parere favorevole in quanto la concessione demaniale rimane inalterata"
+                }
+            },
+            {
+                "input" : {
+                    "case" : "829-2015",
+                    "off2Role" : "offPolizia"
+                },
+                "output" : {
+                    "off2FeedbackMotivation" : "parere di conformità al codice della strada - nulla osta per quanto di competenza"
+                }
+            },
+            {
+                "input" : {
+                    "case" : "829-2015",
+                    "off2Role" : "offTrib"
+                },
+                "output" : {
+                    "off2FeedbackMotivation" : "precedentemente presentato conteggio oneri imposta pubblicitaria con cui si esenta l\'esercizio - avendo superficie < 5 mq - con la prescrizione che al termine dei lavori dovrà essere presentata nuova dichiarazione superfici ai fini della tassa rifiuti "
+                }
+            },
+            {
+                "input" : {
+                    "case" : "829-2015",
+                    "off2Role" : "offSoprint"
+                },
+                "output" : {
+                    "off2FeedbackMotivation" : "parere ai sensi dell\'art. 146 DLgs 42/2004 e smi e art. 14-ter comma 3bis L. 241/1990 - silenzio assenso"
+                }
+            },
+            {
+                "input" : {
+                    "case" : "829-2015",
+                    "off2Role" : "offDog"
+                },
+                "output" : {
+                    "off2FeedbackMotivation" : "autorizzazione doganale ai sensi dell\'art. 19 DLgs 374/1990 precedentemente rilasciata - parere favorevole già espresso: non c\'è bisogno di ulteriori risposte né di intervenire nella conferenza di servizi"
+                }
+            },
+            {
+                "input" : {
+                    "case" : "829-2015",
+                    "off2Role" : "offCap"
+                },
+                "output" : {
+                    "off2FeedbackMotivation" : "informato solo per conoscenza - silenzio assenso"
+                }
+            },
+            {
+                "input" : {
+                    "case" : "1118-2015",
+                    "off2Role" : "offEdiuzia"
+                },
+                "output" : {
+                    "off2FeedbackMotivation" : "rilascio parere favorevole su presentazione SCIA"
+                }
+            },
+            {
+                "input" : {
+                    "case" : "1118-2015",
+                    "off2Role" : "offAmb"
+                },
+                "output" : {
+                    "off2FeedbackMotivation" : "l\'intervento proposto è compatibile a livello paesaggistico ai sensi dell\'art. 146 DLgs 42/2004"
+                }
+            },
+            {
+                "input" : {
+                    "case" : "1118-2015",
+                    "off2Role" : "offAtt"
+                },
+                "output" : {
+                    "off2FeedbackMotivation" : "espletata attività istruttoria - ok sui controlli formali e di merito"
+                }
+            },
+            {
+                "input" : {
+                    "case" : "1118-2015",
+                    "off2Role" : "offPat"
+                },
+                "output" : {
+                    "off2FeedbackMotivation" : "NULLA OSTA quale Ente proprietario dell\'area - parere favorevole ai sensi dell\'art. 6 par. 2 contratto rep 28 27/12/2001 (scadenza 31/12/2019)"
+                }
+            },
+            {
+                "input" : {
+                    "case" : "1118-2015",
+                    "off2Role" : "offSoprint"
+                },
+                "output" : {
+                    "off2FeedbackMotivation" : "parere ai sensi dell\'art. 146 DLgs 42/2004 e smi e art. 14-ter comma 3bis L. 241/1990 - silenzio assenso"
+                }
+            }
+        ],
+        "usertask16" : [
+            {
+                "input" : {
+                    "case" : "829-2015"
+                },
+                "output" : {
+                    "suapChoice" : "suapUC"
+                }
+            },
+            {
+                "input" : {
+                    "case" : "1118-2015"
+                },
+                "output" : {
+                    "suapChoice" : "suapOk"
+                }
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Simulation now uses MarkovBot instead of SimpleRobot.
MarkovBot is trained with the basic example training file provided.

These bots use a simple markov chain of
depth 1 to produce their output.

These bots are trained using a file format similar to the one of the
validation db. These training files contain a one-level context of each
observed answers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/learnpad/learnpad/573)
<!-- Reviewable:end -->
