### PR TITLE
[sim] Simulator now have a `robot_type` property

### DIFF
--- a/lp-simulation-environment/simulator/README.md
+++ b/lp-simulation-environment/simulator/README.md
@@ -50,6 +50,9 @@ To override the glimpse server, put the following inside the file:
 To override the LearnPAd platform address, put the following inside the file:
 `platform_address=<address>`
 
+To change the type of robot available in the platform, use the following property:
+`robot_type=<none|simple|markov`
+
 # Interfaces
 
 ## Java API

--- a/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/Main.java
+++ b/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/Main.java
@@ -57,7 +57,10 @@ public class Main {
 		try {
 
 			simulator = new Simulator(ACTIVITY_CONFIG_PATH, PORT);
-			simulator.robotHandler().addRobot(AbstractFormHandler.DEFAULT_ROBOT_ROLE);
+
+			if (simulator.robotHandler() != null) {
+				simulator.robotHandler().addRobot(AbstractFormHandler.DEFAULT_ROBOT_ROLE);
+			}
 
 			// load process definitions
 			simulator.processManager().addProjectDefinitions(

--- a/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/Simulator.java
+++ b/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/Simulator.java
@@ -38,11 +38,14 @@ import eu.learnpad.simulator.robot.IRobotFactory;
 import eu.learnpad.simulator.robot.RobotUserEventReceiver;
 import eu.learnpad.simulator.robot.activiti.ActivitiRobotInputExtractor;
 import eu.learnpad.simulator.robot.activiti.markovrobot.onelevel.OneLevelMarkovBotFactory;
+import eu.learnpad.simulator.robot.activiti.simplerobot.SimpleRobotFactory;
 import eu.learnpad.simulator.uihandler.formhandler.AbstractFormHandler;
 import eu.learnpad.simulator.uihandler.formhandler.multi2jsonform.Multi2JsonFormFormHandler;
 import eu.learnpad.simulator.uihandler.webserver.UIHandlerWebImpl;
 import eu.learnpad.simulator.uihandler.webserver.WebServer;
 import eu.learnpad.simulator.utils.BPMNExplorerRepository;
+import eu.learnpad.simulator.utils.SimulatorProperties;
+import eu.learnpad.simulator.utils.SimulatorProperties.ROBOT_TYPE_VALUE;
 
 /**
  *
@@ -90,14 +93,6 @@ public class Simulator implements IProcessManagerProvider,
 		uiHandler = new UIHandlerWebImpl(new WebServer(webserverPort, "ui",
 				"tasks", this), new ArrayList<String>(), this, formHandler);
 
-		// handle robots
-		robotFactory = new OneLevelMarkovBotFactory(processEngine.getTaskService(), processEngine.getRepositoryService(),
-				OneLevelMarkovBotFactory.readTrainingData(Arrays.asList("markov/train.json")), 12345L);
-
-		robotEventReceiver = new RobotUserEventReceiver<>(
-				robotFactory, new ActivitiRobotInputExtractor(
-						processEngine.getTaskService()), processManager);
-
 		// manage events subscriptions
 		eventDispatcher = new EventDispatcherImpl();
 		eventDispatcher.subscribe(uiHandler);
@@ -108,10 +103,36 @@ public class Simulator implements IProcessManagerProvider,
 			eventDispatcher.subscribe(new ProbeEventReceiver(processManager));
 		}
 
-		// note that the robot receiver is subscribed at the end in order to be
-		// executed last
-		// (this is important as the robots tend to complete tasks *very fast*)
-		eventDispatcher.subscribe(robotEventReceiver);
+		// handle robots
+
+		switch (ROBOT_TYPE_VALUE.valueOf(SimulatorProperties.props.getProperty(SimulatorProperties.ROBOT_TYPE))) {
+		case markov:
+			robotFactory = new OneLevelMarkovBotFactory(processEngine.getTaskService(), processEngine.getRepositoryService(),
+					OneLevelMarkovBotFactory.readTrainingData(Arrays.asList("markov/train.json")), 12345L);
+			System.out.println("create markov bot factory");
+			break;
+		case simple:
+			robotFactory = new SimpleRobotFactory(processEngine.getRepositoryService(), processEngine.getTaskService(),
+					formHandler);
+			System.out.println("create simple bot factory");
+			break;
+		default:
+			robotFactory = null;
+			System.out.println("create no bot factory");
+			break;
+
+		}
+
+		if (robotFactory != null) {
+			// note that the robot receiver is subscribed at the end in order to be
+			// executed last
+			// (this is important as the robots tend to complete tasks *very fast*)
+			robotEventReceiver = new RobotUserEventReceiver<>(robotFactory,
+					new ActivitiRobotInputExtractor(processEngine.getTaskService()), processManager);
+			eventDispatcher.subscribe(robotEventReceiver);
+		} else {
+			robotEventReceiver = null;
+		}
 
 	}
 

--- a/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/uihandler/formhandler/AbstractFormHandler.java
+++ b/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/uihandler/formhandler/AbstractFormHandler.java
@@ -37,6 +37,7 @@ import org.activiti.engine.impl.util.json.JSONObject;
 
 import eu.learnpad.simulator.datastructures.document.LearnPadDocumentField;
 import eu.learnpad.simulator.uihandler.IFormHandler;
+import eu.learnpad.simulator.utils.SimulatorProperties;
 
 /**
  *
@@ -158,6 +159,10 @@ public abstract class AbstractFormHandler implements IFormHandler {
 			Collection<String> singleRoles, Collection<String> groupRoles,
 			Collection<String> users) {
 
+		// do we add robots or not?
+		boolean withRobot = !SimulatorProperties.props.getProperty(SimulatorProperties.ROBOT_TYPE)
+				.equals(SimulatorProperties.ROBOT_TYPE_VALUE.none.toString());
+
 		// insert roles to users mapping
 		JSONObject res = new JSONObject(base);
 
@@ -168,8 +173,12 @@ public abstract class AbstractFormHandler implements IFormHandler {
 			JSONObject isHuman = new JSONObject();
 			isHuman.put("type", "boolean");
 			isHuman.put("required", true);
-			res.getJSONObject("schema").put(SINGLE_USER_IS_HUMAN_KEY_PREFIX + role,
-					isHuman);
+
+			if (!withRobot) {
+				isHuman.put("default", true);
+			}
+
+			res.getJSONObject("schema").put(SINGLE_USER_IS_HUMAN_KEY_PREFIX + role, isHuman);
 
 			JSONObject o = new JSONObject();
 			o.put("type", "string");
@@ -182,6 +191,11 @@ public abstract class AbstractFormHandler implements IFormHandler {
 			JSONObject isHuman = new JSONObject();
 			isHuman.put("type", "boolean");
 			isHuman.put("required", true);
+
+			if (!withRobot) {
+				isHuman.put("default", true);
+			}
+
 			res.getJSONObject("schema").put(GROUP_USER_IS_HUMAN_KEY_PREFIX + role,
 					isHuman);
 
@@ -204,44 +218,66 @@ public abstract class AbstractFormHandler implements IFormHandler {
 
 		JSONArray items = new JSONArray();
 		for (String role : singleRoles) {
-			JSONObject isHuman = new JSONObject();
-			isHuman.put("title", "Role: " + role);
-			isHuman.put("key", SINGLE_USER_IS_HUMAN_KEY_PREFIX + role);
-			isHuman.put("type", "radios");
-			isHuman.put("inline", true);
-
-			JSONObject isHumanOptions = new JSONObject();
-			isHumanOptions.put("true", "human");
-			isHumanOptions.put("false", "robot");
-			isHuman.put("options", isHumanOptions);
-
-			JSONObject toggleNextMap = new JSONObject();
-			toggleNextMap.put("true", true);
-			isHuman.put("toggleNextMap", toggleNextMap);
-			items.put(isHuman);
 
 			JSONObject o = new JSONObject();
+
+			if (withRobot) {
+				JSONObject isHuman = new JSONObject();
+				isHuman.put("title", "Role: " + role);
+				isHuman.put("key", SINGLE_USER_IS_HUMAN_KEY_PREFIX + role);
+				isHuman.put("type", "radios");
+				isHuman.put("inline", true);
+
+				JSONObject isHumanOptions = new JSONObject();
+				isHumanOptions.put("true", "human");
+				isHumanOptions.put("false", "robot");
+				isHuman.put("options", isHumanOptions);
+
+				JSONObject toggleNextMap = new JSONObject();
+				toggleNextMap.put("true", true);
+				isHuman.put("toggleNextMap", toggleNextMap);
+				items.put(isHuman);
+			} else {
+				JSONObject isHuman = new JSONObject();
+				isHuman.put("key", SINGLE_USER_IS_HUMAN_KEY_PREFIX + role);
+				isHuman.put("type", "hidden");
+				items.put(isHuman);
+
+				o.put("title", "Role: " + role);
+			}
+
 			o.put("key", SINGLE_USER_KEY_PREFIX + role);
 			items.put(o);
 		}
 		for (String role : groupRoles) {
-			JSONObject isHuman = new JSONObject();
-			isHuman.put("title", "Role: " + role);
-			isHuman.put("key", GROUP_USER_IS_HUMAN_KEY_PREFIX + role);
-			isHuman.put("type", "radios");
-			isHuman.put("inline", true);
-
-			JSONObject isHumanOptions = new JSONObject();
-			isHumanOptions.put("true", "human");
-			isHumanOptions.put("false", "robot");
-			isHuman.put("options", isHumanOptions);
-
-			JSONObject toggleNextMap = new JSONObject();
-			toggleNextMap.put("true", true);
-			isHuman.put("toggleNextMap", toggleNextMap);
-			items.put(isHuman);
 
 			JSONObject o = new JSONObject();
+
+			if (withRobot) {
+				JSONObject isHuman = new JSONObject();
+				isHuman.put("title", "Role: " + role);
+				isHuman.put("key", GROUP_USER_IS_HUMAN_KEY_PREFIX + role);
+				isHuman.put("type", "radios");
+				isHuman.put("inline", true);
+
+				JSONObject isHumanOptions = new JSONObject();
+				isHumanOptions.put("true", "human");
+				isHumanOptions.put("false", "robot");
+				isHuman.put("options", isHumanOptions);
+
+				JSONObject toggleNextMap = new JSONObject();
+				toggleNextMap.put("true", true);
+				isHuman.put("toggleNextMap", toggleNextMap);
+				items.put(isHuman);
+			} else {
+				JSONObject isHuman = new JSONObject();
+				isHuman.put("key", GROUP_USER_IS_HUMAN_KEY_PREFIX + role);
+				isHuman.put("type", "hidden");
+				items.put(isHuman);
+
+				o.put("title", "Role: " + role);
+			}
+
 			o.put("key", GROUP_USER_KEY_PREFIX + role);
 			o.put("type", "checkboxes");
 			items.put(o);

--- a/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/utils/SimulatorProperties.java
+++ b/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/utils/SimulatorProperties.java
@@ -25,6 +25,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Arrays;
 import java.util.Properties;
 
 /**
@@ -43,6 +44,12 @@ public class SimulatorProperties {
 	public final static String PROP_ADDRESS = "address";
 	public final static String PROP_GLIMPSE_SERVER = "glimpse_server";
 	public final static String PLATFORM_ADDRESS = "platform_address";
+
+	public final static String ROBOT_TYPE = "robot_type";
+
+	public static enum ROBOT_TYPE_VALUE {
+		none, simple, markov
+	}
 
 	static {
 
@@ -71,5 +78,17 @@ public class SimulatorProperties {
 			}
 		}
 
+		// ROBOT_TYPE_VALUE are the only valid values for the ROBOT_TYPE property
+		try {
+			ROBOT_TYPE_VALUE.valueOf(props.getProperty(ROBOT_TYPE));
+		} catch (NullPointerException e) {
+			throw new RuntimeException(
+					"Missing mandatory value for property " + ROBOT_TYPE + " (valid values: "
+							+ Arrays.asList(ROBOT_TYPE_VALUE.values())
+							+ " )");
+		} catch (IllegalArgumentException e) {
+			throw new RuntimeException("Invalid value for property " + ROBOT_TYPE + ": " + props.getProperty(ROBOT_TYPE)
+					+ " (valid values: " + Arrays.asList(ROBOT_TYPE_VALUE.values()) + " )");
+		}
 	}
 }

--- a/lp-simulation-environment/simulator/src/main/resources/simulator.properties
+++ b/lp-simulation-environment/simulator/src/main/resources/simulator.properties
@@ -1,2 +1,3 @@
 glimpse_server=tcp://localhost:61616
 platform_address=localhost:8080
+robot_type=markov


### PR DESCRIPTION
Add support for a new `robot_type` property. This property can take the
following values:
- none (for no robot)
- simple (for simple robot)
- markov (for markov chain based robots)

The simulator uses the `robot_type` property to decide which type of
robots to instantiate in the platform (if any).

Add related doc in the README

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/learnpad/learnpad/574)
<!-- Reviewable:end -->
