### PR TITLE
[sim] Fix servconf process init with robots

### DIFF
--- a/lp-simulation-environment/simulator/src/main/resources/static/SingleProcess.js
+++ b/lp-simulation-environment/simulator/src/main/resources/static/SingleProcess.js
@@ -117,6 +117,15 @@ function processInstanciator(address) {
             }
  
             // some default values
+            values['off1Choice'] = 'off1Ok';
+            values['off2Choice'] = 'off2Ok';
+
+            values['off1FeedbackOpinionStatus'] = 's5';
+            values['off2FeedbackOpinionStatus'] = 's5';
+
+            values['off1FeedbackMotivation'] = '';
+            values['off2FeedbackMotivation'] = '';
+
             values['off1FeedbackCond1'] = '';
             values['off1FeedbackCond2'] = '';
             values['off1FeedbackCond3'] = '';


### PR DESCRIPTION
A previous update to the initialization of processes was not ported to
SingleProcess.js, this caused failures when using robots in the
integrated version of the UI.

This commit adds the missing initialization.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/learnpad/learnpad/575)
<!-- Reviewable:end -->
