### PR TITLE
[sim] Change notification order on processStart

### DIFF
--- a/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/processmanager/activiti/ActivitiProcessManager.java
+++ b/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/processmanager/activiti/ActivitiProcessManager.java
@@ -392,13 +392,6 @@ public class ActivitiProcessManager implements IProcessManager,
 		// we are ready, so we can start the dispatcher
 		processDispatchers.get(process.getId()).start();
 
-		// signal process start
-		this.processEventReceiverProvider.processEventReceiver()
-				.receiveProcessStartEvent(
-				new ProcessStartSimEvent(System.currentTimeMillis(),
-						(String) parameters.get(SIMULATION_ID_KEY),
-						users, data));
-
 		try (java.util.Scanner s = new java.util.Scanner(repositoryService.getProcessModel(repositoryService
 				.createProcessDefinitionQuery().processDefinitionKey(projectDefinitionKey).singleResult().getId()))) {
 			String bpmnFile =  s.useDelimiter("\\A").hasNext() ? s.next() : "";
@@ -413,6 +406,10 @@ public class ActivitiProcessManager implements IProcessManager,
 						.error("Failed to create score probe for process {}. Is monitoring component accessible?", process.getId());
 				e.printStackTrace();
 			}
+
+			// signal process start
+			this.processEventReceiverProvider.processEventReceiver().receiveProcessStartEvent(new ProcessStartSimEvent(
+					System.currentTimeMillis(), (String) parameters.get(SIMULATION_ID_KEY), users, data));
 
 		}
 


### PR DESCRIPTION
MON needs to receive the BPMN *before* receiving the start event.
Change the order in which these two events are propagated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/learnpad/learnpad/581)
<!-- Reviewable:end -->
