### PR TITLE
[sim] Fix probe score events handling and display probe scores if provided

### DIFF
--- a/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/IProcessEventReceiver.java
+++ b/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/IProcessEventReceiver.java
@@ -28,6 +28,7 @@ import eu.learnpad.simulator.monitoring.event.impl.ProcessEndSimEvent;
 import eu.learnpad.simulator.monitoring.event.impl.ProcessStartSimEvent;
 import eu.learnpad.simulator.monitoring.event.impl.SessionScoreUpdateSimEvent;
 import eu.learnpad.simulator.monitoring.event.impl.SimulationEndSimEvent;
+import eu.learnpad.simulator.monitoring.event.impl.SimulationFinalizeSimEvent;
 import eu.learnpad.simulator.monitoring.event.impl.SimulationStartSimEvent;
 import eu.learnpad.simulator.monitoring.event.impl.TaskEndSimEvent;
 import eu.learnpad.simulator.monitoring.event.impl.TaskFailedSimEvent;
@@ -49,6 +50,8 @@ public interface IProcessEventReceiver {
 	public void receiveSimulationStartEvent(SimulationStartSimEvent event);
 
 	public void receiveSimulationEndEvent(SimulationEndSimEvent event);
+
+	public void receiveSimulationFinalizeEvent(SimulationFinalizeSimEvent event);
 
 	public void receiveProcessStartEvent(ProcessStartSimEvent event);
 

--- a/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/monitoring/EventDispatcherImpl.java
+++ b/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/monitoring/EventDispatcherImpl.java
@@ -29,6 +29,7 @@ import eu.learnpad.simulator.monitoring.event.impl.ProcessEndSimEvent;
 import eu.learnpad.simulator.monitoring.event.impl.ProcessStartSimEvent;
 import eu.learnpad.simulator.monitoring.event.impl.SessionScoreUpdateSimEvent;
 import eu.learnpad.simulator.monitoring.event.impl.SimulationEndSimEvent;
+import eu.learnpad.simulator.monitoring.event.impl.SimulationFinalizeSimEvent;
 import eu.learnpad.simulator.monitoring.event.impl.SimulationStartSimEvent;
 import eu.learnpad.simulator.monitoring.event.impl.TaskEndSimEvent;
 import eu.learnpad.simulator.monitoring.event.impl.TaskFailedSimEvent;
@@ -115,4 +116,11 @@ public class EventDispatcherImpl implements IEventDispatcher {
 
 	}
 
+	@Override
+	public void receiveSimulationFinalizeEvent(SimulationFinalizeSimEvent event) {
+		for (IProcessEventReceiver receiver : receivers) {
+			receiver.receiveSimulationFinalizeEvent(event);
+		}
+
+	}
 }

--- a/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/monitoring/activiti/ProbeEventReceiver.java
+++ b/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/monitoring/activiti/ProbeEventReceiver.java
@@ -28,6 +28,7 @@ import eu.learnpad.simulator.monitoring.event.impl.ProcessEndSimEvent;
 import eu.learnpad.simulator.monitoring.event.impl.ProcessStartSimEvent;
 import eu.learnpad.simulator.monitoring.event.impl.SessionScoreUpdateSimEvent;
 import eu.learnpad.simulator.monitoring.event.impl.SimulationEndSimEvent;
+import eu.learnpad.simulator.monitoring.event.impl.SimulationFinalizeSimEvent;
 import eu.learnpad.simulator.monitoring.event.impl.SimulationStartSimEvent;
 import eu.learnpad.simulator.monitoring.event.impl.TaskEndSimEvent;
 import eu.learnpad.simulator.monitoring.event.impl.TaskFailedSimEvent;
@@ -296,6 +297,13 @@ public class ProbeEventReceiver extends GlimpseAbstractProbe implements
 						event.user, event.sessionscore));
 
 		send(monitoringEvent);
+
+	}
+
+
+	@Override
+	public void receiveSimulationFinalizeEvent(SimulationFinalizeSimEvent event) {
+		// Nothing to do
 
 	}
 

--- a/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/monitoring/activiti/scoreprobe/ScoreProbeConsumer.java
+++ b/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/monitoring/activiti/scoreprobe/ScoreProbeConsumer.java
@@ -67,15 +67,17 @@ public class ScoreProbeConsumer extends GlimpseAbstractConsumer {
 	}
 
 	@Override
-	public void messageReceived(Message arg0) throws JMSException {
-		try {
-			ObjectMessage responseFromMonitoring = (ObjectMessage) arg0;
-			if (responseFromMonitoring.getObject() instanceof ComplexEventException) {
-				ComplexEventException exceptionReceived = (ComplexEventException) responseFromMonitoring.getObject();
-				logger.error("Receive exception from probe: {}",
-						exceptionReceived.getMessage());
-				logger.error("Stack trace:\n{}", exceptionReceived.getStackTrace());
-			} else if (responseFromMonitoring.getObject() instanceof Map) {
+	public void onMessage(Message arg0) {
+		if (firstMessage) {
+			super.onMessage(arg0);
+		} else {
+			try {
+				ObjectMessage responseFromMonitoring = (ObjectMessage) arg0;
+				if (responseFromMonitoring.getObject() instanceof ComplexEventException) {
+					ComplexEventException exceptionReceived = (ComplexEventException) responseFromMonitoring.getObject();
+					logger.error("Receive exception from probe: {}", exceptionReceived.getMessage());
+					logger.error("Stack trace:\n{}", exceptionReceived.getStackTrace());
+				} else if (responseFromMonitoring.getObject() instanceof Map) {
 
 					@SuppressWarnings("unchecked")
 					Map<ScoreType, Float> theScores = (Map<ScoreType, Float>)responseFromMonitoring.getObject();
@@ -90,9 +92,16 @@ public class ScoreProbeConsumer extends GlimpseAbstractConsumer {
 				} else {
 					logger.debug("Received unexpected message from probe: {}", responseFromMonitoring);
 				}
-		} catch (ClassCastException asd) {
-			asd.printStackTrace();
+			} catch (Exception asd) {
+				logger.error("Exception from probe: {}", asd.getMessage());
+				asd.printStackTrace();
+			}
 		}
+	}
+
+	@Override
+	public void messageReceived(Message arg0) throws JMSException {
+		// nothing to do here
 	}
 
 	/**

--- a/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/monitoring/event/impl/SimulationEndSimEvent.java
+++ b/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/monitoring/event/impl/SimulationEndSimEvent.java
@@ -41,9 +41,7 @@ package eu.learnpad.simulator.monitoring.event.impl;
  */
 
 import java.util.Collection;
-import java.util.Map;
 
-import eu.learnpad.sim.rest.event.ScoreType;
 import eu.learnpad.simulator.monitoring.event.AbstractSimEvent;
 import eu.learnpad.simulator.monitoring.event.SimEventType;
 
@@ -54,12 +52,9 @@ import eu.learnpad.simulator.monitoring.event.SimEventType;
  */
 public class SimulationEndSimEvent extends AbstractSimEvent {
 
-	public final Map<String, Map<ScoreType, Float>> probeScores;
-
 	public SimulationEndSimEvent(Long timestamp, String simulationsessionid,
-			Collection<String> involvedusers, Map<String, Map<ScoreType, Float>> probeScores) {
+			Collection<String> involvedusers) {
 		super(timestamp, simulationsessionid, involvedusers);
-		this.probeScores = probeScores;
 	}
 
 	@Override

--- a/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/monitoring/event/impl/SimulationFinalizeSimEvent.java
+++ b/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/monitoring/event/impl/SimulationFinalizeSimEvent.java
@@ -17,7 +17,7 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package eu.learnpad.simulator.monitoring.event;
+package eu.learnpad.simulator.monitoring.event.impl;
 
 /*
  * #%L
@@ -40,11 +40,31 @@ package eu.learnpad.simulator.monitoring.event;
  * #L%
  */
 
+import java.util.Collection;
+import java.util.Map;
+
+import eu.learnpad.sim.rest.event.ScoreType;
+import eu.learnpad.simulator.monitoring.event.AbstractSimEvent;
+import eu.learnpad.simulator.monitoring.event.SimEventType;
+
 /**
  *
  * @author Tom Jorquera - Linagora
  *
  */
-public enum SimEventType {
-	SIMULATION_START, SIMULATION_END, SIMULATION_FINALIZED, PROCESS_START, PROCESS_END, TASK_START, TASK_END, TASK_FAILED, SESSION_SCORE_UPDATE
+public class SimulationFinalizeSimEvent extends AbstractSimEvent {
+
+	public final Map<String, Map<ScoreType, Float>> probeScores;
+
+	public SimulationFinalizeSimEvent(Long timestamp, String simulationsessionid,
+			Collection<String> involvedusers, Map<String, Map<ScoreType, Float>> probeScores) {
+		super(timestamp, simulationsessionid, involvedusers);
+		this.probeScores = probeScores;
+	}
+
+	@Override
+	public SimEventType getType() {
+		return SimEventType.SIMULATION_FINALIZED;
+	}
+
 }

--- a/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/processmanager/activiti/ActivitiProcessManager.java
+++ b/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/processmanager/activiti/ActivitiProcessManager.java
@@ -75,6 +75,7 @@ import eu.learnpad.simulator.monitoring.activiti.scoreprobe.IProbeScoresReceiver
 import eu.learnpad.simulator.monitoring.activiti.scoreprobe.ScoreProbeConsumer;
 import eu.learnpad.simulator.monitoring.event.impl.ProcessStartSimEvent;
 import eu.learnpad.simulator.monitoring.event.impl.SimulationEndSimEvent;
+import eu.learnpad.simulator.monitoring.event.impl.SimulationFinalizeSimEvent;
 import eu.learnpad.simulator.monitoring.event.impl.SimulationStartSimEvent;
 import eu.learnpad.simulator.processmanager.ITaskValidator;
 import eu.learnpad.simulator.processmanager.activiti.processdispatcher.ActivitiProcessDispatcher;
@@ -123,6 +124,7 @@ public class ActivitiProcessManager implements IProcessManager,
 
 	private final Map<String, String> simSessionIdToModelSet = new ConcurrentHashMap<>();
 	private final Map<String, ScoreProbeConsumer> scoreProbeConsumerBySession = new HashMap<>();
+	private final Map<String, Boolean> scoreProbeCompletedBySession = new HashMap<>();
 
 	public ActivitiProcessManager(
 			ProcessEngine processEngine,
@@ -400,6 +402,7 @@ public class ActivitiProcessManager implements IProcessManager,
 			try {
 				scoreProbeConsumerBySession.put(simSession,
 						ScoreProbeConsumer.create(this, simSession, projectDefinitionKey, bpmnFile, new ArrayList<>(users)));
+				scoreProbeCompletedBySession.put(simSession, false);
 			} catch (NullPointerException e) {
 				// probably cannot connect to mon
 				LoggerFactory.getLogger(ActivitiProcessManager.class)
@@ -504,17 +507,34 @@ public class ActivitiProcessManager implements IProcessManager,
 		processDispatchers.remove(processId);
 
 		// check if session is terminated
-		int nbActiveProcesses = nbProcessesBySession.get(simSession);
-		if (nbActiveProcesses > 1) {
-			nbProcessesBySession.put(simSession, nbActiveProcesses - 1);
-		} else {
-			// this was the last process of the simulation
+		int nbActiveProcesses = nbProcessesBySession.get(simSession) - 1;
+		nbProcessesBySession.put(simSession, nbActiveProcesses );
+		if (nbActiveProcesses == 0) {
+			// this was the last process of the simulation, check for completion
+			//checkCompletion(simSession);
 
 			this.processEventReceiverProvider.processEventReceiver()
-			.receiveSimulationEndEvent(
-					new SimulationEndSimEvent(System
-							.currentTimeMillis(), simSession,
-									usersBySession.get(simSession), probeScoreByTypeByUsersBySession.get(simSession)));
+			.receiveSimulationEndEvent(new SimulationEndSimEvent(System.currentTimeMillis(), simSession,
+					usersBySession.get(simSession)));
+
+			checkCompletion(simSession);
+		}
+
+	}
+
+	private synchronized void checkCompletion(String simSession) {
+		// check if session is terminated
+		boolean noMoreActiveProcess = nbProcessesBySession.get(simSession) == 0;
+
+		// check that probe message has been received, if probe exists
+		boolean scoreProbeCompleted = !scoreProbeCompletedBySession.containsKey(simSession)
+				|| scoreProbeCompletedBySession.get(simSession);
+
+		if (noMoreActiveProcess && scoreProbeCompleted) {
+			// session ends, send event and clean everything
+			this.processEventReceiverProvider.processEventReceiver()
+					.receiveSimulationFinalizeEvent(new SimulationFinalizeSimEvent(System.currentTimeMillis(), simSession,
+							usersBySession.get(simSession), probeScoreByTypeByUsersBySession.get(simSession)));
 
 			nbProcessesBySession.remove(simSession);
 			usersBySession.remove(simSession);
@@ -525,7 +545,7 @@ public class ActivitiProcessManager implements IProcessManager,
 
 			probeScoreByTypeByUsersBySession.remove(simSession);
 			scoreProbeConsumerBySession.remove(simSession);
-
+			scoreProbeCompletedBySession.remove(simSession);
 		}
 
 	}
@@ -651,6 +671,10 @@ public class ActivitiProcessManager implements IProcessManager,
 		}
 
 		probeScoreByTypeByUsersBySession.get(sessionId).get(userId).put(type, value);
+		scoreProbeCompletedBySession.put(sessionId, true);
+
+		// probe have notified of score, check for completion
+		checkCompletion(sessionId);
 
 	}
 

--- a/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/robot/RobotUserEventReceiver.java
+++ b/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/robot/RobotUserEventReceiver.java
@@ -36,6 +36,7 @@ import eu.learnpad.simulator.monitoring.event.impl.ProcessEndSimEvent;
 import eu.learnpad.simulator.monitoring.event.impl.ProcessStartSimEvent;
 import eu.learnpad.simulator.monitoring.event.impl.SessionScoreUpdateSimEvent;
 import eu.learnpad.simulator.monitoring.event.impl.SimulationEndSimEvent;
+import eu.learnpad.simulator.monitoring.event.impl.SimulationFinalizeSimEvent;
 import eu.learnpad.simulator.monitoring.event.impl.SimulationStartSimEvent;
 import eu.learnpad.simulator.monitoring.event.impl.TaskEndSimEvent;
 import eu.learnpad.simulator.monitoring.event.impl.TaskFailedSimEvent;
@@ -107,6 +108,11 @@ IProcessEventReceiver, IRobotHandler {
 
 	@Override
 	public void receiveSimulationEndEvent(SimulationEndSimEvent event) {
+		// nothing to do
+	}
+
+	@Override
+	public void receiveSimulationFinalizeEvent(SimulationFinalizeSimEvent event) {
 		// nothing to do
 	}
 

--- a/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/uihandler/webserver/UIHandlerWebImpl.java
+++ b/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/uihandler/webserver/UIHandlerWebImpl.java
@@ -41,6 +41,7 @@ import eu.learnpad.simulator.monitoring.event.impl.ProcessEndSimEvent;
 import eu.learnpad.simulator.monitoring.event.impl.ProcessStartSimEvent;
 import eu.learnpad.simulator.monitoring.event.impl.SessionScoreUpdateSimEvent;
 import eu.learnpad.simulator.monitoring.event.impl.SimulationEndSimEvent;
+import eu.learnpad.simulator.monitoring.event.impl.SimulationFinalizeSimEvent;
 import eu.learnpad.simulator.monitoring.event.impl.SimulationStartSimEvent;
 import eu.learnpad.simulator.monitoring.event.impl.TaskEndSimEvent;
 import eu.learnpad.simulator.monitoring.event.impl.TaskFailedSimEvent;
@@ -157,6 +158,11 @@ public class UIHandlerWebImpl implements IUserHandler, IProcessEventReceiver {
 
 	@Override
 	public void receiveSimulationEndEvent(SimulationEndSimEvent event) {
+		// nothing to do
+	}
+
+	@Override
+	public void receiveSimulationFinalizeEvent(SimulationFinalizeSimEvent event) {
 		for (String userId : event.involvedusers) {
 			if (usersMap.containsKey(userId)) {
 				((UIServlet) usersMap.get(userId).getServletInstance())

--- a/lp-simulation-environment/simulator/src/main/resources/static/TaskReceiver.js
+++ b/lp-simulation-environment/simulator/src/main/resources/static/TaskReceiver.js
@@ -164,9 +164,11 @@ function taskReceiver(address, user, integratedMode, sessionid, platformAddress)
                 var totalScore = 0;
 
                 var result = '<h4>Congratulations, you successfully completed the simulation</h4>';
+
                 result += '<p>Session Score Summary:</p>';
                 result += '<table class="detailed-score table table-striped table-condensed">';
                 result += '<tr><th>Task</th><th>Score</th></tr>';
+
                 // add task scores
                 for(var aTask in msg.tasknames) {
                     result += '<tr><td>' + msg.tasknames[aTask] + '</td><td>' +
@@ -175,9 +177,41 @@ function taskReceiver(address, user, integratedMode, sessionid, platformAddress)
                     totalScore += msg.taskscores[aTask];
                 }
 
-                result += '<tr><td><i>Total session score</i></td><td><i>' + totalScore + '</i></td></tr>';
-                result += '</table>';
+                if (msg.probescores !== null) {
+                    var userscore = msg.probescores[user];
+                    if(userscore.hasOwnProperty('SESSION_SCORE')) {
+                        result += '<tr><td><i>Session Score</i></td><td><i>' + userscore.SESSION_SCORE + '</i></td></tr>';
+                    }
+                    if(userscore.hasOwnProperty('SESSION_SCORE')) {
+                        result += '<tr><td><i>Absolute Session Score</i></td><td><i>' + userscore.ABSOLUTE_SESSION_SCORE + '</i></td></tr>';
+                    }
+                    if(userscore.hasOwnProperty('BP_SCORE')) {
+                        result += '<tr><td><i>BP Score</i></td><td><i>' + userscore.BP_SCORE + '</i></td></tr>';
+                    }
+                    if(userscore.hasOwnProperty('RELATIVE_BP_SCORE')) {
+                        result += '<tr><td><i>Relative BP Score</i></td><td><i>' + userscore.RELATIVE_BP_SCORE + '</i></td></tr>';
+                    }
+                    if(userscore.hasOwnProperty('BP_COVERAGE')) {
+                        result += '<tr><td><i>BP Coverage</i></td><td><i>' + userscore.BP_COVERAGE + '</i></td></tr>';
+                    }
+                    if(userscore.hasOwnProperty('ABSOLUTE_BP_COVERAGE')) {
+                        result += '<tr><td><i>Absolute BP Score</i></td><td><i>' + userscore.ABSOLUTE_BP_SCORE + '</i></td></tr>';
+                    }
+                    if(userscore.hasOwnProperty('GLOBAL_SCORE')) {
+                        result += '<tr><td><i>Global Score</i></td><td><i>' + userscore.GLOBAL_SCORE + '</i></td></tr>';
+                    }
+                    if(userscore.hasOwnProperty('RELATIVE_GLOBAL_SCORE')) {
+                        result += '<tr><td><i>Relative Global Score</i></td><td><i>' + userscore.RELATIVE_GLOBAL_SCORE + '</i></td></tr>';
+                    }
+                    if(userscore.hasOwnProperty('ABSOLUTE_GLOBAL_SCORE')) {
+                        result += '<tr><td><i>Absolute Global Score</i></td><td><i>' + userscore.ABSOLUTE_GLOBAL_SCORE + '</i></td></tr>';
+                    }
+                } else {
+                    // use computed total session score
+                    result += '<tr><td><i>Total session score</i></td><td><i>' + totalScore + '</i></td></tr>';
+                }
 
+                result += '</table>';
                 processFinished.innerHTML = result;
 
                 containerDiv.append(processFinished);

--- a/lp-simulation-environment/simulator/src/test/java/eu/learnpad/simulator/uihandler/webserver/UIHandlerWebImplTest.java
+++ b/lp-simulation-environment/simulator/src/test/java/eu/learnpad/simulator/uihandler/webserver/UIHandlerWebImplTest.java
@@ -52,7 +52,7 @@ import org.mockito.stubbing.Answer;
 import eu.learnpad.sim.rest.data.UserData;
 import eu.learnpad.simulator.IProcessManager;
 import eu.learnpad.simulator.datastructures.LearnPadTask;
-import eu.learnpad.simulator.monitoring.event.impl.SimulationEndSimEvent;
+import eu.learnpad.simulator.monitoring.event.impl.SimulationFinalizeSimEvent;
 import eu.learnpad.simulator.monitoring.event.impl.TaskEndSimEvent;
 import eu.learnpad.simulator.monitoring.event.impl.TaskStartSimEvent;
 import eu.learnpad.simulator.uihandler.IFormHandler;
@@ -292,25 +292,25 @@ public class UIHandlerWebImplTest {
 
 		// signal some session completion
 
-		uiHandler.receiveSimulationEndEvent(new SimulationEndSimEvent(System
+		uiHandler.receiveSimulationFinalizeEvent(new SimulationFinalizeSimEvent(System
 				.currentTimeMillis(), "session1", Arrays.asList("user1"), null));
 
-		uiHandler.receiveSimulationEndEvent(new SimulationEndSimEvent(System
+		uiHandler.receiveSimulationFinalizeEvent(new SimulationFinalizeSimEvent(System
 				.currentTimeMillis(), "session2", Arrays.asList("user1",
 						"user2"),
 				null));
 
-		uiHandler.receiveSimulationEndEvent(new SimulationEndSimEvent(System
+		uiHandler.receiveSimulationFinalizeEvent(new SimulationFinalizeSimEvent(System
 				.currentTimeMillis(), "session3", Arrays.asList("user1",
 						"user2", "user3"),
 				null));
 
-		uiHandler.receiveSimulationEndEvent(new SimulationEndSimEvent(System
+		uiHandler.receiveSimulationFinalizeEvent(new SimulationFinalizeSimEvent(System
 				.currentTimeMillis(), "session4", Arrays.asList("user2",
 						"user3"),
 				null));
 
-		uiHandler.receiveSimulationEndEvent(new SimulationEndSimEvent(System
+		uiHandler.receiveSimulationFinalizeEvent(new SimulationFinalizeSimEvent(System
 				.currentTimeMillis(), "session5", Arrays.asList("user3"), null));
 
 		// check that concerned users (and only them) received session


### PR DESCRIPTION
Probe score events were not correctly handed. They were not received
correctly, and when received were handled too late to be displayed.

Correct score probe step.

Introduce a new simulation event to separate the completion and the
finalization of a session. A session is completed when the process is
finished. A session is finalized when it is completed and a last probe
score event has been finalized (if the session is associated with a
probe). 	

The Web UI now display the probe scores at the end of a session if they
have been provided.

If not, it still falls back on the manually calculated session score.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/learnpad/learnpad/584)
<!-- Reviewable:end -->
