### PR TITLE
[sim] Fix multi-user score events 

### DIFF
--- a/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/monitoring/activiti/scoreprobe/ScoreProbeConsumer.java
+++ b/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/monitoring/activiti/scoreprobe/ScoreProbeConsumer.java
@@ -74,13 +74,14 @@ public class ScoreProbeConsumer extends GlimpseAbstractConsumer {
 				try {
 					ObjectMessage responseFromMonitoring = (ObjectMessage) arg0;
 					if (responseFromMonitoring.getObject() instanceof ComplexEventException) {
-						ComplexEventException exceptionReceived = (ComplexEventException) responseFromMonitoring.getObject();
+						ComplexEventException exceptionReceived = (ComplexEventException) responseFromMonitoring
+								.getObject();
 						logger.error("Receive exception from probe: {}", exceptionReceived.getMessage());
 						logger.error("Stack trace:\n{}", exceptionReceived.getStackTrace());
 					} else if (responseFromMonitoring.getObject() instanceof Map) {
 
 						@SuppressWarnings("unchecked")
-						Map<ScoreType, Float> theScores = (Map<ScoreType, Float>)responseFromMonitoring.getObject();
+						Map<ScoreType, Float> theScores = (Map<ScoreType, Float>) responseFromMonitoring.getObject();
 
 						String userId = responseFromMonitoring.getStringProperty(USER_ID_PROPERTY);
 
@@ -96,15 +97,15 @@ public class ScoreProbeConsumer extends GlimpseAbstractConsumer {
 				}
 			}
 		} catch (JMSException e) {
-			// TODO Auto-generated catch block
+			logger.error("Exception from probe: {}", e.getMessage());
 			e.printStackTrace();
 		}
 	}
 
-		@Override
-		public void messageReceived(Message arg0) throws JMSException {
-			// nothing to do here
-		}
+	@Override
+	public void messageReceived(Message arg0) throws JMSException {
+		// nothing to do here
+	}
 
 	/**
 	 *


### PR DESCRIPTION
Score events did not work correctly for multiple users, waiting only for
the first message instead of all the users scores.

Now Manager checks that the scores for *all* users have been received
before finalizing the simulation session.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/learnpad/learnpad/591)
<!-- Reviewable:end -->
