### PR TITLE
[sim] Filter probe events by sim session id

### DIFF
--- a/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/monitoring/activiti/scoreprobe/ScoreProbeConsumer.java
+++ b/lp-simulation-environment/simulator/src/main/java/eu/learnpad/simulator/monitoring/activiti/scoreprobe/ScoreProbeConsumer.java
@@ -78,7 +78,8 @@ public class ScoreProbeConsumer extends GlimpseAbstractConsumer {
 								.getObject();
 						logger.error("Receive exception from probe: {}", exceptionReceived.getMessage());
 						logger.error("Stack trace:\n{}", exceptionReceived.getStackTrace());
-					} else if (responseFromMonitoring.getObject() instanceof Map) {
+					} else if (responseFromMonitoring.getObject() instanceof Map
+							&& responseFromMonitoring.getStringProperty("SIMSESSIONID").equals(this.sessionId)) {
 
 						@SuppressWarnings("unchecked")
 						Map<ScoreType, Float> theScores = (Map<ScoreType, Float>) responseFromMonitoring.getObject();


### PR DESCRIPTION
Probes now only try to handle messages corresponding to their simulation
session.