### PR TITLE
Enabled the "-Dhttps.protocols=TLSv1.2" option in the __MVN_PROFILE__

### DIFF
--- a/lp-collaborative-workspace/build
+++ b/lp-collaborative-workspace/build
@@ -23,7 +23,7 @@ declare -r __OUT_RUNDEPS_FILE__="${__OUT_PATH__}/rundeps.txt"
 # This is the path to the directory where you can optionally put some configuration files
 declare -r __OUT_CONF_PATH__="${__OUT_PATH__}/etc"
 
-declare -r __MVN_PROFILE__="--batch-mode"
+declare -r __MVN_PROFILE__="--batch-mode -Dhttps.protocols=TLSv1.2"
 
 ### BUILD ###
 # This is where you compile and build each part of your component

--- a/lp-content-analysis/build
+++ b/lp-content-analysis/build
@@ -17,7 +17,7 @@ declare -r __OUT_RUNDEPS_FILE__="${__OUT_PATH__}/rundeps.txt"
 declare -r __OUT_CONF_PATH__="${__OUT_PATH__}/etc"
 
 # avoid deleting/re-downloading license files
-declare -r __MVN_PROFILE__="-Pkeep-license-files --batch-mode"
+declare -r __MVN_PROFILE__="-Pkeep-license-files --batch-mode -Dhttps.protocols=TLSv1.2"
 
 declare __ARG_FLAG__="";
 for arg in $*

--- a/lp-content-analysis/lp-ca-ui/build
+++ b/lp-content-analysis/lp-ca-ui/build
@@ -17,7 +17,7 @@ declare -r __OUT_RUNDEPS_FILE__="${__OUT_PATH__}/rundeps.txt"
 declare -r __OUT_CONF_PATH__="${__OUT_PATH__}/etc"
 
 # avoid deleting/re-downloading license files
-declare -r __MVN_PROFILE__="-Pkeep-license-files --batch-mode"
+declare -r __MVN_PROFILE__="-Pkeep-license-files --batch-mode -Dhttps.protocols=TLSv1.2"
 
 ### BUILD ###
 function component_build() {

--- a/lp-core-platform/build
+++ b/lp-core-platform/build
@@ -23,7 +23,7 @@ declare -r __OUT_RUNDEPS_FILE__="${__OUT_PATH__}/rundeps.txt"
 # This is the path to the directory where you can optionally put some configuration files
 declare -r __OUT_CONF_PATH__="${__OUT_PATH__}/etc"
 
-declare -r __MVN_PROFILE__="--batch-mode"
+declare -r __MVN_PROFILE__="--batch-mode -Dhttps.protocols=TLSv1.2"
 
 ### BUILD ###
 # This is where you compile and build each part of your component

--- a/lp-dashboard-kpi/build
+++ b/lp-dashboard-kpi/build
@@ -17,7 +17,7 @@ declare -r __OUT_RUNDEPS_FILE__="${__OUT_PATH__}/rundeps.txt"
 declare -r __OUT_CONF_PATH__="${__OUT_PATH__}/etc"
 
 # avoid deleting/re-downloading license files
-declare -r __MVN_PROFILE__="-Pkeep-license-files --batch-mode"
+declare -r __MVN_PROFILE__="-Pkeep-license-files -Dhttps.protocols=TLSv1.2 --batch-mode"
 
 # This is the name of the ADOXX Cockpit sub-component 
 declare -r __COCKPIT_SUBCOMPONENT_NAME__="lp-dash-adoxx-cockpit"

--- a/lp-dashboard-kpi/lp-dash-adoxx-cockpit/build
+++ b/lp-dashboard-kpi/lp-dash-adoxx-cockpit/build
@@ -17,7 +17,7 @@ declare -r __OUT_RUNDEPS_FILE__="${__OUT_PATH__}/rundeps.txt"
 declare -r __OUT_CONF_PATH__="${__OUT_PATH__}/etc"
 
 # avoid deleting/re-downloading license files
-declare -r __MVN_PROFILE__="-Pkeep-license-files --batch-mode"
+declare -r __MVN_PROFILE__="-Pkeep-license-files -Dhttps.protocols=TLSv1.2 --batch-mode"
 
 ### BUILD ###
 function component_build() {

--- a/lp-learning-session-manager/build
+++ b/lp-learning-session-manager/build
@@ -23,6 +23,8 @@ declare -r __OUT_RUNDEPS_FILE__="${__OUT_PATH__}/rundeps.txt"
 # This is the path to the directory where you can optionally put some configuration files
 declare -r __OUT_CONF_PATH__="${__OUT_PATH__}/etc"
 
+declare -r __MVN_PROFILE__="--batch-mode -Dhttps.protocols=TLSv1.2"
+
 ### BUILD ###
 # This is where you compile and build each part of your component
 function component_build() {

--- a/lp-model-transformer/build
+++ b/lp-model-transformer/build
@@ -23,7 +23,7 @@ declare -r __OUT_RUNDEPS_FILE__="${__OUT_PATH__}/rundeps.txt"
 # This is the path to the directory where you can optionally put some configuration files
 declare -r __OUT_CONF_PATH__="${__OUT_PATH__}/etc"
 
-declare __MVN_PROFILE__="--batch-mode"
+declare __MVN_PROFILE__="--batch-mode -Dhttps.protocols=TLSv1.2"
 
 for arg in $*
 do

--- a/lp-model-transformer/build
+++ b/lp-model-transformer/build
@@ -23,7 +23,8 @@ declare -r __OUT_RUNDEPS_FILE__="${__OUT_PATH__}/rundeps.txt"
 # This is the path to the directory where you can optionally put some configuration files
 declare -r __OUT_CONF_PATH__="${__OUT_PATH__}/etc"
 
-declare __MVN_PROFILE__="--batch-mode -Dhttps.protocols=TLSv1.2"
+## declare __MVN_PROFILE__="--batch-mode -Dhttps.protocols=TLSv1.2"
+declare __MVN_PROFILE__="--batch-mode"
 
 for arg in $*
 do

--- a/lp-model-verification/build
+++ b/lp-model-verification/build
@@ -17,7 +17,7 @@ declare -r __OUT_RUNDEPS_FILE__="${__OUT_PATH__}/rundeps.txt"
 declare -r __OUT_CONF_PATH__="${__OUT_PATH__}/etc"
 
 # avoid deleting/re-downloading license files
-declare -r __MVN_PROFILE__="-Pkeep-license-files --batch-mode"
+declare -r __MVN_PROFILE__="-Pkeep-license-files --batch-mode -Dhttps.protocols=TLSv1.2"
 
 ### BUILD ###
 function component_build() {

--- a/lp-ontology-recommender/build
+++ b/lp-ontology-recommender/build
@@ -23,7 +23,7 @@ declare -r __OUT_RUNDEPS_FILE__="${__OUT_PATH__}/rundeps.txt"
 # This is the path to the directory where you can optionally put some configuration files
 declare -r __OUT_CONF_PATH__="${__OUT_PATH__}/etc"
 
-declare -r __MVN_PROFILE__="--batch-mode"
+declare -r __MVN_PROFILE__="--batch-mode -Dhttps.protocols=TLSv1.2"
 
 ### BUILD ###
 # This is where you compile and build each part of your component

--- a/lp-platform/build
+++ b/lp-platform/build
@@ -23,7 +23,7 @@ declare -r __OUT_RUNDEPS_FILE__="${__OUT_PATH__}/rundeps.txt"
 # This is the path to the directory where you can optionally put some configuration files
 declare -r __OUT_CONF_PATH__="${__OUT_PATH__}/etc"
 
-declare __MVN_PROFILE__="--batch-mode"
+declare __MVN_PROFILE__="--batch-mode -Dhttps.protocols=TLSv1.2"
 declare __MVN_BUILD_PROFILES__=""
 
 for arg in $*

--- a/lp-questionnaire-manager/build
+++ b/lp-questionnaire-manager/build
@@ -23,7 +23,7 @@ declare -r __OUT_RUNDEPS_FILE__="${__OUT_PATH__}/rundeps.txt"
 # This is the path to the directory where you can optionally put some configuration files
 declare -r __OUT_CONF_PATH__="${__OUT_PATH__}/etc"
 
-declare -r __MVN_PROFILE__="--batch-mode"
+declare -r __MVN_PROFILE__="--batch-mode -Dhttps.protocols=TLSv1.2"
 
 ### BUILD ###
 # This is where you compile and build each part of your component

--- a/lp-simulation-environment/build
+++ b/lp-simulation-environment/build
@@ -17,7 +17,7 @@ declare -r __OUT_RUNDEPS_FILE__="${__OUT_PATH__}/rundeps.txt"
 declare -r __OUT_CONF_PATH__="${__OUT_PATH__}/etc"
 
 # avoid deleting/re-downloading license files
-declare -r __MVN_PROFILE__="-Pkeep-license-files --batch-mode"
+declare -r __MVN_PROFILE__="-Pkeep-license-files --batch-mode -Dhttps.protocols=TLSv1.2"
 
 ### BUILD ###
 function component_build() {

--- a/template-component/build
+++ b/template-component/build
@@ -23,6 +23,8 @@ declare -r __OUT_RUNDEPS_FILE__="${__OUT_PATH__}/rundeps.txt"
 # This is the path to the directory where you can optionally put some configuration files
 declare -r __OUT_CONF_PATH__="${__OUT_PATH__}/etc"
 
+declare -r __MVN_PROFILE__="--batch-mode -Dhttps.protocols=TLSv1.2"
+
 ### BUILD ###
 # This is where you compile and build each part of your component
 function component_build() {


### PR DESCRIPTION
Enabled the "-Dhttps.protocols=TLSv1.2" option in the __MVN_PROFILE__ of the build scripts.
Specifically this is due to this issue:
 * https://stackoverflow.com/questions/50824789/why-am-i-getting-received-fatal-alert-protocol-version-or-peer-not-authentic